### PR TITLE
Change Deref for VecM typedefs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ src/curr.rs: $(XDR_FILES_LOCAL_CURR)
 	touch $@
 	docker run -it --rm -v $$PWD:/wd -w /wd ruby /bin/bash -c '\
 		gem install specific_install -v 0.3.7 && \
-		gem specific_install https://github.com/leighmcculloch/stellar--xdrgen.git -b rustvecmtypefix && \
+		gem specific_install https://github.com/stellar/xdrgen.git -b master && \
 		xdrgen --language rust --namespace curr --output src/ $^ \
 		'
 	rustfmt $@
@@ -64,7 +64,7 @@ src/next.rs: $(XDR_FILES_LOCAL_NEXT)
 	touch $@
 	docker run -it --rm -v $$PWD:/wd -w /wd ruby /bin/bash -c '\
 		gem install specific_install -v 0.3.7 && \
-		gem specific_install https://github.com/leighmcculloch/stellar--xdrgen.git -b rustvecmtypefix && \
+		gem specific_install https://github.com/stellar/xdrgen.git -b master && \
 		xdrgen --language rust --namespace next --output src/ $^ \
 		'
 	rustfmt $@

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ src/curr.rs: $(XDR_FILES_LOCAL_CURR)
 	touch $@
 	docker run -it --rm -v $$PWD:/wd -w /wd ruby /bin/bash -c '\
 		gem install specific_install -v 0.3.7 && \
-		gem specific_install https://github.com/stellar/xdrgen.git -b master && \
+		gem specific_install https://github.com/leighmcculloch/stellar--xdrgen.git -b rustvecmtypefix && \
 		xdrgen --language rust --namespace curr --output src/ $^ \
 		'
 	rustfmt $@
@@ -64,7 +64,7 @@ src/next.rs: $(XDR_FILES_LOCAL_NEXT)
 	touch $@
 	docker run -it --rm -v $$PWD:/wd -w /wd ruby /bin/bash -c '\
 		gem install specific_install -v 0.3.7 && \
-		gem specific_install https://github.com/stellar/xdrgen.git -b master && \
+		gem specific_install https://github.com/leighmcculloch/stellar--xdrgen.git -b rustvecmtypefix && \
 		xdrgen --language rust --namespace next --output src/ $^ \
 		'
 	rustfmt $@

--- a/src/curr.rs
+++ b/src/curr.rs
@@ -6515,7 +6515,7 @@ impl WriteXdr for LedgerEntryChanges {
 }
 
 impl Deref for LedgerEntryChanges {
-    type Target = Vec<LedgerEntryChange>;
+    type Target = VecM<LedgerEntryChange>;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
@@ -7852,7 +7852,7 @@ impl WriteXdr for PeerStatList {
 }
 
 impl Deref for PeerStatList {
-    type Target = Vec<PeerStats>;
+    type Target = VecM<PeerStats, 25>;
     fn deref(&self) -> &Self::Target {
         &self.0
     }

--- a/src/next.rs
+++ b/src/next.rs
@@ -6964,7 +6964,7 @@ impl WriteXdr for LedgerEntryChanges {
 }
 
 impl Deref for LedgerEntryChanges {
-    type Target = Vec<LedgerEntryChange>;
+    type Target = VecM<LedgerEntryChange>;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
@@ -8301,7 +8301,7 @@ impl WriteXdr for PeerStatList {
 }
 
 impl Deref for PeerStatList {
-    type Target = Vec<PeerStats>;
+    type Target = VecM<PeerStats, 25>;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
@@ -18074,7 +18074,7 @@ impl WriteXdr for ScVec {
 }
 
 impl Deref for ScVec {
-    type Target = Vec<ScVal>;
+    type Target = VecM<ScVal, 256000>;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
@@ -18190,7 +18190,7 @@ impl WriteXdr for ScMap {
 }
 
 impl Deref for ScMap {
-    type Target = Vec<ScMapEntry>;
+    type Target = VecM<ScMapEntry, 256000>;
     fn deref(&self) -> &Self::Target {
         &self.0
     }


### PR DESCRIPTION
### What

Change Deref for VecM typedefs to be VecM instead of Vec.

### Why

I just added the Derefs, but I made the Deref target Vec for typedefs that wrap VecM. The internal type is VecM and so Deref should target that, and due to automatic chaining with Deref we'll get Vec anyway.

Related https://github.com/stellar/xdrgen/pull/92

### Known limitations

[TODO or N/A]
