### PR TITLE
Add forbid unsafe

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,3 @@
+#![forbid(unsafe_code)]
 mod xdr;
 pub use xdr::*;


### PR DESCRIPTION
### What

Make using unsafe forbidden in stellar-xdr.

### Why

@graydon showed us the forbid macro today. Seem worthwhile to try and keep some of our simple crates as unsafe forbidden. There isn't a ton of reasons to use it in this lib.

### Known limitations

N/A