### PR TITLE
Add iter fn to VecM

### DIFF
--- a/src/xdr.rs
+++ b/src/xdr.rs
@@ -12,6 +12,7 @@ use std::{
     fmt::Debug,
     io,
     io::{Cursor, Read, Write},
+    slice::Iter,
 };
 
 #[derive(Debug)]
@@ -291,6 +292,10 @@ impl<T, const MAX: u32> VecM<T, MAX> {
 
     pub fn as_slice(&self) -> &[T] {
         self.as_ref()
+    }
+
+    pub fn iter(&self) -> Iter<'_, T> {
+        self.0.iter()
     }
 }
 


### PR DESCRIPTION
### What

Add iter() fn to VecM.

### Why

Convenience.

Related https://github.com/stellar/xdrgen/pull/79/commits/cd8e98b4fc2c9c1c12de115aba9b97de9121f10a

### Known limitations

N/A
