### PR TITLE
Implement std Error on Error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ use core::{fmt, fmt::Debug, slice::Iter};
 
 #[cfg(feature = "std")]
 use std::{
-    io,
+    error, io,
     io::{Cursor, Read, Write},
 };
 
@@ -31,6 +31,16 @@ pub enum Error {
     LengthMismatch,
     #[cfg(feature = "std")]
     IO(io::Error),
+}
+
+#[cfg(feature = "std")]
+impl error::Error for Error {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match self {
+            Self::IO(e) => Some(e),
+            _ => None,
+        }
+    }
 }
 
 impl fmt::Display for Error {


### PR DESCRIPTION
### What

Implement std::error::Error on Error when std feature enabled.

### Why

For convenience.

Related https://github.com/stellar/xdrgen/pull/79/commits/bf5c8aa4f0d8f4df698d98099dfd23aacb1ea285

### Known limitations

N/A

cc @graydon