### PR TITLE
Change Makefile clean to not remove .x files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,14 +69,17 @@ src/next.rs: $(XDR_FILES_LOCAL_NEXT)
 		'
 	rustfmt $@
 
+clean:
+	rm -f src/curr.rs
+	rm -f src/next.rs
+	cargo clean
+
 $(XDR_FILES_LOCAL_CURR):
 	curl -L -o $@ $(XDR_BASE_URL_CURR)/$(notdir $@)
 
 $(XDR_FILES_LOCAL_NEXT):
 	curl -L -o $@ $(XDR_BASE_URL_NEXT)/$(notdir $@)
 
-clean:
+reset-xdr-to-stellar-core:
 	rm -f xdr/*/*.x
-	rm -f src/curr.rs
-	rm -f src/next.rs
-	cargo clean
+	$(MAKE) build


### PR DESCRIPTION
### What

Makefile clean no longer remove .x files. Add a new target for specifically resetting the XDR to match that of stellar-core.

### Why

Increasingly the .x files in this repo are being iterated on without downloading them from stellar-core. It seems less part of the update process to get them from stellar-core.

### Known limitations

[TODO or N/A]
