### PR TITLE
Simplify ci builds

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,12 +27,6 @@ jobs:
         - os: ubuntu-latest
           target: x86_64-unknown-linux-gnu
           profile: release
-        - os: macos-latest
-          target: x86_64-apple-darwin
-          profile: dev
-        - os: macos-latest
-          target: x86_64-apple-darwin
-          profile: release
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
@@ -45,16 +39,7 @@ jobs:
         include:
         - os: ubuntu-latest
           target: x86_64-unknown-linux-gnu
-          profile: dev
-        - os: ubuntu-latest
-          target: x86_64-unknown-linux-gnu
-          profile: release
-        - os: macos-latest
-          target: x86_64-apple-darwin
-          profile: dev
-        - os: macos-latest
-          target: x86_64-apple-darwin
-          profile: release
+          profile: test
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
### What

Remove mac builds. Fix profile used on tests.

### Why

According to Rust discord it isn't really important to test all the platforms if we don't have platform specific cfg.

### Known limitations

N/A
