### PR TITLE
Fix generated files ownership

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ watch:
 	cargo watch --clear --watch-when-idle --shell '$(MAKE)'
 
 src/curr.rs: $(XDR_FILES_LOCAL_CURR)
+	touch $@
 	docker run -it --rm -v $$PWD:/wd -w /wd ruby /bin/bash -c '\
 		gem install specific_install -v 0.3.7 && \
 		gem specific_install https://github.com/stellar/xdrgen.git -b master && \
@@ -60,6 +61,7 @@ src/curr.rs: $(XDR_FILES_LOCAL_CURR)
 	rustfmt src/curr.rs
 
 src/next.rs: $(XDR_FILES_LOCAL_NEXT)
+	touch $@
 	docker run -it --rm -v $$PWD:/wd -w /wd ruby /bin/bash -c '\
 		gem install specific_install -v 0.3.7 && \
 		gem specific_install https://github.com/stellar/xdrgen.git -b master && \


### PR DESCRIPTION
### What

Create generated files outside docker before the docker command writes the generated contents to them.

### Why

@graydon reported that the files are being created with owner root:root on Linux systems. We should create files as the current user so that the user doesn't have to be root to interact with them.

### Known limitations

[TODO or N/A]
