### PR TITLE
Update stellar-xdr that is clippy compliant

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  RUSTFLAGS: -D warnings
+  RUSTFLAGS: -Dwarnings -Dclippy::all -Dclippy::pedantic
 
 jobs:
 
@@ -85,9 +85,6 @@ jobs:
         --no-default-features
         --features='${{ matrix.features }}'
         --all-targets
-        --
-        -Dclippy::all
-        -Dclippy::pedantic
     - if: matrix.sys.test
       run: >
         cargo test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,12 +66,28 @@ jobs:
         restore-keys: |
           target-${{ strategy.job-index }}
           target-
+    # - uses: actions-rs/clippy-check@b5b5f21f4797c02da247df37026fcd0a5024aa4d
+    #   with:
+    #     token: ${{ secrets.GITHUB_TOKEN }}
+    #     args: >
+    #       --profile ${{ matrix.profile }}
+    #       --target ${{ matrix.sys.target }}
+    #       --no-default-features
+    #       --features='${{ matrix.features }}'
+    #       --all-targets
+    #       --
+    #       -Dclippy::all
+    #       -Dclippy::pedantic
     - run: >
-        cargo check
+        cargo clippy
         --profile ${{ matrix.profile }}
         --target ${{ matrix.sys.target }}
         --no-default-features
         --features='${{ matrix.features }}'
+        --all-targets
+        --
+        -Dclippy::all
+        -Dclippy::pedantic
     - if: matrix.sys.test
       run: >
         cargo test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,18 +66,13 @@ jobs:
         restore-keys: |
           target-${{ strategy.job-index }}
           target-
-    - uses: actions-rs/clippy-check@b5b5f21f4797c02da247df37026fcd0a5024aa4d
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        args: >
-          --profile ${{ matrix.profile }}
-          --target ${{ matrix.sys.target }}
-          --no-default-features
-          --features='${{ matrix.features }}'
-          --all-targets
-          --
-          -Dclippy::all
-          -Dclippy::pedantic
+    - run: >
+        cargo clippy
+        --profile ${{ matrix.profile }}
+        --target ${{ matrix.sys.target }}
+        --no-default-features
+        --features='${{ matrix.features }}'
+        --all-targets
     - if: matrix.sys.test
       run: >
         cargo test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,25 +66,18 @@ jobs:
         restore-keys: |
           target-${{ strategy.job-index }}
           target-
-    # - uses: actions-rs/clippy-check@b5b5f21f4797c02da247df37026fcd0a5024aa4d
-    #   with:
-    #     token: ${{ secrets.GITHUB_TOKEN }}
-    #     args: >
-    #       --profile ${{ matrix.profile }}
-    #       --target ${{ matrix.sys.target }}
-    #       --no-default-features
-    #       --features='${{ matrix.features }}'
-    #       --all-targets
-    #       --
-    #       -Dclippy::all
-    #       -Dclippy::pedantic
-    - run: >
-        cargo clippy
-        --profile ${{ matrix.profile }}
-        --target ${{ matrix.sys.target }}
-        --no-default-features
-        --features='${{ matrix.features }}'
-        --all-targets
+    - uses: actions-rs/clippy-check@b5b5f21f4797c02da247df37026fcd0a5024aa4d
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        args: >
+          --profile ${{ matrix.profile }}
+          --target ${{ matrix.sys.target }}
+          --no-default-features
+          --features='${{ matrix.features }}'
+          --all-targets
+          --
+          -Dclippy::all
+          -Dclippy::pedantic
     - if: matrix.sys.test
       run: >
         cargo test

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ XDR_FILES= \
 	xdr/Stellar-transaction.x \
 	xdr/Stellar-types.x
 
+export RUSTFLAGS=-Dwarnings -Dclippy::all -Dclippy::pedantic
+
 all: build test
 
 test:
@@ -15,12 +17,12 @@ test:
 	cargo test --no-default-features --features ''
 
 build: src/lib.rs
-	cargo build --no-default-features --features 'std'
-	cargo build --no-default-features --features 'alloc'
-	cargo build --no-default-features --features ''
-	cargo build --no-default-features --features 'std' --release --target wasm32-unknown-unknown
-	cargo build --no-default-features --features 'alloc' --release --target wasm32-unknown-unknown
-	cargo build --no-default-features --features '' --release --target wasm32-unknown-unknown
+	cargo clippy --no-default-features --features 'std'
+	cargo clippy --no-default-features --features 'alloc'
+	cargo clippy --no-default-features --features ''
+	cargo clippy --no-default-features --features 'std' --release --target wasm32-unknown-unknown
+	cargo clippy --no-default-features --features 'alloc' --release --target wasm32-unknown-unknown
+	cargo clippy --no-default-features --features '' --release --target wasm32-unknown-unknown
 
 watch:
 	cargo watch --clear --watch-when-idle --shell '$(MAKE)'

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -379,7 +379,6 @@ impl<T, const MAX: u32> VecM<T, MAX> {
         self.as_ref()
     }
 
-    #[must_use]
     pub fn iter(&self) -> Iter<'_, T> {
         self.0.iter()
     }
@@ -6415,7 +6414,6 @@ impl LedgerEntryChanges {
         self.as_ref()
     }
 
-    #[must_use]
     pub fn iter(&self) -> Iter<'_, LedgerEntryChange> {
         self.0.iter()
     }
@@ -7746,7 +7744,6 @@ impl PeerStatList {
         self.as_ref()
     }
 
-    #[must_use]
     pub fn iter(&self) -> Iter<'_, PeerStats> {
         self.0.iter()
     }

--- a/tests/tx_prot18.rs
+++ b/tests/tx_prot18.rs
@@ -1,17 +1,17 @@
 #[cfg(feature = "std")]
-use stellar_xdr::*;
+use stellar_xdr::{Error, OperationBody, ReadXdr, SequenceNumber, TransactionEnvelope};
 
 #[cfg(feature = "std")]
 #[test]
 fn test_parse_pubnet_v18_tx() -> Result<(), Error> {
     let xdr = "AAAAAgAAAAA/ESDPPSBIB8pWPGt/zZ3dSJhShRxziDdkmLQXrdytCQAPQkAACMblAAAABQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAABAAAAABB90WssODNIgi6BHveqzxTRmIpvAFRyVNM+Hm2GVuCcAAAAAAAAAAAtDSg//ZfvJXgv2/0yiA7QUDWdXpKYhdjYEWkN4yVm+AAAABdIdugAAAAAAAAAAAKt3K0JAAAAQC3/n83fG/BCSRaIQjuqL2i1koiCHChxt1aagXn2ABCRP9IL83u5zldxuUaDBklKOHEdy4cOvl2BhPNbjs7w0QSGVuCcAAAAQKxHSgHZgZY7AMlPumIt0iZvtkbsRAtt6BYahJdnxrqm3+JuCVv/1ijWi1kM85uLfo7NAITi1TbdLg0gVFO16wM=";
-    let te = TransactionEnvelope::from_xdr_base64(xdr.to_string()).unwrap();
+    let te = TransactionEnvelope::from_xdr_base64(xdr.to_string())?;
     println!("{:?}", te);
 
     if let TransactionEnvelope::Tx(te) = te {
-        assert_eq!(te.tx.seq_num, SequenceNumber(2470486663495685));
+        assert_eq!(te.tx.seq_num, SequenceNumber(2_470_486_663_495_685));
         if let OperationBody::CreateAccount(op) = &te.tx.operations.as_vec()[0].body {
-            assert_eq!(op.starting_balance, 100000000000);
+            assert_eq!(op.starting_balance, 100_000_000_000);
         } else {
             panic!("op is not the type expected");
         }

--- a/tests/tx_small.rs
+++ b/tests/tx_small.rs
@@ -1,4 +1,10 @@
-use stellar_xdr::*;
+use stellar_xdr::{
+    Error, Memo, MuxedAccount, Preconditions, SequenceNumber, Transaction, TransactionEnvelope,
+    TransactionExt, TransactionV1Envelope, Uint256,
+};
+
+#[cfg(feature = "std")]
+use stellar_xdr::WriteXdr;
 
 #[cfg(feature = "std")]
 #[test]
@@ -23,7 +29,7 @@ fn test_build_small_tx_with_std() -> Result<(), Error> {
 #[cfg(feature = "alloc")]
 #[test]
 fn test_build_small_tx_with_alloc() -> Result<(), Error> {
-    let _ = TransactionEnvelope::Tx(TransactionV1Envelope {
+    let _tx = TransactionEnvelope::Tx(TransactionV1Envelope {
         tx: Transaction {
             source_account: MuxedAccount::Ed25519(Uint256([0; 32])),
             fee: 0,


### PR DESCRIPTION
### What

Update stellar-xdr that is clippy compliant.

### Why

Clippy is Rust's linter. It is pretty opinionated, but it identified some minor misunderstandings that were worth fixing.

Related https://github.com/stellar/xdrgen/pull/79/commits/a796c684531a7c3534e39700883f75412be35af8
Related https://github.com/stellar/xdrgen/pull/79/commits/c83a0e26c94a834cf89b7331e170c4b4ab60381d

### Known limitations

N/A
