### PR TITLE
Make serde dependency optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,18 +28,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.138"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1578c6245786b9d168c5447eeacfb96856573ca56c9d68fdcf394be134882a47"
+checksum = "0171ebb889e45aa68b44aee0859b3eede84c6f5f5c228e6f140c0b2a0a46cad6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.138"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "023e9b1467aef8a10fb88f25611870ada9800ef7e22afce356bb0d2387b6f27c"
+checksum = "dc1d3230c1de7932af58ad8ffbe1d784bd55efd5a9d84ac24f69c72d83543dfb"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,11 +5,11 @@ edition = "2021"
 
 [dependencies]
 base64 = "0.13.0"
-serde = {version = "1.0.137", features = ["derive"] }
+serde = {version = "1.0.139", features = ["derive"], optional = true }
 
 [features]
 default = ["std"]
 std = ["alloc", "base64/std"]
+serde = ["alloc", "dep:serde"]
 alloc = []
 next = []
-serde = ["alloc"]

--- a/Makefile
+++ b/Makefile
@@ -27,28 +27,17 @@ export RUSTFLAGS=-Dwarnings -Dclippy::all -Dclippy::pedantic
 
 all: build test
 
+# TODO: Remove the `--optional-deps` usage once weak dependencies are recognized
+# by cargo-hack https://github.com/taiki-e/cargo-hack/issues/147 and once the
+# bug with optional dependencies not having a first-class feature with the same
+# name https://github.com/taiki-e/cargo-hack/issues/153.
+
 test:
-	cargo test --no-default-features --features 'std'
-	cargo test --no-default-features --features 'alloc'
-	cargo test --no-default-features --features ''
-	cargo test --no-default-features --features 'next,std'
-	cargo test --no-default-features --features 'next,alloc'
-	cargo test --no-default-features --features 'next'
+	cargo hack test --feature-powerset --optional-deps
 
 build: generate
-	cargo clippy --all-targets --no-default-features --features 'std'
-	cargo clippy --all-targets --no-default-features --features 'alloc'
-	cargo clippy --all-targets --no-default-features --features ''
-	cargo clippy --all-targets --no-default-features --features 'std' --release --target wasm32-unknown-unknown
-	cargo clippy --all-targets --no-default-features --features 'alloc' --release --target wasm32-unknown-unknown
-	cargo clippy --all-targets --no-default-features --features '' --release --target wasm32-unknown-unknown
-
-	cargo clippy --all-targets --no-default-features --features 'next,std'
-	cargo clippy --all-targets --no-default-features --features 'next,alloc'
-	cargo clippy --all-targets --no-default-features --features 'next'
-	cargo clippy --all-targets --no-default-features --features 'next,std' --release --target wasm32-unknown-unknown
-	cargo clippy --all-targets --no-default-features --features 'next,alloc' --release --target wasm32-unknown-unknown
-	cargo clippy --all-targets --no-default-features --features 'next' --release --target wasm32-unknown-unknown
+	cargo hack clippy --feature-powerset --optional-deps --all-targets
+	cargo hack clippy --feature-powerset --optional-deps --all-targets --release --target wasm32-unknown-unknown
 
 watch:
 	cargo watch --clear --watch-when-idle --shell '$(MAKE)'


### PR DESCRIPTION
### What
Make `serde` dependency optional.

### Why
The `serde` dependency shouldn't be included in the dependency tree unless the `serde` feature is enabled.