### PR TITLE
Add PartialOrd and Ord to all types

### DIFF
--- a/src/xdr.rs
+++ b/src/xdr.rs
@@ -320,7 +320,7 @@ mod tests {
 //
 //   typedef opaque Value<>;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Value(pub Vec<u8>);
 
 impl From<Value> for Vec<u8> {
@@ -357,7 +357,7 @@ impl WriteXDR for Value {
 //        Value value;    // x
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ScpBallot {
     pub counter: u32,
     pub value: Value,
@@ -391,7 +391,7 @@ impl WriteXDR for ScpBallot {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum ScpStatementType {
     ScpStPrepare = 0,
@@ -446,7 +446,7 @@ impl WriteXDR for ScpStatementType {
 //        Value accepted<>;   // Y
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ScpNomination {
     pub quorum_set_hash: Hash,
     pub votes: Vec<Value>,
@@ -484,7 +484,7 @@ impl WriteXDR for ScpNomination {
 //                uint32 nH;                // h.n
 //            }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ScpStatementPrepare {
     pub quorum_set_hash: Hash,
     pub ballot: ScpBallot,
@@ -530,7 +530,7 @@ impl WriteXDR for ScpStatementPrepare {
 //                Hash quorumSetHash; // D
 //            }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ScpStatementConfirm {
     pub ballot: ScpBallot,
     pub n_prepared: u32,
@@ -571,7 +571,7 @@ impl WriteXDR for ScpStatementConfirm {
 //                Hash commitQuorumSetHash; // D used before EXTERNALIZE
 //            }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ScpStatementExternalize {
     pub commit: ScpBallot,
     pub n_h: u32,
@@ -632,7 +632,7 @@ impl WriteXDR for ScpStatementExternalize {
 //        }
 //
 // union with discriminant ScpStatementType
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ScpStatementPledges {
     ScpStPrepare(ScpStatementPrepare),
     ScpStConfirm(ScpStatementConfirm),
@@ -728,7 +728,7 @@ impl WriteXDR for ScpStatementPledges {
 //        pledges;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ScpStatement {
     pub node_id: NodeId,
     pub slot_index: u64,
@@ -762,7 +762,7 @@ impl WriteXDR for ScpStatement {
 //        Signature signature;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ScpEnvelope {
     pub statement: ScpStatement,
     pub signature: Signature,
@@ -794,7 +794,7 @@ impl WriteXDR for ScpEnvelope {
 //        SCPQuorumSet innerSets<>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ScpQuorumSet {
     pub threshold: u32,
     pub validators: Vec<NodeId>,
@@ -824,7 +824,7 @@ impl WriteXDR for ScpQuorumSet {
 //
 //   typedef PublicKey AccountID;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct AccountId(pub PublicKey);
 
 impl From<AccountId> for PublicKey {
@@ -857,7 +857,7 @@ impl WriteXDR for AccountId {
 //
 //   typedef opaque Thresholds[4];
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Thresholds(pub [u8; 4]);
 
 impl From<Thresholds> for [u8; 4] {
@@ -902,7 +902,7 @@ pub type String64 = Vec<u8>;
 //
 //   typedef int64 SequenceNumber;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SequenceNumber(pub i64);
 
 impl From<SequenceNumber> for i64 {
@@ -935,7 +935,7 @@ impl WriteXDR for SequenceNumber {
 //
 //   typedef uint64 TimePoint;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TimePoint(pub u64);
 
 impl From<TimePoint> for u64 {
@@ -968,7 +968,7 @@ impl WriteXDR for TimePoint {
 //
 //   typedef uint64 Duration;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Duration(pub u64);
 
 impl From<Duration> for u64 {
@@ -1001,7 +1001,7 @@ impl WriteXDR for Duration {
 //
 //   typedef opaque DataValue<64>;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct DataValue(pub Vec<u8>);
 
 impl From<DataValue> for Vec<u8> {
@@ -1034,7 +1034,7 @@ impl WriteXDR for DataValue {
 //
 //   typedef Hash PoolID;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PoolId(pub Hash);
 
 impl From<PoolId> for Hash {
@@ -1067,7 +1067,7 @@ impl WriteXDR for PoolId {
 //
 //   typedef opaque AssetCode4[4];
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct AssetCode4(pub [u8; 4]);
 
 impl From<AssetCode4> for [u8; 4] {
@@ -1100,7 +1100,7 @@ impl WriteXDR for AssetCode4 {
 //
 //   typedef opaque AssetCode12[12];
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct AssetCode12(pub [u8; 12]);
 
 impl From<AssetCode12> for [u8; 12] {
@@ -1140,7 +1140,7 @@ impl WriteXDR for AssetCode12 {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum AssetType {
     AssetTypeNative = 0,
@@ -1200,7 +1200,7 @@ impl WriteXDR for AssetType {
 //    };
 //
 // union with discriminant AssetType
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum AssetCode {
     AssetTypeCreditAlphanum4(AssetCode4),
     AssetTypeCreditAlphanum12(AssetCode12),
@@ -1251,7 +1251,7 @@ impl WriteXDR for AssetCode {
 //        AccountID issuer;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct AlphaNum4 {
     pub asset_code: AssetCode4,
     pub issuer: AccountId,
@@ -1282,7 +1282,7 @@ impl WriteXDR for AlphaNum4 {
 //        AccountID issuer;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct AlphaNum12 {
     pub asset_code: AssetCode12,
     pub issuer: AccountId,
@@ -1322,7 +1322,7 @@ impl WriteXDR for AlphaNum12 {
 //    };
 //
 // union with discriminant AssetType
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Asset {
     AssetTypeNative,
     AssetTypeCreditAlphanum4(AlphaNum4),
@@ -1377,7 +1377,7 @@ impl WriteXDR for Asset {
 //        int32 d; // denominator
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Price {
     pub n: i32,
     pub d: i32,
@@ -1408,7 +1408,7 @@ impl WriteXDR for Price {
 //        int64 selling;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Liabilities {
     pub buying: i64,
     pub selling: i64,
@@ -1442,7 +1442,7 @@ impl WriteXDR for Liabilities {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum ThresholdIndexes {
     ThresholdMasterWeight = 0,
@@ -1501,7 +1501,7 @@ impl WriteXDR for ThresholdIndexes {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum LedgerEntryType {
     Account = 0,
@@ -1559,7 +1559,7 @@ impl WriteXDR for LedgerEntryType {
 //        uint32 weight; // really only need 1 byte
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Signer {
     pub key: SignerKey,
     pub weight: u32,
@@ -1603,7 +1603,7 @@ impl WriteXDR for Signer {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum AccountFlags {
     AuthRequiredFlag = 1,
@@ -1671,7 +1671,7 @@ pub const MAX_SIGNERS: u64 = 20;
 //
 //   typedef AccountID* SponsorshipDescriptor;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SponsorshipDescriptor(pub Option<AccountId>);
 
 impl From<SponsorshipDescriptor> for Option<AccountId> {
@@ -1715,7 +1715,7 @@ impl WriteXDR for SponsorshipDescriptor {
 //        TimePoint seqTime;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct AccountEntryExtensionV3 {
     pub ext: ExtensionPoint,
     pub seq_ledger: u32,
@@ -1752,7 +1752,7 @@ impl WriteXDR for AccountEntryExtensionV3 {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum AccountEntryExtensionV2Ext {
     V0,
     V3(AccountEntryExtensionV3),
@@ -1809,7 +1809,7 @@ impl WriteXDR for AccountEntryExtensionV2Ext {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct AccountEntryExtensionV2 {
     pub num_sponsored: u32,
     pub num_sponsoring: u32,
@@ -1849,7 +1849,7 @@ impl WriteXDR for AccountEntryExtensionV2 {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum AccountEntryExtensionV1Ext {
     V0,
     V2(AccountEntryExtensionV2),
@@ -1904,7 +1904,7 @@ impl WriteXDR for AccountEntryExtensionV1Ext {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct AccountEntryExtensionV1 {
     pub liabilities: Liabilities,
     pub ext: AccountEntryExtensionV1Ext,
@@ -1938,7 +1938,7 @@ impl WriteXDR for AccountEntryExtensionV1 {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum AccountEntryExt {
     V0,
     V1(AccountEntryExtensionV1),
@@ -2008,7 +2008,7 @@ impl WriteXDR for AccountEntryExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct AccountEntry {
     pub account_id: AccountId,
     pub balance: i64,
@@ -2070,7 +2070,7 @@ impl WriteXDR for AccountEntry {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum TrustLineFlags {
     AuthorizedFlag = 1,
@@ -2140,7 +2140,7 @@ pub const MASK_TRUSTLINE_FLAGS_V17: u64 = 7;
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum LiquidityPoolType {
     LiquidityPoolConstantProduct = 0,
@@ -2200,7 +2200,7 @@ impl WriteXDR for LiquidityPoolType {
 //    };
 //
 // union with discriminant AssetType
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TrustLineAsset {
     AssetTypeNative,
     AssetTypeCreditAlphanum4(AlphaNum4),
@@ -2262,7 +2262,7 @@ impl WriteXDR for TrustLineAsset {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TrustLineEntryExtensionV2Ext {
     V0,
 }
@@ -2311,7 +2311,7 @@ impl WriteXDR for TrustLineEntryExtensionV2Ext {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TrustLineEntryExtensionV2 {
     pub liquidity_pool_use_count: i32,
     pub ext: TrustLineEntryExtensionV2Ext,
@@ -2345,7 +2345,7 @@ impl WriteXDR for TrustLineEntryExtensionV2 {
 //                }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TrustLineEntryV1Ext {
     V0,
     V2(TrustLineEntryExtensionV2),
@@ -2400,7 +2400,7 @@ impl WriteXDR for TrustLineEntryV1Ext {
 //                ext;
 //            }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TrustLineEntryV1 {
     pub liabilities: Liabilities,
     pub ext: TrustLineEntryV1Ext,
@@ -2446,7 +2446,7 @@ impl WriteXDR for TrustLineEntryV1 {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TrustLineEntryExt {
     V0,
     V1(TrustLineEntryV1),
@@ -2520,7 +2520,7 @@ impl WriteXDR for TrustLineEntryExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TrustLineEntry {
     pub account_id: AccountId,
     pub asset: TrustLineAsset,
@@ -2565,7 +2565,7 @@ impl WriteXDR for TrustLineEntry {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum OfferEntryFlags {
     PassiveFlag = 1,
@@ -2620,7 +2620,7 @@ pub const MASK_OFFERENTRY_FLAGS: u64 = 1;
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum OfferEntryExt {
     V0,
 }
@@ -2682,7 +2682,7 @@ impl WriteXDR for OfferEntryExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct OfferEntry {
     pub seller_id: AccountId,
     pub offer_id: i64,
@@ -2732,7 +2732,7 @@ impl WriteXDR for OfferEntry {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum DataEntryExt {
     V0,
 }
@@ -2784,7 +2784,7 @@ impl WriteXDR for DataEntryExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct DataEntry {
     pub account_id: AccountId,
     pub data_name: Vec<u8>,
@@ -2826,7 +2826,7 @@ impl WriteXDR for DataEntry {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum ClaimPredicateType {
     ClaimPredicateUnconditional = 0,
@@ -2896,7 +2896,7 @@ impl WriteXDR for ClaimPredicateType {
 //    };
 //
 // union with discriminant ClaimPredicateType
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ClaimPredicate {
     ClaimPredicateUnconditional,
     ClaimPredicateAnd(Vec<ClaimPredicate>),
@@ -2973,7 +2973,7 @@ impl WriteXDR for ClaimPredicate {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum ClaimantType {
     ClaimantTypeV0 = 0,
@@ -3021,7 +3021,7 @@ impl WriteXDR for ClaimantType {
 //            ClaimPredicate predicate; // Claimable if predicate is true
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ClaimantV0 {
     pub destination: AccountId,
     pub predicate: ClaimPredicate,
@@ -3057,7 +3057,7 @@ impl WriteXDR for ClaimantV0 {
 //    };
 //
 // union with discriminant ClaimantType
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Claimant {
     ClaimantTypeV0(ClaimantV0),
 }
@@ -3102,7 +3102,7 @@ impl WriteXDR for Claimant {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum ClaimableBalanceIdType {
     ClaimableBalanceIdTypeV0 = 0,
@@ -3151,7 +3151,7 @@ impl WriteXDR for ClaimableBalanceIdType {
 //    };
 //
 // union with discriminant ClaimableBalanceIdType
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ClaimableBalanceId {
     ClaimableBalanceIdTypeV0(Hash),
 }
@@ -3198,7 +3198,7 @@ impl WriteXDR for ClaimableBalanceId {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum ClaimableBalanceFlags {
     ClaimableBalanceClawbackEnabledFlag = 1,
@@ -3253,7 +3253,7 @@ pub const MASK_CLAIMABLE_BALANCE_FLAGS: u64 = 0x1;
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ClaimableBalanceEntryExtensionV1Ext {
     V0,
 }
@@ -3302,7 +3302,7 @@ impl WriteXDR for ClaimableBalanceEntryExtensionV1Ext {
 //        uint32 flags; // see ClaimableBalanceFlags
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ClaimableBalanceEntryExtensionV1 {
     pub ext: ClaimableBalanceEntryExtensionV1Ext,
     pub flags: u32,
@@ -3336,7 +3336,7 @@ impl WriteXDR for ClaimableBalanceEntryExtensionV1 {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ClaimableBalanceEntryExt {
     V0,
     V1(ClaimableBalanceEntryExtensionV1),
@@ -3402,7 +3402,7 @@ impl WriteXDR for ClaimableBalanceEntryExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ClaimableBalanceEntry {
     pub balance_id: ClaimableBalanceId,
     pub claimants: Vec<Claimant>,
@@ -3443,7 +3443,7 @@ impl WriteXDR for ClaimableBalanceEntry {
 //        int32 fee; // Fee is in basis points, so the actual rate is (fee/100)%
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct LiquidityPoolConstantProductParameters {
     pub asset_a: Asset,
     pub asset_b: Asset,
@@ -3482,7 +3482,7 @@ impl WriteXDR for LiquidityPoolConstantProductParameters {
 //                                                // associated pool shares
 //            }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct LiquidityPoolEntryConstantProduct {
     pub params: LiquidityPoolConstantProductParameters,
     pub reserve_a: i64,
@@ -3532,7 +3532,7 @@ impl WriteXDR for LiquidityPoolEntryConstantProduct {
 //        }
 //
 // union with discriminant LiquidityPoolType
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum LiquidityPoolEntryBody {
     LiquidityPoolConstantProduct(LiquidityPoolEntryConstantProduct),
 }
@@ -3594,7 +3594,7 @@ impl WriteXDR for LiquidityPoolEntryBody {
 //        body;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct LiquidityPoolEntry {
     pub liquidity_pool_id: PoolId,
     pub body: LiquidityPoolEntryBody,
@@ -3626,7 +3626,7 @@ impl WriteXDR for LiquidityPoolEntry {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum LedgerEntryExtensionV1Ext {
     V0,
 }
@@ -3675,7 +3675,7 @@ impl WriteXDR for LedgerEntryExtensionV1Ext {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct LedgerEntryExtensionV1 {
     pub sponsoring_id: SponsorshipDescriptor,
     pub ext: LedgerEntryExtensionV1Ext,
@@ -3717,7 +3717,7 @@ impl WriteXDR for LedgerEntryExtensionV1 {
 //        }
 //
 // union with discriminant LedgerEntryType
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum LedgerEntryData {
     Account(AccountEntry),
     Trustline(TrustLineEntry),
@@ -3789,7 +3789,7 @@ impl WriteXDR for LedgerEntryData {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum LedgerEntryExt {
     V0,
     V1(LedgerEntryExtensionV1),
@@ -3862,7 +3862,7 @@ impl WriteXDR for LedgerEntryExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct LedgerEntry {
     pub last_modified_ledger_seq: u32,
     pub data: LedgerEntryData,
@@ -3895,7 +3895,7 @@ impl WriteXDR for LedgerEntry {
 //            AccountID accountID;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct LedgerKeyAccount {
     pub account_id: AccountId,
 }
@@ -3923,7 +3923,7 @@ impl WriteXDR for LedgerKeyAccount {
 //            TrustLineAsset asset;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct LedgerKeyTrustLine {
     pub account_id: AccountId,
     pub asset: TrustLineAsset,
@@ -3954,7 +3954,7 @@ impl WriteXDR for LedgerKeyTrustLine {
 //            int64 offerID;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct LedgerKeyOffer {
     pub seller_id: AccountId,
     pub offer_id: i64,
@@ -3985,7 +3985,7 @@ impl WriteXDR for LedgerKeyOffer {
 //            string64 dataName;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct LedgerKeyData {
     pub account_id: AccountId,
     pub data_name: Vec<u8>,
@@ -4015,7 +4015,7 @@ impl WriteXDR for LedgerKeyData {
 //            ClaimableBalanceID balanceID;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct LedgerKeyClaimableBalance {
     pub balance_id: ClaimableBalanceId,
 }
@@ -4042,7 +4042,7 @@ impl WriteXDR for LedgerKeyClaimableBalance {
 //            PoolID liquidityPoolID;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct LedgerKeyLiquidityPool {
     pub liquidity_pool_id: PoolId,
 }
@@ -4107,7 +4107,7 @@ impl WriteXDR for LedgerKeyLiquidityPool {
 //    };
 //
 // union with discriminant LedgerEntryType
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum LedgerKey {
     Account(LedgerKeyAccount),
     Trustline(LedgerKeyTrustLine),
@@ -4183,7 +4183,7 @@ impl WriteXDR for LedgerKey {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum EnvelopeType {
     EnvelopeTypeTxV0 = 0,
@@ -4241,7 +4241,7 @@ impl WriteXDR for EnvelopeType {
 //
 //   typedef opaque UpgradeType<128>;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct UpgradeType(pub Vec<u8>);
 
 impl From<UpgradeType> for Vec<u8> {
@@ -4279,7 +4279,7 @@ impl WriteXDR for UpgradeType {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum StellarValueType {
     StellarValueBasic = 0,
@@ -4329,7 +4329,7 @@ impl WriteXDR for StellarValueType {
 //        Signature signature; // nodeID's signature
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct LedgerCloseValueSignature {
     pub node_id: NodeId,
     pub signature: Signature,
@@ -4363,7 +4363,7 @@ impl WriteXDR for LedgerCloseValueSignature {
 //        }
 //
 // union with discriminant StellarValueType
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum StellarValueExt {
     StellarValueBasic,
     StellarValueSigned(LedgerCloseValueSignature),
@@ -4429,7 +4429,7 @@ impl WriteXDR for StellarValueExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct StellarValue {
     pub tx_set_hash: Hash,
     pub close_time: TimePoint,
@@ -4474,7 +4474,7 @@ pub const MASK_LEDGER_HEADER_FLAGS: u64 = 0x7;
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum LedgerHeaderFlags {
     DisableLiquidityPoolTradingFlag = 1,
@@ -4527,7 +4527,7 @@ impl WriteXDR for LedgerHeaderFlags {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum LedgerHeaderExtensionV1Ext {
     V0,
 }
@@ -4576,7 +4576,7 @@ impl WriteXDR for LedgerHeaderExtensionV1Ext {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct LedgerHeaderExtensionV1 {
     pub flags: u32,
     pub ext: LedgerHeaderExtensionV1Ext,
@@ -4610,7 +4610,7 @@ impl WriteXDR for LedgerHeaderExtensionV1 {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum LedgerHeaderExt {
     V0,
     V1(LedgerHeaderExtensionV1),
@@ -4691,7 +4691,7 @@ impl WriteXDR for LedgerHeaderExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct LedgerHeader {
     pub ledger_version: u32,
     pub previous_ledger_hash: Hash,
@@ -4765,7 +4765,7 @@ impl WriteXDR for LedgerHeader {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum LedgerUpgradeType {
     LedgerUpgradeVersion = 1,
@@ -4830,7 +4830,7 @@ impl WriteXDR for LedgerUpgradeType {
 //    };
 //
 // union with discriminant LedgerUpgradeType
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum LedgerUpgrade {
     LedgerUpgradeVersion(u32),
     LedgerUpgradeBaseFee(u32),
@@ -4904,7 +4904,7 @@ impl WriteXDR for LedgerUpgrade {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum BucketEntryType {
     Metaentry = -1,
@@ -4959,7 +4959,7 @@ impl WriteXDR for BucketEntryType {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum BucketMetadataExt {
     V0,
 }
@@ -5010,7 +5010,7 @@ impl WriteXDR for BucketMetadataExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct BucketMetadata {
     pub ledger_version: u32,
     pub ext: BucketMetadataExt,
@@ -5048,7 +5048,7 @@ impl WriteXDR for BucketMetadata {
 //    };
 //
 // union with discriminant BucketEntryType
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum BucketEntry {
     Liveentry(LedgerEntry),
     Initentry(LedgerEntry),
@@ -5105,7 +5105,7 @@ impl WriteXDR for BucketEntry {
 //        TransactionEnvelope txs<>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TransactionSet {
     pub previous_ledger_hash: Hash,
     pub txs: Vec<TransactionEnvelope>,
@@ -5136,7 +5136,7 @@ impl WriteXDR for TransactionSet {
 //        TransactionResult result; // result for the transaction
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TransactionResultPair {
     pub transaction_hash: Hash,
     pub result: TransactionResult,
@@ -5166,7 +5166,7 @@ impl WriteXDR for TransactionResultPair {
 //        TransactionResultPair results<>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TransactionResultSet {
     pub results: Vec<TransactionResultPair>,
 }
@@ -5195,7 +5195,7 @@ impl WriteXDR for TransactionResultSet {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TransactionHistoryEntryExt {
     V0,
 }
@@ -5246,7 +5246,7 @@ impl WriteXDR for TransactionHistoryEntryExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TransactionHistoryEntry {
     pub ledger_seq: u32,
     pub tx_set: TransactionSet,
@@ -5281,7 +5281,7 @@ impl WriteXDR for TransactionHistoryEntry {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TransactionHistoryResultEntryExt {
     V0,
 }
@@ -5332,7 +5332,7 @@ impl WriteXDR for TransactionHistoryResultEntryExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TransactionHistoryResultEntry {
     pub ledger_seq: u32,
     pub tx_result_set: TransactionResultSet,
@@ -5367,7 +5367,7 @@ impl WriteXDR for TransactionHistoryResultEntry {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum LedgerHeaderHistoryEntryExt {
     V0,
 }
@@ -5418,7 +5418,7 @@ impl WriteXDR for LedgerHeaderHistoryEntryExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct LedgerHeaderHistoryEntry {
     pub hash: Hash,
     pub header: LedgerHeader,
@@ -5452,7 +5452,7 @@ impl WriteXDR for LedgerHeaderHistoryEntry {
 //        SCPEnvelope messages<>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct LedgerScpMessages {
     pub ledger_seq: u32,
     pub messages: Vec<ScpEnvelope>,
@@ -5483,7 +5483,7 @@ impl WriteXDR for LedgerScpMessages {
 //        LedgerSCPMessages ledgerMessages;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ScpHistoryEntryV0 {
     pub quorum_sets: Vec<ScpQuorumSet>,
     pub ledger_messages: LedgerScpMessages,
@@ -5515,7 +5515,7 @@ impl WriteXDR for ScpHistoryEntryV0 {
 //    };
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ScpHistoryEntry {
     V0(ScpHistoryEntryV0),
 }
@@ -5561,7 +5561,7 @@ impl WriteXDR for ScpHistoryEntry {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum LedgerEntryChangeType {
     LedgerEntryCreated = 0,
@@ -5622,7 +5622,7 @@ impl WriteXDR for LedgerEntryChangeType {
 //    };
 //
 // union with discriminant LedgerEntryChangeType
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum LedgerEntryChange {
     LedgerEntryCreated(LedgerEntry),
     LedgerEntryUpdated(LedgerEntry),
@@ -5681,7 +5681,7 @@ impl WriteXDR for LedgerEntryChange {
 //
 //   typedef LedgerEntryChange LedgerEntryChanges<>;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct LedgerEntryChanges(pub Vec<LedgerEntryChange>);
 
 impl From<LedgerEntryChanges> for Vec<LedgerEntryChange> {
@@ -5717,7 +5717,7 @@ impl WriteXDR for LedgerEntryChanges {
 //        LedgerEntryChanges changes;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct OperationMeta {
     pub changes: LedgerEntryChanges,
 }
@@ -5745,7 +5745,7 @@ impl WriteXDR for OperationMeta {
 //        OperationMeta operations<>;   // meta for each operation
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TransactionMetaV1 {
     pub tx_changes: LedgerEntryChanges,
     pub operations: Vec<OperationMeta>,
@@ -5779,7 +5779,7 @@ impl WriteXDR for TransactionMetaV1 {
 //                                            // applied if any
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TransactionMetaV2 {
     pub tx_changes_before: LedgerEntryChanges,
     pub operations: Vec<OperationMeta>,
@@ -5818,7 +5818,7 @@ impl WriteXDR for TransactionMetaV2 {
 //    };
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TransactionMeta {
     V0(Vec<OperationMeta>),
     V1(TransactionMetaV1),
@@ -5870,7 +5870,7 @@ impl WriteXDR for TransactionMeta {
 //        TransactionMeta txApplyProcessing;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TransactionResultMeta {
     pub result: TransactionResultPair,
     pub fee_processing: LedgerEntryChanges,
@@ -5904,7 +5904,7 @@ impl WriteXDR for TransactionResultMeta {
 //        LedgerEntryChanges changes;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct UpgradeEntryMeta {
     pub upgrade: LedgerUpgrade,
     pub changes: LedgerEntryChanges,
@@ -5947,7 +5947,7 @@ impl WriteXDR for UpgradeEntryMeta {
 //        SCPHistoryEntry scpInfo<>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct LedgerCloseMetaV0 {
     pub ledger_header: LedgerHeaderHistoryEntry,
     pub tx_set: TransactionSet,
@@ -5988,7 +5988,7 @@ impl WriteXDR for LedgerCloseMetaV0 {
 //    };
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum LedgerCloseMeta {
     V0(LedgerCloseMetaV0),
 }
@@ -6035,7 +6035,7 @@ impl WriteXDR for LedgerCloseMeta {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum ErrorCode {
     ErrMisc = 0,
@@ -6091,7 +6091,7 @@ impl WriteXDR for ErrorCode {
 //        string msg<100>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SError {
     pub code: ErrorCode,
     pub msg: Vec<u8>,
@@ -6121,7 +6121,7 @@ impl WriteXDR for SError {
 //        uint32 numMessages;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SendMore {
     pub num_messages: u32,
 }
@@ -6150,7 +6150,7 @@ impl WriteXDR for SendMore {
 //        Signature sig;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct AuthCert {
     pub pubkey: Curve25519Public,
     pub expiration: u64,
@@ -6191,7 +6191,7 @@ impl WriteXDR for AuthCert {
 //        uint256 nonce;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Hello {
     pub ledger_version: u32,
     pub overlay_version: u32,
@@ -6244,7 +6244,7 @@ impl WriteXDR for Hello {
 //        int unused;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Auth {
     pub unused: i32,
 }
@@ -6273,7 +6273,7 @@ impl WriteXDR for Auth {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum IpAddrType {
     IPv4 = 0,
@@ -6326,7 +6326,7 @@ impl WriteXDR for IpAddrType {
 //        }
 //
 // union with discriminant IpAddrType
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum PeerAddressIp {
     IPv4([u8; 4]),
     IPv6([u8; 16]),
@@ -6381,7 +6381,7 @@ impl WriteXDR for PeerAddressIp {
 //        uint32 numFailures;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PeerAddress {
     pub ip: PeerAddressIp,
     pub port: u32,
@@ -6439,7 +6439,7 @@ impl WriteXDR for PeerAddress {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum MessageType {
     ErrorMsg = 0,
@@ -6517,7 +6517,7 @@ impl WriteXDR for MessageType {
 //        uint256 reqHash;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct DontHave {
     pub type_: MessageType,
     pub req_hash: Uint256,
@@ -6548,7 +6548,7 @@ impl WriteXDR for DontHave {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum SurveyMessageCommandType {
     SurveyTopology = 0,
@@ -6599,7 +6599,7 @@ impl WriteXDR for SurveyMessageCommandType {
 //        SurveyMessageCommandType commandType;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SurveyRequestMessage {
     pub surveyor_peer_id: NodeId,
     pub surveyed_peer_id: NodeId,
@@ -6639,7 +6639,7 @@ impl WriteXDR for SurveyRequestMessage {
 //        SurveyRequestMessage request;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SignedSurveyRequestMessage {
     pub request_signature: Signature,
     pub request: SurveyRequestMessage,
@@ -6666,7 +6666,7 @@ impl WriteXDR for SignedSurveyRequestMessage {
 //
 //   typedef opaque EncryptedBody<64000>;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct EncryptedBody(pub Vec<u8>);
 
 impl From<EncryptedBody> for Vec<u8> {
@@ -6706,7 +6706,7 @@ impl WriteXDR for EncryptedBody {
 //        EncryptedBody encryptedBody;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SurveyResponseMessage {
     pub surveyor_peer_id: NodeId,
     pub surveyed_peer_id: NodeId,
@@ -6746,7 +6746,7 @@ impl WriteXDR for SurveyResponseMessage {
 //        SurveyResponseMessage response;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SignedSurveyResponseMessage {
     pub response_signature: Signature,
     pub response: SurveyResponseMessage,
@@ -6792,7 +6792,7 @@ impl WriteXDR for SignedSurveyResponseMessage {
 //        uint64 duplicateFetchMessageRecv;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PeerStats {
     pub id: NodeId,
     pub version_str: Vec<u8>,
@@ -6858,7 +6858,7 @@ impl WriteXDR for PeerStats {
 //
 //   typedef PeerStats PeerStatList<25>;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PeerStatList(pub Vec<PeerStats>);
 
 impl From<PeerStatList> for Vec<PeerStats> {
@@ -6898,7 +6898,7 @@ impl WriteXDR for PeerStatList {
 //        uint32 totalOutboundPeerCount;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TopologyResponseBody {
     pub inbound_peers: PeerStatList,
     pub outbound_peers: PeerStatList,
@@ -6936,7 +6936,7 @@ impl WriteXDR for TopologyResponseBody {
 //    };
 //
 // union with discriminant SurveyMessageCommandType
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum SurveyResponseBody {
     SurveyTopology(TopologyResponseBody),
 }
@@ -7018,7 +7018,7 @@ impl WriteXDR for SurveyResponseBody {
 //    };
 //
 // union with discriminant MessageType
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum StellarMessage {
     ErrorMsg(SError),
     Hello(Hello),
@@ -7132,7 +7132,7 @@ impl WriteXDR for StellarMessage {
 //            HmacSha256Mac mac;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct AuthenticatedMessageV0 {
     pub sequence: u64,
     pub message: StellarMessage,
@@ -7172,7 +7172,7 @@ impl WriteXDR for AuthenticatedMessageV0 {
 //    };
 //
 // union with discriminant u32
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum AuthenticatedMessage {
     V0(AuthenticatedMessageV0),
 }
@@ -7216,7 +7216,7 @@ impl WriteXDR for AuthenticatedMessage {
 //    };
 //
 // union with discriminant LiquidityPoolType
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum LiquidityPoolParameters {
     LiquidityPoolConstantProduct(LiquidityPoolConstantProductParameters),
 }
@@ -7263,7 +7263,7 @@ impl WriteXDR for LiquidityPoolParameters {
 //            uint256 ed25519;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct MuxedAccountMed25519 {
     pub id: u64,
     pub ed25519: Uint256,
@@ -7301,7 +7301,7 @@ impl WriteXDR for MuxedAccountMed25519 {
 //    };
 //
 // union with discriminant CryptoKeyType
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum MuxedAccount {
     KeyTypeEd25519(Uint256),
     KeyTypeMuxedEd25519(MuxedAccountMed25519),
@@ -7352,7 +7352,7 @@ impl WriteXDR for MuxedAccount {
 //        Signature signature; // actual signature
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct DecoratedSignature {
     pub hint: SignatureHint,
     pub signature: Signature,
@@ -7406,7 +7406,7 @@ impl WriteXDR for DecoratedSignature {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum OperationType {
     CreateAccount = 0,
@@ -7500,7 +7500,7 @@ impl WriteXDR for OperationType {
 //        int64 startingBalance; // amount they end up with
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct CreateAccountOp {
     pub destination: AccountId,
     pub starting_balance: i64,
@@ -7532,7 +7532,7 @@ impl WriteXDR for CreateAccountOp {
 //        int64 amount;             // amount they end up with
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PaymentOp {
     pub destination: MuxedAccount,
     pub asset: Asset,
@@ -7574,7 +7574,7 @@ impl WriteXDR for PaymentOp {
 //        Asset path<5>; // additional hops it must go through to get there
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PathPaymentStrictReceiveOp {
     pub send_asset: Asset,
     pub send_max: i64,
@@ -7625,7 +7625,7 @@ impl WriteXDR for PathPaymentStrictReceiveOp {
 //        Asset path<5>; // additional hops it must go through to get there
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PathPaymentStrictSendOp {
     pub send_asset: Asset,
     pub send_amount: i64,
@@ -7673,7 +7673,7 @@ impl WriteXDR for PathPaymentStrictSendOp {
 //        int64 offerID;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ManageSellOfferOp {
     pub selling: Asset,
     pub buying: Asset,
@@ -7719,7 +7719,7 @@ impl WriteXDR for ManageSellOfferOp {
 //        int64 offerID;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ManageBuyOfferOp {
     pub selling: Asset,
     pub buying: Asset,
@@ -7761,7 +7761,7 @@ impl WriteXDR for ManageBuyOfferOp {
 //        Price price;   // cost of A in terms of B
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct CreatePassiveSellOfferOp {
     pub selling: Asset,
     pub buying: Asset,
@@ -7812,7 +7812,7 @@ impl WriteXDR for CreatePassiveSellOfferOp {
 //        Signer* signer;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SetOptionsOp {
     pub inflation_dest: Option<AccountId>,
     pub clear_flags: Option<u32>,
@@ -7876,7 +7876,7 @@ impl WriteXDR for SetOptionsOp {
 //    };
 //
 // union with discriminant AssetType
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ChangeTrustAsset {
     AssetTypeNative,
     AssetTypeCreditAlphanum4(AlphaNum4),
@@ -7939,7 +7939,7 @@ impl WriteXDR for ChangeTrustAsset {
 //        int64 limit;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ChangeTrustOp {
     pub line: ChangeTrustAsset,
     pub limit: i64,
@@ -7973,7 +7973,7 @@ impl WriteXDR for ChangeTrustOp {
 //        uint32 authorize;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct AllowTrustOp {
     pub trustor: AccountId,
     pub asset: AssetCode,
@@ -8007,7 +8007,7 @@ impl WriteXDR for AllowTrustOp {
 //        DataValue* dataValue; // set to null to clear
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ManageDataOp {
     pub data_name: Vec<u8>,
     pub data_value: Option<DataValue>,
@@ -8037,7 +8037,7 @@ impl WriteXDR for ManageDataOp {
 //        SequenceNumber bumpTo;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct BumpSequenceOp {
     pub bump_to: SequenceNumber,
 }
@@ -8066,7 +8066,7 @@ impl WriteXDR for BumpSequenceOp {
 //        Claimant claimants<10>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct CreateClaimableBalanceOp {
     pub asset: Asset,
     pub amount: i64,
@@ -8099,7 +8099,7 @@ impl WriteXDR for CreateClaimableBalanceOp {
 //        ClaimableBalanceID balanceID;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ClaimClaimableBalanceOp {
     pub balance_id: ClaimableBalanceId,
 }
@@ -8126,7 +8126,7 @@ impl WriteXDR for ClaimClaimableBalanceOp {
 //        AccountID sponsoredID;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct BeginSponsoringFutureReservesOp {
     pub sponsored_id: AccountId,
 }
@@ -8155,7 +8155,7 @@ impl WriteXDR for BeginSponsoringFutureReservesOp {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum RevokeSponsorshipType {
     RevokeSponsorshipLedgerEntry = 0,
@@ -8205,7 +8205,7 @@ impl WriteXDR for RevokeSponsorshipType {
 //            SignerKey signerKey;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct RevokeSponsorshipOpSigner {
     pub account_id: AccountId,
     pub signer_key: SignerKey,
@@ -8243,7 +8243,7 @@ impl WriteXDR for RevokeSponsorshipOpSigner {
 //    };
 //
 // union with discriminant RevokeSponsorshipType
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum RevokeSponsorshipOp {
     RevokeSponsorshipLedgerEntry(LedgerKey),
     RevokeSponsorshipSigner(RevokeSponsorshipOpSigner),
@@ -8297,7 +8297,7 @@ impl WriteXDR for RevokeSponsorshipOp {
 //        int64 amount;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ClawbackOp {
     pub asset: Asset,
     pub from: MuxedAccount,
@@ -8330,7 +8330,7 @@ impl WriteXDR for ClawbackOp {
 //        ClaimableBalanceID balanceID;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ClawbackClaimableBalanceOp {
     pub balance_id: ClaimableBalanceId,
 }
@@ -8361,7 +8361,7 @@ impl WriteXDR for ClawbackClaimableBalanceOp {
 //        uint32 setFlags;   // which flags to set
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SetTrustLineFlagsOp {
     pub trustor: AccountId,
     pub asset: Asset,
@@ -8407,7 +8407,7 @@ pub const LIQUIDITY_POOL_FEE_V18: u64 = 30;
 //        Price maxPrice;   // maximum depositA/depositB
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct LiquidityPoolDepositOp {
     pub liquidity_pool_id: PoolId,
     pub max_amount_a: i64,
@@ -8449,7 +8449,7 @@ impl WriteXDR for LiquidityPoolDepositOp {
 //        int64 minAmountB; // minimum amount of second asset to withdraw
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct LiquidityPoolWithdrawOp {
     pub liquidity_pool_id: PoolId,
     pub amount: i64,
@@ -8533,7 +8533,7 @@ impl WriteXDR for LiquidityPoolWithdrawOp {
 //        }
 //
 // union with discriminant OperationType
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum OperationBody {
     CreateAccount(CreateAccountOp),
     Payment(PaymentOp),
@@ -8757,7 +8757,7 @@ impl WriteXDR for OperationBody {
 //        body;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Operation {
     pub source_account: Option<MuxedAccount>,
     pub body: OperationBody,
@@ -8789,7 +8789,7 @@ impl WriteXDR for Operation {
 //            uint32 opNum;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct HashIdPreimageOperationId {
     pub source_account: AccountId,
     pub seq_num: SequenceNumber,
@@ -8826,7 +8826,7 @@ impl WriteXDR for HashIdPreimageOperationId {
 //            Asset asset;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct HashIdPreimageRevokeId {
     pub source_account: AccountId,
     pub seq_num: SequenceNumber,
@@ -8881,7 +8881,7 @@ impl WriteXDR for HashIdPreimageRevokeId {
 //    };
 //
 // union with discriminant EnvelopeType
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum HashIdPreimage {
     EnvelopeTypeOpId(HashIdPreimageOperationId),
     EnvelopeTypePoolRevokeOpId(HashIdPreimageRevokeId),
@@ -8936,7 +8936,7 @@ impl WriteXDR for HashIdPreimage {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum MemoType {
     MemoNone = 0,
@@ -9001,7 +9001,7 @@ impl WriteXDR for MemoType {
 //    };
 //
 // union with discriminant MemoType
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Memo {
     MemoNone,
     MemoText(Vec<u8>),
@@ -9060,7 +9060,7 @@ impl WriteXDR for Memo {
 //        TimePoint maxTime; // 0 here means no maxTime
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TimeBounds {
     pub min_time: TimePoint,
     pub max_time: TimePoint,
@@ -9091,7 +9091,7 @@ impl WriteXDR for TimeBounds {
 //        uint32 maxLedger; // 0 here means no maxLedger
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct LedgerBounds {
     pub min_ledger: u32,
     pub max_ledger: u32,
@@ -9149,7 +9149,7 @@ impl WriteXDR for LedgerBounds {
 //        SignerKey extraSigners<2>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PreconditionsV2 {
     pub time_bounds: Option<TimeBounds>,
     pub ledger_bounds: Option<LedgerBounds>,
@@ -9194,7 +9194,7 @@ impl WriteXDR for PreconditionsV2 {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum PreconditionType {
     PrecondNone = 0,
@@ -9251,7 +9251,7 @@ impl WriteXDR for PreconditionType {
 //    };
 //
 // union with discriminant PreconditionType
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Preconditions {
     PrecondNone,
     PrecondTime(TimeBounds),
@@ -9313,7 +9313,7 @@ pub const MAX_OPS_PER_TX: u64 = 100;
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TransactionV0Ext {
     V0,
 }
@@ -9366,7 +9366,7 @@ impl WriteXDR for TransactionV0Ext {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TransactionV0 {
     pub source_account_ed25519: Uint256,
     pub fee: u32,
@@ -9414,7 +9414,7 @@ impl WriteXDR for TransactionV0 {
 //        DecoratedSignature signatures<20>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TransactionV0Envelope {
     pub tx: TransactionV0,
     pub signatures: Vec<DecoratedSignature>,
@@ -9446,7 +9446,7 @@ impl WriteXDR for TransactionV0Envelope {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TransactionExt {
     V0,
 }
@@ -9510,7 +9510,7 @@ impl WriteXDR for TransactionExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Transaction {
     pub source_account: MuxedAccount,
     pub fee: u32,
@@ -9558,7 +9558,7 @@ impl WriteXDR for Transaction {
 //        DecoratedSignature signatures<20>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TransactionV1Envelope {
     pub tx: Transaction,
     pub signatures: Vec<DecoratedSignature>,
@@ -9590,7 +9590,7 @@ impl WriteXDR for TransactionV1Envelope {
 //        }
 //
 // union with discriminant EnvelopeType
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum FeeBumpTransactionInnerTx {
     EnvelopeTypeTx(TransactionV1Envelope),
 }
@@ -9636,7 +9636,7 @@ impl WriteXDR for FeeBumpTransactionInnerTx {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum FeeBumpTransactionExt {
     V0,
 }
@@ -9691,7 +9691,7 @@ impl WriteXDR for FeeBumpTransactionExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct FeeBumpTransaction {
     pub fee_source: MuxedAccount,
     pub fee: i64,
@@ -9730,7 +9730,7 @@ impl WriteXDR for FeeBumpTransaction {
 //        DecoratedSignature signatures<20>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct FeeBumpTransactionEnvelope {
     pub tx: FeeBumpTransaction,
     pub signatures: Vec<DecoratedSignature>,
@@ -9766,7 +9766,7 @@ impl WriteXDR for FeeBumpTransactionEnvelope {
 //    };
 //
 // union with discriminant EnvelopeType
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TransactionEnvelope {
     EnvelopeTypeTxV0(TransactionV0Envelope),
     EnvelopeTypeTx(TransactionV1Envelope),
@@ -9827,7 +9827,7 @@ impl WriteXDR for TransactionEnvelope {
 //        }
 //
 // union with discriminant EnvelopeType
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TransactionSignaturePayloadTaggedTransaction {
     EnvelopeTypeTx(Transaction),
     EnvelopeTypeTxFeeBump(FeeBumpTransaction),
@@ -9886,7 +9886,7 @@ impl WriteXDR for TransactionSignaturePayloadTaggedTransaction {
 //        taggedTransaction;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TransactionSignaturePayload {
     pub network_id: Hash,
     pub tagged_transaction: TransactionSignaturePayloadTaggedTransaction,
@@ -9920,7 +9920,7 @@ impl WriteXDR for TransactionSignaturePayload {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum ClaimAtomType {
     ClaimAtomTypeV0 = 0,
@@ -9981,7 +9981,7 @@ impl WriteXDR for ClaimAtomType {
 //        int64 amountBought;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ClaimOfferAtomV0 {
     pub seller_ed25519: Uint256,
     pub offer_id: i64,
@@ -10033,7 +10033,7 @@ impl WriteXDR for ClaimOfferAtomV0 {
 //        int64 amountBought;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ClaimOfferAtom {
     pub seller_id: AccountId,
     pub offer_id: i64,
@@ -10083,7 +10083,7 @@ impl WriteXDR for ClaimOfferAtom {
 //        int64 amountBought;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ClaimLiquidityAtom {
     pub liquidity_pool_id: PoolId,
     pub asset_sold: Asset,
@@ -10128,7 +10128,7 @@ impl WriteXDR for ClaimLiquidityAtom {
 //    };
 //
 // union with discriminant ClaimAtomType
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ClaimAtom {
     ClaimAtomTypeV0(ClaimOfferAtomV0),
     ClaimAtomTypeOrderBook(ClaimOfferAtom),
@@ -10193,7 +10193,7 @@ impl WriteXDR for ClaimAtom {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum CreateAccountResultCode {
     CreateAccountSuccess = 0,
@@ -10252,7 +10252,7 @@ impl WriteXDR for CreateAccountResultCode {
 //    };
 //
 // union with discriminant CreateAccountResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum CreateAccountResult {
     CreateAccountSuccess,
 }
@@ -10307,7 +10307,7 @@ impl WriteXDR for CreateAccountResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum PaymentResultCode {
     PaymentSuccess = 0,
@@ -10376,7 +10376,7 @@ impl WriteXDR for PaymentResultCode {
 //    };
 //
 // union with discriminant PaymentResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum PaymentResult {
     PaymentSuccess,
 }
@@ -10443,7 +10443,7 @@ impl WriteXDR for PaymentResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum PathPaymentStrictReceiveResultCode {
     PathPaymentStrictReceiveSuccess = 0,
@@ -10516,7 +10516,7 @@ impl WriteXDR for PathPaymentStrictReceiveResultCode {
 //        int64 amount;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SimplePaymentResult {
     pub destination: AccountId,
     pub asset: Asset,
@@ -10550,7 +10550,7 @@ impl WriteXDR for SimplePaymentResult {
 //            SimplePaymentResult last;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PathPaymentStrictReceiveResultSuccess {
     pub offers: Vec<ClaimAtom>,
     pub last: SimplePaymentResult,
@@ -10591,7 +10591,7 @@ impl WriteXDR for PathPaymentStrictReceiveResultSuccess {
 //    };
 //
 // union with discriminant PathPaymentStrictReceiveResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum PathPaymentStrictReceiveResult {
     PathPaymentStrictReceiveSuccess(PathPaymentStrictReceiveResultSuccess),
     PathPaymentStrictReceiveNoIssuer(Asset),
@@ -10672,7 +10672,7 @@ impl WriteXDR for PathPaymentStrictReceiveResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum PathPaymentStrictSendResultCode {
     PathPaymentStrictSendSuccess = 0,
@@ -10744,7 +10744,7 @@ impl WriteXDR for PathPaymentStrictSendResultCode {
 //            SimplePaymentResult last;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PathPaymentStrictSendResultSuccess {
     pub offers: Vec<ClaimAtom>,
     pub last: SimplePaymentResult,
@@ -10784,7 +10784,7 @@ impl WriteXDR for PathPaymentStrictSendResultSuccess {
 //    };
 //
 // union with discriminant PathPaymentStrictSendResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum PathPaymentStrictSendResult {
     PathPaymentStrictSendSuccess(PathPaymentStrictSendResultSuccess),
     PathPaymentStrictSendNoIssuer(Asset),
@@ -10864,7 +10864,7 @@ impl WriteXDR for PathPaymentStrictSendResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum ManageSellOfferResultCode {
     ManageSellOfferSuccess = 0,
@@ -10938,7 +10938,7 @@ impl WriteXDR for ManageSellOfferResultCode {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum ManageOfferEffect {
     ManageOfferCreated = 0,
@@ -10994,7 +10994,7 @@ impl WriteXDR for ManageOfferEffect {
 //        }
 //
 // union with discriminant ManageOfferEffect
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ManageOfferSuccessResultOffer {
     ManageOfferCreated(OfferEntry),
     ManageOfferUpdated(OfferEntry),
@@ -11055,7 +11055,7 @@ impl WriteXDR for ManageOfferSuccessResultOffer {
 //        offer;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ManageOfferSuccessResult {
     pub offers_claimed: Vec<ClaimAtom>,
     pub offer: ManageOfferSuccessResultOffer,
@@ -11089,7 +11089,7 @@ impl WriteXDR for ManageOfferSuccessResult {
 //    };
 //
 // union with discriminant ManageSellOfferResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ManageSellOfferResult {
     ManageSellOfferSuccess(ManageOfferSuccessResult),
 }
@@ -11153,7 +11153,7 @@ impl WriteXDR for ManageSellOfferResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum ManageBuyOfferResultCode {
     ManageBuyOfferSuccess = 0,
@@ -11228,7 +11228,7 @@ impl WriteXDR for ManageBuyOfferResultCode {
 //    };
 //
 // union with discriminant ManageBuyOfferResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ManageBuyOfferResult {
     ManageBuyOfferSuccess(ManageOfferSuccessResult),
 }
@@ -11286,7 +11286,7 @@ impl WriteXDR for ManageBuyOfferResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum SetOptionsResultCode {
     SetOptionsSuccess = 0,
@@ -11357,7 +11357,7 @@ impl WriteXDR for SetOptionsResultCode {
 //    };
 //
 // union with discriminant SetOptionsResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum SetOptionsResult {
     SetOptionsSuccess,
 }
@@ -11414,7 +11414,7 @@ impl WriteXDR for SetOptionsResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum ChangeTrustResultCode {
     ChangeTrustSuccess = 0,
@@ -11481,7 +11481,7 @@ impl WriteXDR for ChangeTrustResultCode {
 //    };
 //
 // union with discriminant ChangeTrustResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ChangeTrustResult {
     ChangeTrustSuccess,
 }
@@ -11534,7 +11534,7 @@ impl WriteXDR for ChangeTrustResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum AllowTrustResultCode {
     AllowTrustSuccess = 0,
@@ -11597,7 +11597,7 @@ impl WriteXDR for AllowTrustResultCode {
 //    };
 //
 // union with discriminant AllowTrustResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum AllowTrustResult {
     AllowTrustSuccess,
 }
@@ -11650,7 +11650,7 @@ impl WriteXDR for AllowTrustResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum AccountMergeResultCode {
     AccountMergeSuccess = 0,
@@ -11715,7 +11715,7 @@ impl WriteXDR for AccountMergeResultCode {
 //    };
 //
 // union with discriminant AccountMergeResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum AccountMergeResult {
     AccountMergeSuccess(i64),
 }
@@ -11763,7 +11763,7 @@ impl WriteXDR for AccountMergeResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum InflationResultCode {
     InflationSuccess = 0,
@@ -11813,7 +11813,7 @@ impl WriteXDR for InflationResultCode {
 //        int64 amount;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct InflationPayout {
     pub destination: AccountId,
     pub amount: i64,
@@ -11847,7 +11847,7 @@ impl WriteXDR for InflationPayout {
 //    };
 //
 // union with discriminant InflationResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum InflationResult {
     InflationSuccess(Vec<InflationPayout>),
 }
@@ -11900,7 +11900,7 @@ impl WriteXDR for InflationResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum ManageDataResultCode {
     ManageDataSuccess = 0,
@@ -11959,7 +11959,7 @@ impl WriteXDR for ManageDataResultCode {
 //    };
 //
 // union with discriminant ManageDataResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ManageDataResult {
     ManageDataSuccess,
 }
@@ -12005,7 +12005,7 @@ impl WriteXDR for ManageDataResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum BumpSequenceResultCode {
     BumpSequenceSuccess = 0,
@@ -12058,7 +12058,7 @@ impl WriteXDR for BumpSequenceResultCode {
 //    };
 //
 // union with discriminant BumpSequenceResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum BumpSequenceResult {
     BumpSequenceSuccess,
 }
@@ -12106,7 +12106,7 @@ impl WriteXDR for BumpSequenceResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum CreateClaimableBalanceResultCode {
     CreateClaimableBalanceSuccess = 0,
@@ -12168,7 +12168,7 @@ impl WriteXDR for CreateClaimableBalanceResultCode {
 //    };
 //
 // union with discriminant CreateClaimableBalanceResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum CreateClaimableBalanceResult {
     CreateClaimableBalanceSuccess(ClaimableBalanceId),
 }
@@ -12222,7 +12222,7 @@ impl WriteXDR for CreateClaimableBalanceResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum ClaimClaimableBalanceResultCode {
     ClaimClaimableBalanceSuccess = 0,
@@ -12283,7 +12283,7 @@ impl WriteXDR for ClaimClaimableBalanceResultCode {
 //    };
 //
 // union with discriminant ClaimClaimableBalanceResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ClaimClaimableBalanceResult {
     ClaimClaimableBalanceSuccess,
 }
@@ -12337,7 +12337,7 @@ impl WriteXDR for ClaimClaimableBalanceResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum BeginSponsoringFutureReservesResultCode {
     BeginSponsoringFutureReservesSuccess = 0,
@@ -12395,7 +12395,7 @@ impl WriteXDR for BeginSponsoringFutureReservesResultCode {
 //    };
 //
 // union with discriminant BeginSponsoringFutureReservesResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum BeginSponsoringFutureReservesResult {
     BeginSponsoringFutureReservesSuccess,
 }
@@ -12447,7 +12447,7 @@ impl WriteXDR for BeginSponsoringFutureReservesResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum EndSponsoringFutureReservesResultCode {
     EndSponsoringFutureReservesSuccess = 0,
@@ -12501,7 +12501,7 @@ impl WriteXDR for EndSponsoringFutureReservesResultCode {
 //    };
 //
 // union with discriminant EndSponsoringFutureReservesResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum EndSponsoringFutureReservesResult {
     EndSponsoringFutureReservesSuccess,
 }
@@ -12557,7 +12557,7 @@ impl WriteXDR for EndSponsoringFutureReservesResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum RevokeSponsorshipResultCode {
     RevokeSponsorshipSuccess = 0,
@@ -12618,7 +12618,7 @@ impl WriteXDR for RevokeSponsorshipResultCode {
 //    };
 //
 // union with discriminant RevokeSponsorshipResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum RevokeSponsorshipResult {
     RevokeSponsorshipSuccess,
 }
@@ -12669,7 +12669,7 @@ impl WriteXDR for RevokeSponsorshipResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum ClawbackResultCode {
     ClawbackSuccess = 0,
@@ -12728,7 +12728,7 @@ impl WriteXDR for ClawbackResultCode {
 //    };
 //
 // union with discriminant ClawbackResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ClawbackResult {
     ClawbackSuccess,
 }
@@ -12777,7 +12777,7 @@ impl WriteXDR for ClawbackResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum ClawbackClaimableBalanceResultCode {
     ClawbackClaimableBalanceSuccess = 0,
@@ -12835,7 +12835,7 @@ impl WriteXDR for ClawbackClaimableBalanceResultCode {
 //    };
 //
 // union with discriminant ClawbackClaimableBalanceResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ClawbackClaimableBalanceResult {
     ClawbackClaimableBalanceSuccess,
 }
@@ -12892,7 +12892,7 @@ impl WriteXDR for ClawbackClaimableBalanceResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum SetTrustLineFlagsResultCode {
     SetTrustLineFlagsSuccess = 0,
@@ -12953,7 +12953,7 @@ impl WriteXDR for SetTrustLineFlagsResultCode {
 //    };
 //
 // union with discriminant SetTrustLineFlagsResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum SetTrustLineFlagsResult {
     SetTrustLineFlagsSuccess,
 }
@@ -13011,7 +13011,7 @@ impl WriteXDR for SetTrustLineFlagsResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum LiquidityPoolDepositResultCode {
     LiquidityPoolDepositSuccess = 0,
@@ -13076,7 +13076,7 @@ impl WriteXDR for LiquidityPoolDepositResultCode {
 //    };
 //
 // union with discriminant LiquidityPoolDepositResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum LiquidityPoolDepositResult {
     LiquidityPoolDepositSuccess,
 }
@@ -13135,7 +13135,7 @@ impl WriteXDR for LiquidityPoolDepositResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum LiquidityPoolWithdrawResultCode {
     LiquidityPoolWithdrawSuccess = 0,
@@ -13196,7 +13196,7 @@ impl WriteXDR for LiquidityPoolWithdrawResultCode {
 //    };
 //
 // union with discriminant LiquidityPoolWithdrawResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum LiquidityPoolWithdrawResult {
     LiquidityPoolWithdrawSuccess,
 }
@@ -13251,7 +13251,7 @@ impl WriteXDR for LiquidityPoolWithdrawResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum OperationResultCode {
     OpInner = 0,
@@ -13358,7 +13358,7 @@ impl WriteXDR for OperationResultCode {
 //        }
 //
 // union with discriminant OperationType
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum OperationResultTr {
     CreateAccount(CreateAccountResult),
     Payment(PaymentResult),
@@ -13589,7 +13589,7 @@ impl WriteXDR for OperationResultTr {
 //    };
 //
 // union with discriminant OperationResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum OperationResult {
     OpInner(OperationResultTr),
 }
@@ -13656,7 +13656,7 @@ impl WriteXDR for OperationResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum TransactionResultCode {
     TxFeeBumpInnerSuccess = 1,
@@ -13757,7 +13757,7 @@ impl WriteXDR for TransactionResultCode {
 //        }
 //
 // union with discriminant TransactionResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum InnerTransactionResultResult {
     TxSuccess(Vec<OperationResult>),
     TxFailed(Vec<OperationResult>),
@@ -13865,7 +13865,7 @@ impl WriteXDR for InnerTransactionResultResult {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum InnerTransactionResultExt {
     V0,
 }
@@ -13941,7 +13941,7 @@ impl WriteXDR for InnerTransactionResultExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct InnerTransactionResult {
     pub fee_charged: i64,
     pub result: InnerTransactionResultResult,
@@ -13975,7 +13975,7 @@ impl WriteXDR for InnerTransactionResult {
 //        InnerTransactionResult result; // result for the inner transaction
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct InnerTransactionResultPair {
     pub transaction_hash: Hash,
     pub result: InnerTransactionResult,
@@ -14013,7 +14013,7 @@ impl WriteXDR for InnerTransactionResultPair {
 //        }
 //
 // union with discriminant TransactionResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TransactionResultResult {
     TxFeeBumpInnerSuccess(InnerTransactionResultPair),
     TxFeeBumpInnerFailed(InnerTransactionResultPair),
@@ -14077,7 +14077,7 @@ impl WriteXDR for TransactionResultResult {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TransactionResultExt {
     V0,
 }
@@ -14140,7 +14140,7 @@ impl WriteXDR for TransactionResultExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TransactionResult {
     pub fee_charged: i64,
     pub result: TransactionResultResult,
@@ -14170,7 +14170,7 @@ impl WriteXDR for TransactionResult {
 //
 //   typedef opaque Hash[32];
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Hash(pub [u8; 32]);
 
 impl From<Hash> for [u8; 32] {
@@ -14203,7 +14203,7 @@ impl WriteXDR for Hash {
 //
 //   typedef opaque uint256[32];
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Uint256(pub [u8; 32]);
 
 impl From<Uint256> for [u8; 32] {
@@ -14265,7 +14265,7 @@ pub type Int64 = i64;
 //    };
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ExtensionPoint {
     V0,
 }
@@ -14314,7 +14314,7 @@ impl WriteXDR for ExtensionPoint {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum CryptoKeyType {
     KeyTypeEd25519 = 0,
@@ -14370,7 +14370,7 @@ impl WriteXDR for CryptoKeyType {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum PublicKeyType {
     PublicKeyTypeEd25519 = 0,
@@ -14421,7 +14421,7 @@ impl WriteXDR for PublicKeyType {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum SignerKeyType {
     SignerKeyTypeEd25519 = 0,
@@ -14476,7 +14476,7 @@ impl WriteXDR for SignerKeyType {
 //    };
 //
 // union with discriminant PublicKeyType
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum PublicKey {
     PublicKeyTypeEd25519(Uint256),
 }
@@ -14523,7 +14523,7 @@ impl WriteXDR for PublicKey {
 //            opaque payload<64>;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SignerKeyEd25519SignedPayload {
     pub ed25519: Uint256,
     pub payload: Vec<u8>,
@@ -14569,7 +14569,7 @@ impl WriteXDR for SignerKeyEd25519SignedPayload {
 //    };
 //
 // union with discriminant SignerKeyType
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum SignerKey {
     SignerKeyTypeEd25519(Uint256),
     SignerKeyTypePreAuthTx(Uint256),
@@ -14632,7 +14632,7 @@ impl WriteXDR for SignerKey {
 //
 //   typedef opaque Signature<64>;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Signature(pub Vec<u8>);
 
 impl From<Signature> for Vec<u8> {
@@ -14665,7 +14665,7 @@ impl WriteXDR for Signature {
 //
 //   typedef opaque SignatureHint[4];
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SignatureHint(pub [u8; 4]);
 
 impl From<SignatureHint> for [u8; 4] {
@@ -14698,7 +14698,7 @@ impl WriteXDR for SignatureHint {
 //
 //   typedef PublicKey NodeID;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct NodeId(pub PublicKey);
 
 impl From<NodeId> for PublicKey {
@@ -14734,7 +14734,7 @@ impl WriteXDR for NodeId {
 //        opaque key[32];
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Curve25519Secret {
     pub key: [u8; 32],
 }
@@ -14761,7 +14761,7 @@ impl WriteXDR for Curve25519Secret {
 //        opaque key[32];
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Curve25519Public {
     pub key: [u8; 32],
 }
@@ -14788,7 +14788,7 @@ impl WriteXDR for Curve25519Public {
 //        opaque key[32];
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct HmacSha256Key {
     pub key: [u8; 32],
 }
@@ -14815,7 +14815,7 @@ impl WriteXDR for HmacSha256Key {
 //        opaque mac[32];
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct HmacSha256Mac {
     pub mac: [u8; 32],
 }
@@ -14856,7 +14856,7 @@ pub type ScSymbol = Vec<u8>;
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum ScValType {
     ScvU63 = 0,
@@ -14920,7 +14920,7 @@ impl WriteXDR for ScValType {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum ScStatic {
     ScsVoid = 0,
@@ -14974,7 +14974,7 @@ impl WriteXDR for ScStatic {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum ScStatusType {
     SstOk = 0,
@@ -15027,7 +15027,7 @@ impl WriteXDR for ScStatusType {
 //    };
 //
 // union with discriminant ScStatusType
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ScStatus {
     SstOk,
     SstUnknownError(u32),
@@ -15089,7 +15089,7 @@ impl WriteXDR for ScStatus {
 //    };
 //
 // union with discriminant ScValType
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ScVal {
     ScvU63(u64),
     ScvU32(u32),
@@ -15189,7 +15189,7 @@ impl WriteXDR for ScVal {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum ScObjectType {
     ScoBox = 0,
@@ -15267,7 +15267,7 @@ impl WriteXDR for ScObjectType {
 //        SCVal val;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ScMapEntry {
     pub key: ScVal,
     pub val: ScVal,
@@ -15294,7 +15294,7 @@ impl WriteXDR for ScMapEntry {
 //
 //   typedef SCVal SCVec<>;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ScVec(pub Vec<ScVal>);
 
 impl From<ScVec> for Vec<ScVal> {
@@ -15327,7 +15327,7 @@ impl WriteXDR for ScVec {
 //
 //   typedef SCMapEntry SCMap<>;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ScMap(pub Vec<ScMapEntry>);
 
 impl From<ScMap> for Vec<ScMapEntry> {
@@ -15364,7 +15364,7 @@ impl WriteXDR for ScMap {
 //        opaque magnitude<>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ScBigInt {
     pub positive: bool,
     pub magnitude: Vec<u8>,
@@ -15396,7 +15396,7 @@ impl WriteXDR for ScBigInt {
 //        opaque denominator<>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ScBigRat {
     pub positive: bool,
     pub numerator: Vec<u8>,
@@ -15461,7 +15461,7 @@ impl WriteXDR for ScBigRat {
 //    };
 //
 // union with discriminant ScObjectType
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ScObject {
     ScoBox(ScVal),
     ScoVec(ScVec),


### PR DESCRIPTION
### What

Add PartialOrd and Ord to all types.

### Why

So that all types can be sorted or used in ordered maps.

Related https://github.com/stellar/xdrgen/pull/79/commits/4407c126b3307627fa0f9758deed2632f23d8747

Close #20

### Known limitations

N/A