### PR TITLE
Add support for no-alloc using static lifetime ref Box and Vec types

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
     needs: [fmt, build, test]
     runs-on: ubuntu-latest
     steps:
-    - if: failure()
+    - if: contains(needs.*.result, 'failure')
       run: exit 1
 
   fmt:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,7 +24,6 @@ jobs:
     - uses: actions/checkout@v3
     - run: rustup update stable && rustup default stable
     - run: find . -type f -name '*.rs' -print0 | xargs -I {} -0 rustfmt --check "{}"
-    - run: exit 1
 
   build:
     strategy:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,6 +24,7 @@ jobs:
     - uses: actions/checkout@v3
     - run: rustup update stable && rustup default stable
     - run: find . -type f -name '*.rs' -print0 | xargs -I {} -0 rustfmt --check "{}"
+    - run: exit 1
 
   build:
     strategy:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,16 +27,20 @@ jobs:
           features: std
         - os: ubuntu-latest
           target: x86_64-unknown-linux-gnu
-          profile: release
-          features: std
+          profile: dev
+          features: alloc
         - os: ubuntu-latest
           target: x86_64-unknown-linux-gnu
           profile: dev
           features:
         - os: ubuntu-latest
-          target: x86_64-unknown-linux-gnu
+          target: wasm32-unknown-unknown
           profile: release
-          features:
+          features: std
+        - os: ubuntu-latest
+          target: wasm32-unknown-unknown
+          profile: release
+          features: alloc
         - os: ubuntu-latest
           target: wasm32-unknown-unknown
           profile: release
@@ -55,9 +59,18 @@ jobs:
         - os: ubuntu-latest
           target: x86_64-unknown-linux-gnu
           profile: test
+          features: std
+        - os: ubuntu-latest
+          target: x86_64-unknown-linux-gnu
+          profile: test
+          features: alloc
+        - os: ubuntu-latest
+          target: x86_64-unknown-linux-gnu
+          profile: test
+          features:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
     - run: rustup update stable && rustup default stable
     - run: rustup target add ${{ matrix.target }}
-    - run: cargo test --verbose --profile ${{ matrix.profile }} --target ${{ matrix.target }}
+    - run: cargo test --verbose --profile ${{ matrix.profile }} --target ${{ matrix.target }} --no-default-features --features='${{ matrix.features }}'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,6 +10,14 @@ env:
 
 jobs:
 
+  complete:
+    if: always()
+    needs: [fmt, build, test]
+    runs-on: ubuntu-latest
+    steps:
+    - if: failure()
+      run: exit 1
+
   fmt:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,5 @@ base64 = "0.13.0"
 
 [features]
 default = ["std"]
-std = ["base64/std"]
+std = ["alloc", "base64/std"]
+alloc = []

--- a/Makefile
+++ b/Makefile
@@ -29,12 +29,8 @@ watch:
 src/lib.rs: $(XDR_FILES)
 	docker run -it --rm -v $$PWD:/wd -w /wd ruby /bin/bash -c '\
 		gem install specific_install -v 0.3.7 && \
-		gem specific_install https://github.com/leighmcculloch/stellar--xdrgen.git -b rust-no-deps-no-alloc && \
-		xdrgen \
-			--language rust \
-			--namespace lib \
-			--output src/ \
-			$(XDR_FILES) \
+		gem specific_install https://github.com/leighmcculloch/stellar--xdrgen.git -b rust-no-deps && \
+		xdrgen --language rust --namespace lib --output src/ $(XDR_FILES) \
 		'
 	rustfmt src/lib.rs
 

--- a/Makefile
+++ b/Makefile
@@ -8,21 +8,28 @@ XDR_FILES= \
 	xdr/Stellar-types.x \
 	xdr/Stellar-contract.x
 
-test: build
-	cargo test
+all: build test
+
+test:
+	cargo test --no-default-features --features 'std'
+	cargo test --no-default-features --features 'alloc'
+	cargo test --no-default-features --features ''
 
 build: src/lib.rs
 	cargo build --no-default-features --features 'std'
+	cargo build --no-default-features --features 'alloc'
 	cargo build --no-default-features --features ''
-	cargo build --target wasm32-unknown-unknown --no-default-features --features ''
+	cargo build --no-default-features --features 'std' --release --target wasm32-unknown-unknown
+	cargo build --no-default-features --features 'alloc' --release --target wasm32-unknown-unknown
+	cargo build --no-default-features --features '' --release --target wasm32-unknown-unknown
 
 watch:
-	cargo watch --clear --watch-when-idle --shell '$(MAKE) build'
+	cargo watch --clear --watch-when-idle --shell '$(MAKE)'
 
 src/lib.rs: $(XDR_FILES)
 	docker run -it --rm -v $$PWD:/wd -w /wd ruby /bin/bash -c '\
 		gem install specific_install -v 0.3.7 && \
-		gem specific_install https://github.com/leighmcculloch/stellar--xdrgen.git -b rust-no-deps && \
+		gem specific_install https://github.com/leighmcculloch/stellar--xdrgen.git -b rust-no-deps-no-alloc && \
 		xdrgen \
 			--language rust \
 			--namespace lib \
@@ -36,5 +43,5 @@ $(XDR_FILES):
 
 clean:
 	rm -f xdr/*.x
-	rm -f src/xdr.rs
+	rm -f src/lib.rs
 	cargo clean

--- a/README.md
+++ b/README.md
@@ -2,3 +2,21 @@
 Rust SDK for Stellar XDR.
 
 **This repository contains code that is in early development, incomplete, not tested, and not recommended for use. The API is unstable, experimental, and is receiving breaking changes frequently.**
+
+## Usage
+
+Include in your toml:
+
+```toml
+stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "..." }
+```
+
+The crate has two features and three tiers of functionality:
+
+1. `std` – The std feature provides all functionality (types, encode, decode), and is the default feature set.
+2. `alloc` – The alloc feature causes the types to use the `Box` and `Vec` types for recursive references and arrays, and is automatically enabled if the std feature is enabled. The default global allocator is used. Support for a custom allocator will be added in [#39]. No encode or decode capability exists, only types. Encode and decode capability will be added in [#46].
+3. If std or alloc are not enabled recursive and array types requires static lifetime values. No encode or decode capability exists. Encode and decode capability will be added in [#47].
+
+[#39](https://github.com/stellar/rs-stellar-xdr/issues/39)]
+[#46](https://github.com/stellar/rs-stellar-xdr/issues/46)]
+[#47](https://github.com/stellar/rs-stellar-xdr/issues/47)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,30 +16,10 @@ use core::{fmt, fmt::Debug, slice::Iter};
 #[cfg(not(feature = "alloc"))]
 mod noalloc {
     pub mod boxed {
-        #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-        pub struct Box<T>(pub &'static T)
-        where
-            T: 'static;
+        pub type Box<T> = &'static T;
     }
     pub mod vec {
-        use core::slice::Iter;
-        #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-        pub struct Vec<T>(pub &'static [T])
-        where
-            T: 'static;
-        impl<T> Vec<T> {
-            pub fn len(&self) -> usize {
-                self.0.len()
-            }
-            pub fn iter(&self) -> Iter<T> {
-                self.0.iter()
-            }
-        }
-        impl<T> AsRef<[T]> for Vec<T> {
-            fn as_ref(&self) -> &[T] {
-                self.0
-            }
-        }
+        pub type Vec<T> = &'static [T];
     }
 }
 #[cfg(not(feature = "alloc"))]
@@ -434,23 +414,6 @@ impl<T: Clone, const MAX: u32> TryFrom<&[T]> for VecM<T, MAX> {
     }
 }
 
-#[cfg(not(feature = "alloc"))]
-impl<T: Clone, const MAX: u32> TryFrom<&'static [T]> for VecM<T, MAX>
-where
-    T: 'static,
-{
-    type Error = Error;
-
-    fn try_from(v: &'static [T]) -> Result<Self> {
-        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
-        if len <= MAX {
-            Ok(VecM(Vec(v)))
-        } else {
-            Err(Error::LengthExceedsMax)
-        }
-    }
-}
-
 impl<T, const MAX: u32> AsRef<[T]> for VecM<T, MAX> {
     fn as_ref(&self) -> &[T] {
         self.0.as_ref()
@@ -505,7 +468,7 @@ where
     fn try_from(v: &'static [T; N]) -> Result<Self> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
-            Ok(VecM(Vec(v)))
+            Ok(VecM(v))
         } else {
             Err(Error::LengthExceedsMax)
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,14 +12,9 @@
 
 use core::{fmt, fmt::Debug, slice::Iter};
 
-#[cfg(all(not(feature = "std"), feature = "alloc"))]
-extern crate alloc;
-
+// When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
-// TODO: Replace the Box and Vec static lifetime types with bumpalo, or
-// heapless, or change the interface to read/write_xdr to support providing a
-// custom allocator.
-mod alloc {
+mod noalloc {
     pub mod boxed {
         #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
         pub struct Box<T>(pub &'static T)
@@ -47,8 +42,18 @@ mod alloc {
         }
     }
 }
-#[cfg(not(feature = "std"))]
+#[cfg(not(feature = "alloc"))]
+use noalloc::{boxed::Box, vec::Vec};
+
+// When feature std is turned off, but feature alloc is turned on import the
+// alloc crate and use its Box and Vec types.
+#[cfg(all(not(feature = "std"), feature = "alloc"))]
+extern crate alloc;
+#[cfg(all(not(feature = "std"), feature = "alloc"))]
 use alloc::{boxed::Box, vec::Vec};
+
+// TODO: Add support for when the alloc or std feature is enabled for specifying
+// a custom allocator, instead of the Global allocator being used.
 
 #[cfg(feature = "std")]
 use std::{

--- a/tests/tx_prot18.rs
+++ b/tests/tx_prot18.rs
@@ -1,24 +1,7 @@
+#[cfg(feature = "std")]
 use stellar_xdr::*;
 
-#[test]
-fn test_build_small_tx() -> Result<(), Error> {
-    let te = TransactionEnvelope::EnvelopeTypeTx(TransactionV1Envelope {
-        tx: Transaction {
-            source_account: MuxedAccount::KeyTypeEd25519(Uint256([0; 32])),
-            fee: 0,
-            seq_num: SequenceNumber(1),
-            cond: Preconditions::PrecondNone,
-            memo: Memo::MemoText("Stellar".as_bytes().try_into()?),
-            operations: [].to_vec().try_into()?,
-            ext: TransactionExt::V0,
-        },
-        signatures: [].try_into()?,
-    });
-    let xdr = te.to_xdr_base64()?;
-    assert_eq!(xdr, "AAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAABAAAAB1N0ZWxsYXIAAAAAAAAAAAAAAAAA");
-    Ok(())
-}
-
+#[cfg(feature = "std")]
 #[test]
 fn test_parse_pubnet_v18_tx() -> Result<(), Error> {
     let xdr = "AAAAAgAAAAA/ESDPPSBIB8pWPGt/zZ3dSJhShRxziDdkmLQXrdytCQAPQkAACMblAAAABQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAABAAAAABB90WssODNIgi6BHveqzxTRmIpvAFRyVNM+Hm2GVuCcAAAAAAAAAAAtDSg//ZfvJXgv2/0yiA7QUDWdXpKYhdjYEWkN4yVm+AAAABdIdugAAAAAAAAAAAKt3K0JAAAAQC3/n83fG/BCSRaIQjuqL2i1koiCHChxt1aagXn2ABCRP9IL83u5zldxuUaDBklKOHEdy4cOvl2BhPNbjs7w0QSGVuCcAAAAQKxHSgHZgZY7AMlPumIt0iZvtkbsRAtt6BYahJdnxrqm3+JuCVv/1ijWi1kM85uLfo7NAITi1TbdLg0gVFO16wM=";

--- a/tests/tx_small.rs
+++ b/tests/tx_small.rs
@@ -1,0 +1,57 @@
+use stellar_xdr::*;
+
+#[cfg(feature = "std")]
+#[test]
+fn test_build_small_tx_with_std() -> Result<(), Error> {
+    let te = TransactionEnvelope::EnvelopeTypeTx(TransactionV1Envelope {
+        tx: Transaction {
+            source_account: MuxedAccount::KeyTypeEd25519(Uint256([0; 32])),
+            fee: 0,
+            seq_num: SequenceNumber(1),
+            cond: Preconditions::PrecondNone,
+            memo: Memo::MemoText("Stellar".as_bytes().try_into()?),
+            operations: [].to_vec().try_into()?,
+            ext: TransactionExt::V0,
+        },
+        signatures: [].try_into()?,
+    });
+    let xdr = te.to_xdr_base64()?;
+    assert_eq!(xdr, "AAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAABAAAAB1N0ZWxsYXIAAAAAAAAAAAAAAAAA");
+    Ok(())
+}
+
+#[cfg(feature = "alloc")]
+#[test]
+fn test_build_small_tx_with_alloc() -> Result<(), Error> {
+    let _ = TransactionEnvelope::EnvelopeTypeTx(TransactionV1Envelope {
+        tx: Transaction {
+            source_account: MuxedAccount::KeyTypeEd25519(Uint256([0; 32])),
+            fee: 0,
+            seq_num: SequenceNumber(1),
+            cond: Preconditions::PrecondNone,
+            memo: Memo::MemoText("Stellar".as_bytes().try_into()?),
+            operations: [].to_vec().try_into()?,
+            ext: TransactionExt::V0,
+        },
+        signatures: [].try_into()?,
+    });
+    Ok(())
+}
+
+#[cfg(not(feature = "alloc"))]
+#[test]
+fn test_build_small_tx_with_alloc() -> Result<(), Error> {
+    let _ = TransactionEnvelope::EnvelopeTypeTx(TransactionV1Envelope {
+        tx: Transaction {
+            source_account: MuxedAccount::KeyTypeEd25519(Uint256([0; 32])),
+            fee: 0,
+            seq_num: SequenceNumber(1),
+            cond: Preconditions::PrecondNone,
+            memo: Memo::MemoText("Stellar".as_bytes().try_into()?),
+            operations: (&[]).try_into()?,
+            ext: TransactionExt::V0,
+        },
+        signatures: (&[]).try_into()?,
+    });
+    Ok(())
+}


### PR DESCRIPTION
### What

Add some super limited support for type construction in no-alloc envs using static lifetime ref `Box` and `Vec` types, used whenever the `alloc` feature is disabled. The `alloc` feature is dependent on the `alloc` crate's `Box` and `Vec`, and is enabled whenever `std` is enabled.

This results in three tiers of capabilities:
- `std`, type construction using the default allocator for recursive types (that use `Box`) and `Vec`s, and encoding/decoding.
- `alloc`, type construction using the default allocator for recursive types (that use `Box`) and `Vec`s.
- Otherwise, type construction using static lifetime refs for recursive types and `Vec`s.

### Why

This crate has good support for `no_std` environments, but not for environments that require no allocator. That's because the XDR types for the Stellar protocol are recursive, and so we can't easily drop-in stack based Vec types like heapless. There are some uses of this lib in no alloc environments that involve using the types for structured programming without us actually needing encoding/decoding. This PR makes that possible without changing the interface of passing an allocator around. Ideally in #39 this is revisited and an allocator is passed down instead.

### Known limitations

These changes are temporary, and will be replaced when #39 is addressed.
