### PR TITLE
Update source location of XDR files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-XDR_BASE_URL=https://github.com/graydon/stellar-core/raw/wasm-runtime/src
+XDR_BASE_URL=https://github.com/graydon/stellar-core/raw/rust-wasm-runtime/src
 XDR_FILES= \
 	xdr/Stellar-SCP.x \
 	xdr/Stellar-ledger-entries.x \


### PR DESCRIPTION
### What

Update source location of XDR files.

### Why

@graydon closed the C++ prototype PR/branch this repo is sourcing XDR from, and has opened a the Rust prototype PR/branch that now has the XDR.

### Known limitations

N/A