### PR TITLE
Rename serde dependency to resolve name conflict

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 base64 = "0.13.0"
-serde = {version = "1.0.137", features = ["derive"] }
+serde_crate = {package = "serde", version = "1.0.137", features = ["derive"] }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
### What

Use the same name `serde` for feature and dependency results in a build error 

> features and dependencies cannot have the same name: `serde`

Since dependencies and features have the same namespace. 

### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]
