### PR TITLE
Update xdrgen install url

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ watch:
 src/lib.rs: $(XDR_FILES)
 	docker run -it --rm -v $$PWD:/wd -w /wd ruby /bin/bash -c '\
 		gem install specific_install -v 0.3.7 && \
-		gem specific_install https://github.com/leighmcculloch/stellar--xdrgen.git -b rust-no-deps && \
+		gem specific_install https://github.com/stellar/xdrgen.git -b master && \
 		xdrgen --language rust --namespace lib --output src/ $(XDR_FILES) \
 		'
 	rustfmt src/lib.rs


### PR DESCRIPTION
### What

Update xdrgen install url to point to stellar/xdrgen master.

### Why

The Rust generator has been merged into xdrgen master.

### Known limitations

[TODO or N/A]
