### PR TITLE
Make name, discriminant const and trait fns

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ src/curr.rs: $(XDR_FILES_LOCAL_CURR)
 	> $@
 	docker run -i --rm -v $$PWD:/wd -w /wd ruby /bin/bash -c '\
 		gem install specific_install -v 0.3.7 && \
-		gem specific_install https://github.com/leighmcculloch/stellar--xdrgen.git -b rustsmallthings && \
+		gem specific_install https://github.com/stellar/xdrgen.git -b master && \
 		xdrgen --language rust --namespace curr --output src/ $^ \
 		'
 	rustfmt $@
@@ -67,7 +67,7 @@ src/next.rs: $(XDR_FILES_LOCAL_NEXT)
 	> $@
 	docker run -i --rm -v $$PWD:/wd -w /wd ruby /bin/bash -c '\
 		gem install specific_install -v 0.3.7 && \
-		gem specific_install https://github.com/leighmcculloch/stellar--xdrgen.git -b rustsmallthings && \
+		gem specific_install https://github.com/stellar/xdrgen.git -b master && \
 		xdrgen --language rust --namespace next --output src/ $^ \
 		'
 	rustfmt $@

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ src/curr.rs: $(XDR_FILES_LOCAL_CURR)
 	> $@
 	docker run -i --rm -v $$PWD:/wd -w /wd ruby /bin/bash -c '\
 		gem install specific_install -v 0.3.7 && \
-		gem specific_install https://github.com/stellar/xdrgen.git -b master && \
+		gem specific_install https://github.com/leighmcculloch/stellar--xdrgen.git -b rustsmallthings && \
 		xdrgen --language rust --namespace curr --output src/ $^ \
 		'
 	rustfmt $@
@@ -67,7 +67,7 @@ src/next.rs: $(XDR_FILES_LOCAL_NEXT)
 	> $@
 	docker run -i --rm -v $$PWD:/wd -w /wd ruby /bin/bash -c '\
 		gem install specific_install -v 0.3.7 && \
-		gem specific_install https://github.com/stellar/xdrgen.git -b master && \
+		gem specific_install https://github.com/leighmcculloch/stellar--xdrgen.git -b rustsmallthings && \
 		xdrgen --language rust --namespace next --output src/ $^ \
 		'
 	rustfmt $@


### PR DESCRIPTION
### What

Make the name and discriminant fns on enums and unions const and add traits that group these fns. Also changed the &str return values so that they have a 'static lifetime.

### Why

The fns can be const fns which increases the places we can use them, and their str values are easier to use if they have a static lifetime. @graydon asked for traits so it is easier to write code across all enum / union types.

Related https://github.com/stellar/xdrgen/issues/108 https://github.com/stellar/xdrgen/issues/107 https://github.com/stellar/xdrgen/issues/106 https://github.com/stellar/xdrgen/pull/109

### Known limitations

[TODO or N/A]
