### PR TITLE
Fix to_vec, add to_string, into_vec, into_string

### DIFF
--- a/src/curr.rs
+++ b/src/curr.rs
@@ -424,13 +424,33 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     }
 
     #[must_use]
-    pub fn to_vec(self) -> Vec<T> {
+    pub fn as_vec(&self) -> &Vec<T> {
+        self.as_ref()
+    }
+}
+
+impl<T: Clone, const MAX: u32> VecM<T, MAX> {
+    #[must_use]
+    #[cfg(feature = "alloc")]
+    pub fn to_vec(&self) -> Vec<T> {
         self.into()
     }
 
     #[must_use]
-    pub fn as_vec(&self) -> &Vec<T> {
-        self.as_ref()
+    pub fn into_vec(self) -> Vec<T> {
+        self.into()
+    }
+}
+
+impl<const MAX: u32> VecM<u8, MAX> {
+    #[cfg(feature = "alloc")]
+    pub fn to_string(&self) -> Result<String> {
+        self.try_into()
+    }
+
+    #[cfg(feature = "alloc")]
+    pub fn into_string(self) -> Result<String> {
+        self.try_into()
     }
 }
 
@@ -451,6 +471,14 @@ impl<T, const MAX: u32> From<VecM<T, MAX>> for Vec<T> {
     #[must_use]
     fn from(v: VecM<T, MAX>) -> Self {
         v.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T: Clone, const MAX: u32> From<&VecM<T, MAX>> for Vec<T> {
+    #[must_use]
+    fn from(v: &VecM<T, MAX>) -> Self {
+        v.0.clone()
     }
 }
 

--- a/src/next.rs
+++ b/src/next.rs
@@ -425,13 +425,33 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     }
 
     #[must_use]
-    pub fn to_vec(self) -> Vec<T> {
+    pub fn as_vec(&self) -> &Vec<T> {
+        self.as_ref()
+    }
+}
+
+impl<T: Clone, const MAX: u32> VecM<T, MAX> {
+    #[must_use]
+    #[cfg(feature = "alloc")]
+    pub fn to_vec(&self) -> Vec<T> {
         self.into()
     }
 
     #[must_use]
-    pub fn as_vec(&self) -> &Vec<T> {
-        self.as_ref()
+    pub fn into_vec(self) -> Vec<T> {
+        self.into()
+    }
+}
+
+impl<const MAX: u32> VecM<u8, MAX> {
+    #[cfg(feature = "alloc")]
+    pub fn to_string(&self) -> Result<String> {
+        self.try_into()
+    }
+
+    #[cfg(feature = "alloc")]
+    pub fn into_string(self) -> Result<String> {
+        self.try_into()
     }
 }
 
@@ -452,6 +472,14 @@ impl<T, const MAX: u32> From<VecM<T, MAX>> for Vec<T> {
     #[must_use]
     fn from(v: VecM<T, MAX>) -> Self {
         v.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T: Clone, const MAX: u32> From<&VecM<T, MAX>> for Vec<T> {
+    #[must_use]
+    fn from(v: &VecM<T, MAX>) -> Self {
+        v.0.clone()
     }
 }
 


### PR DESCRIPTION
### What

Make to_vec not consume.

Add to_string, into_vec, into_string.

### Why

to_ functions shouldn't consume. into_ functions should though and are convenient.

Related https://github.com/stellar/xdrgen/pull/99

### Known limitations

[TODO or N/A]
