### PR TITLE
Include target in builds

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,3 +1,5 @@
+name: Rust
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,19 +20,25 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         profile: [dev, release]
+        include:
+        - os: ubuntu-latest
+          target: x86_64-unknown-linux-gnu
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
     - run: rustup update stable && rustup default stable
-    - run: cargo build --verbose --profile ${{ matrix.profile }}
+    - run: cargo build --verbose --profile ${{ matrix.profile }} --target ${{ matrix.target }}
 
   test:
     strategy:
       matrix:
         os: [ubuntu-latest]
         profile: [dev, release]
+        include:
+        - os: ubuntu-latest
+          target: x86_64-unknown-linux-gnu
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
     - run: rustup update stable && rustup default stable
-    - run: cargo test --verbose --profile ${{ matrix.profile }}
+    - run: cargo test --verbose --profile ${{ matrix.profile }} --target ${{ matrix.target }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,6 +25,12 @@ jobs:
         - os: ubuntu-latest
           target: x86_64-unknown-linux-gnu
           profile: release
+        - os: macos-latest
+          target: x86_64-apple-darwin
+          profile: dev
+        - os: macos-latest
+          target: x86_64-apple-darwin
+          profile: release
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
@@ -40,6 +46,12 @@ jobs:
           profile: dev
         - os: ubuntu-latest
           target: x86_64-unknown-linux-gnu
+          profile: release
+        - os: macos-latest
+          target: x86_64-apple-darwin
+          profile: dev
+        - os: macos-latest
+          target: x86_64-apple-darwin
           profile: release
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,11 +18,13 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        profile: [dev, release]
         include:
         - os: ubuntu-latest
           target: x86_64-unknown-linux-gnu
+          profile: dev
+        - os: ubuntu-latest
+          target: x86_64-unknown-linux-gnu
+          profile: release
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
@@ -32,11 +34,13 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        profile: [dev, release]
         include:
         - os: ubuntu-latest
           target: x86_64-unknown-linux-gnu
+          profile: dev
+        - os: ubuntu-latest
+          target: x86_64-unknown-linux-gnu
+          profile: release
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
### What

Include targets in builds.

### Why

To make it easier to include other targets (Apple Silicon).

### Known limitations

Doesn't actually add builds for Apple Silicon yet, just adds a matrix value, so that when I store these builds in checks lists in terraform we don't have to change these build names later.