### PR TITLE
Add conversions from/to ScVal types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,46 @@
 version = 3
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
 name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -51,6 +87,7 @@ name = "stellar-xdr"
 version = "0.0.0"
 dependencies = [
  "base64",
+ "num-bigint",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,7 @@ default = ["std"]
 std = ["alloc", "base64/std", "num-bigint?/std"]
 alloc = []
 next = []
+
+# Features dependent on optional dependencies.
 serde = ["alloc", "dep:serde"]
 num-bigint = ["alloc", "dep:num-bigint"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,11 +5,13 @@ edition = "2021"
 
 [dependencies]
 base64 = "0.13.0"
-serde = {version = "1.0.139", features = ["derive"], optional = true }
+serde = { version = "1.0.139", features = ["derive"], optional = true }
+num-bigint = { version = "0.4.3", optional = true }
 
 [features]
 default = ["std"]
-std = ["alloc", "base64/std"]
-serde = ["alloc", "dep:serde"]
+std = ["alloc", "base64/std", "num-bigint?/std"]
 alloc = []
 next = []
+serde = ["alloc", "dep:serde"]
+num-bigint = ["alloc", "dep:num-bigint"]

--- a/Makefile
+++ b/Makefile
@@ -77,3 +77,6 @@ $(XDR_FILES_LOCAL_NEXT):
 reset-xdr:
 	rm -f xdr/*/*.x
 	$(MAKE) build
+
+fmt:
+	cargo fmt --all

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,3 +10,8 @@ pub use curr::*;
 mod next;
 #[cfg(feature = "next")]
 pub use next::*;
+
+#[cfg(feature = "next")]
+mod scval;
+#[cfg(feature = "next")]
+pub use scval::*;

--- a/src/scval.rs
+++ b/src/scval.rs
@@ -90,17 +90,17 @@ impl From<i64> for ScObject {
     }
 }
 
-impl From<i64> for ScVal {
-    fn from(v: i64) -> Self {
-        <_ as Into<ScObject>>::into(v).into()
-    }
-}
-
 // TODO: Reverse conditions for ScVal/etc => i64.
 
 impl From<u64> for ScObject {
     fn from(v: u64) -> Self {
         ScObject::U64(v)
+    }
+}
+
+impl From<u64> for ScVal {
+    fn from(v: u64) -> Self {
+        <_ as Into<ScObject>>::into(v).into()
     }
 }
 

--- a/src/scval.rs
+++ b/src/scval.rs
@@ -65,7 +65,16 @@ impl From<i32> for ScVal {
     }
 }
 
-// TODO: Reverse conditions for ScVal/etc => i32.
+impl TryFrom<ScVal> for i32 {
+    type Error = ();
+    fn try_from(v: ScVal) -> Result<Self, Self::Error> {
+        if let ScVal::I32(i) = v {
+            Ok(i)
+        } else {
+            Err(())
+        }
+    }
+}
 
 impl From<u32> for ScVal {
     fn from(v: u32) -> ScVal {

--- a/src/scval.rs
+++ b/src/scval.rs
@@ -22,7 +22,16 @@ impl From<ScObject> for ScVal {
     }
 }
 
-// TODO: Reverse conditions for ScVal/etc => ScObject.
+impl TryFrom<ScVal> for ScObject {
+    type Error = ();
+    fn try_from(v: ScVal) -> Result<Self, Self::Error> {
+        if let ScVal::Object(Some(o)) = v {
+            Ok(o)
+        } else {
+            Err(())
+        }
+    }
+}
 
 impl From<ScStatus> for ScVal {
     fn from(v: ScStatus) -> Self {

--- a/src/scval.rs
+++ b/src/scval.rs
@@ -16,6 +16,12 @@ impl From<ScStatic> for ScVal {
     }
 }
 
+impl From<&ScStatic> for ScVal {
+    fn from(v: &ScStatic) -> Self {
+        Self::Static(*v)
+    }
+}
+
 impl TryFrom<ScVal> for ScStatic {
     type Error = ();
     fn try_from(v: ScVal) -> Result<Self, Self::Error> {
@@ -90,6 +96,12 @@ impl From<u32> for ScVal {
     }
 }
 
+impl From<&u32> for ScVal {
+    fn from(v: &u32) -> ScVal {
+        ScVal::U32(*v)
+    }
+}
+
 impl TryFrom<ScVal> for u32 {
     type Error = ();
     fn try_from(v: ScVal) -> Result<Self, Self::Error> {
@@ -111,6 +123,12 @@ impl From<i64> for ScVal {
     }
 }
 
+impl From<&i64> for ScVal {
+    fn from(v: &i64) -> ScVal {
+        <_ as Into<ScVal>>::into(*v)
+    }
+}
+
 impl TryFrom<ScVal> for i64 {
     type Error = ();
     fn try_from(v: ScVal) -> Result<Self, Self::Error> {
@@ -125,6 +143,12 @@ impl TryFrom<ScVal> for i64 {
 impl From<()> for ScVal {
     fn from(_: ()) -> Self {
         ScStatic::Void.into()
+    }
+}
+
+impl From<&()> for ScVal {
+    fn from(_: &()) -> Self {
+        <_ as Into<ScVal>>::into(*v)
     }
 }
 
@@ -145,6 +169,12 @@ impl From<bool> for ScVal {
     }
 }
 
+impl From<&bool> for ScVal {
+    fn from(v: &bool) -> Self {
+        <_ as Into<ScVal>>::into(*v)
+    }
+}
+
 impl TryFrom<ScVal> for bool {
     type Error = ();
     fn try_from(v: ScVal) -> Result<Self, Self::Error> {
@@ -162,6 +192,12 @@ impl From<i64> for ScObject {
     }
 }
 
+impl From<&i64> for ScObject {
+    fn from(v: &i64) -> Self {
+        ScObject::I64(*v)
+    }
+}
+
 impl TryFrom<ScObject> for i64 {
     type Error = ();
     fn try_from(v: ScObject) -> Result<Self, Self::Error> {
@@ -176,6 +212,12 @@ impl TryFrom<ScObject> for i64 {
 impl From<u64> for ScObject {
     fn from(v: u64) -> Self {
         ScObject::U64(v)
+    }
+}
+
+impl From<&u64> for ScObject {
+    fn from(v: &u64) -> Self {
+        ScObject::U64(*v)
     }
 }
 

--- a/src/scval.rs
+++ b/src/scval.rs
@@ -293,7 +293,27 @@ impl From<PublicKey> for ScVal {
     }
 }
 
-// TODO: Reverse conditions for ScVal/etc => PublicKey.
+impl TryFrom<ScObject> for PublicKey {
+    type Error = ();
+    fn try_from(v: ScObject) -> Result<Self, Self::Error> {
+        if let ScObject::PublicKey(k) = v {
+            Ok(k)
+        } else {
+            Err(())
+        }
+    }
+}
+
+impl TryFrom<ScVal> for PublicKey {
+    type Error = ();
+    fn try_from(v: ScVal) -> Result<Self, Self::Error> {
+        if let ScVal::Object(Some(ScObject::PublicKey(k))) = v {
+            Ok(k)
+        } else {
+            Err(())
+        }
+    }
+}
 
 #[cfg(feature = "alloc")]
 impl TryFrom<String> for ScVal {

--- a/src/scval.rs
+++ b/src/scval.rs
@@ -191,7 +191,7 @@ impl TryFrom<ScObject> for u64 {
 impl TryFrom<ScVal> for u64 {
     type Error = ();
     fn try_from(v: ScVal) -> Result<Self, Self::Error> {
-        if let ScVal::U64() = v {
+        if let ScVal::Object(Some(ScObject::U64(i))) = v {
             Ok(i)
         } else {
             Err(())
@@ -229,7 +229,57 @@ impl From<Hash> for ScVal {
     }
 }
 
-// TODO: Reverse conditions for ScVal/etc => ScHash/Hash.
+impl TryFrom<ScObject> for ScHash {
+    type Error = ();
+    fn try_from(v: ScObject) -> Result<Self, Self::Error> {
+        if let ScObject::Hash(h) = v {
+            Ok(h)
+        } else {
+            Err(())
+        }
+    }
+}
+
+impl TryFrom<ScVal> for ScHash {
+    type Error = ();
+    fn try_from(v: ScVal) -> Result<Self, Self::Error> {
+        if let ScVal::Object(Some(ScObject::Hash(h))) = v {
+            Ok(h)
+        } else {
+            Err(())
+        }
+    }
+}
+
+impl TryFrom<ScHash> for Hash {
+    type Error = ();
+    fn try_from(v: ScHash) -> Result<Self, Self::Error> {
+        let ScHash::SchashSha256(h) = v;
+        Ok(h)
+    }
+}
+
+impl TryFrom<ScObject> for Hash {
+    type Error = ();
+    fn try_from(v: ScObject) -> Result<Self, Self::Error> {
+        if let ScObject::Hash(ScHash::SchashSha256(h)) = v {
+            Ok(h)
+        } else {
+            Err(())
+        }
+    }
+}
+
+impl TryFrom<ScVal> for Hash {
+    type Error = ();
+    fn try_from(v: ScVal) -> Result<Self, Self::Error> {
+        if let ScVal::Object(Some(ScObject::Hash(ScHash::SchashSha256(h)))) = v {
+            Ok(h)
+        } else {
+            Err(())
+        }
+    }
+}
 
 impl From<PublicKey> for ScObject {
     fn from(v: PublicKey) -> Self {

--- a/src/scval.rs
+++ b/src/scval.rs
@@ -1,5 +1,6 @@
 use crate::{
-    Hash, PublicKey, ScBigInt, ScHash, ScMap, ScObject, ScStatic, ScStatus, ScSymbol, ScVal, ScVec,
+    Hash, PublicKey, ScBigInt, ScBinary, ScHash, ScMap, ScObject, ScStatic, ScStatus, ScSymbol,
+    ScVal, ScVec,
 };
 
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
@@ -376,6 +377,40 @@ impl TryFrom<ScVal> for String {
             // TODO: It might be worth distinguishing the error case where this
             // is an invalid symbol with invalid characters.
             Ok(s.into_string().map_err(|_| ())?)
+        } else {
+            Err(())
+        }
+    }
+}
+
+impl From<ScBinary> for ScObject {
+    fn from(v: ScBinary) -> Self {
+        ScObject::Binary(v)
+    }
+}
+
+impl TryFrom<ScObject> for ScBinary {
+    type Error = ();
+    fn try_from(v: ScBinary) -> Result<Self, Self::Error> {
+        if let ScObject::Binary(b) = v {
+            Ok(b)
+        } else {
+            Err(())
+        }
+    }
+}
+
+impl From<ScBinary> for ScVal {
+    fn from(v: ScBinary) -> Self {
+        ScVal::Object(Some(ScObject::Binary(v)))
+    }
+}
+
+impl TryFrom<ScVal> for ScBinary {
+    type Error = ();
+    fn try_from(v: ScBinary) -> Result<Self, Self::Error> {
+        if let ScVal::Object(Some(ScObject::Binary(b))) = v {
+            Ok(b)
         } else {
             Err(())
         }

--- a/src/scval.rs
+++ b/src/scval.rs
@@ -326,7 +326,8 @@ impl From<ScSymbol> for ScVal {
 }
 
 impl TryFrom<ScVal> for ScSymbol {
-    fn from(v: ScSymbol) -> Self {
+    type Error = ();
+    fn try_from(v: ScSymbol) -> Result<Self, Self::Error> {
         if let ScVal::Symbol(s) = v {
             Ok(s)
         } else {

--- a/src/scval.rs
+++ b/src/scval.rs
@@ -445,5 +445,3 @@ impl<T: Into<ScVal>> From<Option<T>> for ScVal {
 //         }
 //     }
 // }
-
-// TODO: Add reverse conversions for all types above.

--- a/src/scval.rs
+++ b/src/scval.rs
@@ -108,6 +108,8 @@ impl From<Hash> for ScVal {
     }
 }
 
+// TODO: Reverse conditions for ScVal/etc => ScHash/Hash.
+
 impl From<PublicKey> for ScObject {
     fn from(v: PublicKey) -> Self {
         ScObject::PublicKey(v)
@@ -119,6 +121,8 @@ impl From<PublicKey> for ScVal {
         <_ as Into<ScObject>>::into(v).into()
     }
 }
+
+// TODO: Reverse conditions for ScVal/etc => PublicKey.
 
 #[cfg(feature = "alloc")]
 impl TryFrom<String> for ScVal {
@@ -151,6 +155,8 @@ impl TryFrom<&'static str> for ScVal {
         Ok(ScVal::Symbol(v.try_into().map_err(|_| ())?))
     }
 }
+
+// TODO: Reverse conditions for ScVal/etc => String/&str/etc.
 
 #[cfg(feature = "alloc")]
 impl TryFrom<Vec<u8>> for ScObject {
@@ -215,6 +221,8 @@ impl TryFrom<&'static [u8]> for ScVal {
         Ok(<_ as TryInto<ScObject>>::try_into(v)?.into())
     }
 }
+
+// TODO: Reverse conditions for ScVal/etc => Binary/etc.
 
 impl From<ScVec> for ScObject {
     fn from(v: ScVec) -> Self {
@@ -303,6 +311,8 @@ where
             .into())
     }
 }
+
+// TODO: Reverse conditions for ScVal/etc => Vec/etc.
 
 impl From<ScMap> for ScObject {
     fn from(v: ScMap) -> Self {

--- a/src/scval.rs
+++ b/src/scval.rs
@@ -14,7 +14,16 @@ impl From<ScStatic> for ScVal {
     }
 }
 
-// TODO: Reverse conditions for ScVal/etc => ScStatic.
+impl TryFrom<ScVal> for ScStatic {
+    type Error = ();
+    fn try_from(v: ScVal) -> Result<Self, Self::Error> {
+        if let ScVal::Static(s) = v {
+            Ok(s)
+        } else {
+            Err(())
+        }
+    }
+}
 
 impl From<ScObject> for ScVal {
     fn from(v: ScObject) -> Self {

--- a/src/scval.rs
+++ b/src/scval.rs
@@ -148,7 +148,7 @@ impl From<()> for ScVal {
 
 impl From<&()> for ScVal {
     fn from(v: &()) -> Self {
-        <_ as Into<ScVal>>::into(*v)
+        ScStatic::Void.into()
     }
 }
 

--- a/src/scval.rs
+++ b/src/scval.rs
@@ -1,9 +1,12 @@
-use crate::{Hash, PublicKey, ScHash, ScMap, ScObject, ScStatic, ScStatus, ScVal, ScVec};
+use crate::{Hash, PublicKey, ScBigInt, ScHash, ScMap, ScObject, ScStatic, ScStatus, ScVal, ScVec};
 
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 extern crate alloc;
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 use alloc::{string::String, vec::Vec};
+
+#[cfg(feature = "num-bigint")]
+use num_bigint::{BigInt, Sign};
 
 impl From<ScStatic> for ScVal {
     fn from(v: ScStatic) -> Self {
@@ -313,10 +316,83 @@ impl From<ScMap> for ScVal {
     }
 }
 
-// TODO: Map(ScMap),
-// TODO: BigInt(ScBigInt),
+// TODO: Add conversions from std::collections::HashMap, im_rcOrdMap, and other
+// popular map types to ScMap.
 
-// TODO: Reverse conversions for all types above.
+impl From<ScBigInt> for ScObject {
+    fn from(v: ScBigInt) -> Self {
+        ScObject::BigInt(v)
+    }
+}
+
+impl From<ScBigInt> for ScVal {
+    fn from(v: ScBigInt) -> Self {
+        <_ as Into<ScObject>>::into(v).into()
+    }
+}
+
+#[cfg(feature = "num-bigint")]
+impl TryFrom<BigInt> for ScBigInt {
+    type Error = ();
+    fn try_from(v: BigInt) -> Result<Self, Self::Error> {
+        Ok(match v.to_bytes_be() {
+            (Sign::NoSign, _) => ScBigInt::Zero,
+            (Sign::Plus, bytes) => ScBigInt::Positive(bytes.try_into().map_err(|_| ())?),
+            (Sign::Minus, bytes) => ScBigInt::Negative(bytes.try_into().map_err(|_| ())?),
+        })
+    }
+}
+
+#[cfg(feature = "num-bigint")]
+impl TryFrom<BigInt> for ScObject {
+    type Error = ();
+    fn try_from(v: BigInt) -> Result<Self, Self::Error> {
+        Ok(<_ as TryInto<ScBigInt>>::try_into(v)?.into())
+    }
+}
+
+#[cfg(feature = "num-bigint")]
+impl TryFrom<BigInt> for ScVal {
+    type Error = ();
+    fn try_from(v: BigInt) -> Result<Self, Self::Error> {
+        Ok(<_ as TryInto<ScObject>>::try_into(v)?.into())
+    }
+}
+
+#[cfg(feature = "num-bigint")]
+impl From<ScBigInt> for BigInt {
+    fn from(v: ScBigInt) -> Self {
+        match v {
+            ScBigInt::Zero => 0u32.into(),
+            ScBigInt::Positive(bytes) => BigInt::from_bytes_be(Sign::Plus, &bytes),
+            ScBigInt::Negative(bytes) => BigInt::from_bytes_be(Sign::Minus, &bytes),
+        }
+    }
+}
+
+#[cfg(feature = "num-bigint")]
+impl TryFrom<ScObject> for BigInt {
+    type Error = ();
+    fn try_from(v: ScObject) -> Result<Self, Self::Error> {
+        if let ScObject::BigInt(b) = v {
+            Ok(<_ as TryInto<BigInt>>::try_into(b).map_err(|_| ())?)
+        } else {
+            Err(())
+        }
+    }
+}
+
+#[cfg(feature = "num-bigint")]
+impl TryFrom<ScVal> for BigInt {
+    type Error = ();
+    fn try_from(v: ScVal) -> Result<Self, Self::Error> {
+        if let ScVal::Object(Some(o)) = v {
+            Ok(<_ as TryInto<BigInt>>::try_into(o).map_err(|_| ())?)
+        } else {
+            Err(())
+        }
+    }
+}
 
 impl<T: Into<ScVal>> From<Option<T>> for ScVal {
     fn from(v: Option<T>) -> Self {
@@ -326,3 +402,5 @@ impl<T: Into<ScVal>> From<Option<T>> for ScVal {
         }
     }
 }
+
+// TODO: Add reverse conversions for all types above.

--- a/src/scval.rs
+++ b/src/scval.rs
@@ -1,8 +1,5 @@
 use crate::{Hash, PublicKey, ScHash, ScObject, ScStatic, ScStatus, ScVal};
 
-#[cfg(not(feature = "alloc"))]
-use crate::ScVec;
-
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 extern crate alloc;
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
@@ -216,6 +213,18 @@ impl TryFrom<&'static [u8]> for ScVal {
     }
 }
 
+impl From<ScVec> for ScObject {
+    fn from(v: ScVec) -> Self {
+        ScObject::Vec(v)
+    }
+}
+
+impl From<ScVec> for ScVal {
+    fn from(v: ScVec) -> Self {
+        Ok(<_ as TryInto<ScObject>>::into(v).into())
+    }
+}
+
 #[cfg(feature = "alloc")]
 impl<T: Into<ScVal>> TryFrom<Vec<T>> for ScObject {
     type Error = ();
@@ -289,6 +298,18 @@ where
         Ok(<_ as TryInto<ScObject>>::try_into(v)
             .map_err(|_| ())?
             .into())
+    }
+}
+
+impl From<ScMap> for ScObject {
+    fn from(v: ScMap) -> Self {
+        ScObject::Map(v)
+    }
+}
+
+impl From<ScMMapap for ScVal {
+    fn from(v: ScMMapap -> Self {
+        Ok(<_ as TryInto<ScObject>>::into(v).into())
     }
 }
 

--- a/src/scval.rs
+++ b/src/scval.rs
@@ -1,4 +1,4 @@
-use crate::{Hash, PublicKey, ScHash, ScObject, ScStatic, ScStatus, ScVal};
+use crate::{Hash, PublicKey, ScHash, ScMap, ScObject, ScStatic, ScStatus, ScVal, ScVec};
 
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 extern crate alloc;
@@ -221,7 +221,7 @@ impl From<ScVec> for ScObject {
 
 impl From<ScVec> for ScVal {
     fn from(v: ScVec) -> Self {
-        Ok(<_ as TryInto<ScObject>>::into(v).into())
+        <_ as Into<ScObject>>::into(v).into()
     }
 }
 
@@ -309,7 +309,7 @@ impl From<ScMap> for ScObject {
 
 impl From<ScMap> for ScVal {
     fn from(v: ScMap) -> Self {
-        Ok(<_ as TryInto<ScObject>>::into(v).into())
+        <_ as Into<ScObject>>::into(v).into()
     }
 }
 

--- a/src/scval.rs
+++ b/src/scval.rs
@@ -48,7 +48,16 @@ impl From<ScStatus> for ScVal {
     }
 }
 
-// TODO: Reverse conditions for ScVal/etc => ScStatus.
+impl TryFrom<ScVal> for ScStatus {
+    type Error = ();
+    fn try_from(v: ScVal) -> Result<Self, Self::Error> {
+        if let ScVal::Status(s) = v {
+            Ok(s)
+        } else {
+            Err(())
+        }
+    }
+}
 
 impl From<i32> for ScVal {
     fn from(v: i32) -> ScVal {

--- a/src/scval.rs
+++ b/src/scval.rs
@@ -147,7 +147,7 @@ impl From<()> for ScVal {
 }
 
 impl From<&()> for ScVal {
-    fn from(v: &()) -> Self {
+    fn from(_: &()) -> Self {
         ScStatic::Void.into()
     }
 }

--- a/src/scval.rs
+++ b/src/scval.rs
@@ -67,6 +67,12 @@ impl From<i32> for ScVal {
     }
 }
 
+impl From<&i32> for ScVal {
+    fn from(v: &i32) -> ScVal {
+        ScVal::I32(*v)
+    }
+}
+
 impl TryFrom<ScVal> for i32 {
     type Error = ();
     fn try_from(v: ScVal) -> Result<Self, Self::Error> {
@@ -724,5 +730,81 @@ impl<T: Into<ScVal>> From<Option<T>> for ScVal {
             Some(v) => v.into(),
             None => ().into(),
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{ScObject, ScVal};
+
+    #[test]
+    fn i32_pos() {
+        let v = 5;
+        let val: ScVal = v.try_into().unwrap();
+        assert_eq!(val, ScVal::I32(5));
+        let roundtrip: i32 = val.try_into().unwrap();
+        assert_eq!(v, roundtrip);
+    }
+
+    #[test]
+    fn i32_neg() {
+        let v = -5;
+        let val: ScVal = v.try_into().unwrap();
+        assert_eq!(val, ScVal::I32(-5));
+        let roundtrip: i32 = val.try_into().unwrap();
+        assert_eq!(v, roundtrip);
+    }
+
+    #[test]
+    fn u32() {
+        use crate::ScVal;
+
+        let v = 5u32;
+        let val: ScVal = v.try_into().unwrap();
+        assert_eq!(val, ScVal::U32(5));
+        let roundtrip: u32 = val.try_into().unwrap();
+        assert_eq!(v, roundtrip);
+    }
+
+    #[test]
+    fn i64_pos() {
+        let v = 5i64;
+        let val: ScVal = v.try_into().unwrap();
+        assert_eq!(val, ScVal::U63(5));
+        let roundtrip: i64 = val.try_into().unwrap();
+        assert_eq!(v, roundtrip);
+    }
+
+    #[test]
+    fn i64_neg() {
+        let v = -5i64;
+        let val: ScVal = v.try_into().unwrap();
+        assert_eq!(val, ScVal::Object(Some(ScObject::I64(-5))));
+        let roundtrip: i64 = val.try_into().unwrap();
+        assert_eq!(v, roundtrip);
+    }
+
+    #[test]
+    fn u64() {
+        let v = 5u64;
+        let val: ScVal = v.try_into().unwrap();
+        assert_eq!(val, ScVal::Object(Some(ScObject::U64(5))));
+        let roundtrip: u64 = val.try_into().unwrap();
+        assert_eq!(v, roundtrip);
+    }
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn vec() {
+        let v = vec![1, 2, 3, 4, 5];
+        let val: ScVal = v.clone().try_into().unwrap();
+        assert_eq!(
+            val,
+            ScVal::Object(Some(ScObject::Vec(
+                vec![1, 2, 3, 4, 5].try_into().unwrap()
+            )))
+        );
+        let roundtrip: Vec<i32> = val.try_into().unwrap();
+        assert_eq!(v, roundtrip);
     }
 }

--- a/src/scval.rs
+++ b/src/scval.rs
@@ -1,6 +1,5 @@
 use crate::{
-    Hash, PublicKey, ScBigInt, ScBinary, ScHash, ScMap, ScObject, ScStatic, ScStatus, ScSymbol,
-    ScVal, ScVec,
+    Hash, PublicKey, ScBigInt, ScHash, ScMap, ScObject, ScStatic, ScStatus, ScSymbol, ScVal, ScVec,
 };
 
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
@@ -328,7 +327,7 @@ impl From<ScSymbol> for ScVal {
 
 impl TryFrom<ScVal> for ScSymbol {
     type Error = ();
-    fn try_from(v: ScSymbol) -> Result<Self, Self::Error> {
+    fn try_from(v: ScVal) -> Result<Self, Self::Error> {
         if let ScVal::Symbol(s) = v {
             Ok(s)
         } else {
@@ -377,40 +376,6 @@ impl TryFrom<ScVal> for String {
             // TODO: It might be worth distinguishing the error case where this
             // is an invalid symbol with invalid characters.
             Ok(s.into_string().map_err(|_| ())?)
-        } else {
-            Err(())
-        }
-    }
-}
-
-impl From<ScBinary> for ScObject {
-    fn from(v: ScBinary) -> Self {
-        ScObject::Binary(v)
-    }
-}
-
-impl TryFrom<ScObject> for ScBinary {
-    type Error = ();
-    fn try_from(v: ScBinary) -> Result<Self, Self::Error> {
-        if let ScObject::Binary(b) = v {
-            Ok(b)
-        } else {
-            Err(())
-        }
-    }
-}
-
-impl From<ScBinary> for ScVal {
-    fn from(v: ScBinary) -> Self {
-        ScVal::Object(Some(ScObject::Binary(v)))
-    }
-}
-
-impl TryFrom<ScVal> for ScBinary {
-    type Error = ();
-    fn try_from(v: ScBinary) -> Result<Self, Self::Error> {
-        if let ScVal::Object(Some(ScObject::Binary(b))) = v {
-            Ok(b)
         } else {
             Err(())
         }

--- a/src/scval.rs
+++ b/src/scval.rs
@@ -394,10 +394,10 @@ impl From<ScBigInt> for BigInt {
 
 #[cfg(feature = "num-bigint")]
 impl TryFrom<ScObject> for BigInt {
-    type Error = <ScBigInt as TryInto<BigInt>>::Error;
+    type Error = ();
     fn try_from(v: ScObject) -> Result<Self, Self::Error> {
         if let ScObject::BigInt(b) = v {
-            <_ as TryInto<BigInt>>::try_into(b)
+            Ok(<_ as TryInto<BigInt>>::try_into(b).map_err(|_| ())?)
         } else {
             Err(())
         }
@@ -406,10 +406,10 @@ impl TryFrom<ScObject> for BigInt {
 
 #[cfg(feature = "num-bigint")]
 impl TryFrom<ScVal> for BigInt {
-    type Error = <ScObject as TryInto<BigInt>>::Error;
+    type Error = ();
     fn try_from(v: ScVal) -> Result<Self, Self::Error> {
         if let ScVal::Object(Some(o)) = v {
-            <_ as TryInto<BigInt>>::try_into(o)
+            Ok(<_ as TryInto<BigInt>>::try_into(o).map_err(|_| ())?)
         } else {
             Err(())
         }

--- a/src/scval.rs
+++ b/src/scval.rs
@@ -158,10 +158,26 @@ impl TryFrom<Vec<u8>> for ScObject {
 }
 
 #[cfg(feature = "alloc")]
+impl TryFrom<Vec<u8>> for ScVal {
+    type Error = ();
+    fn try_from(v: Vec<u8>) -> Result<Self, Self::Error> {
+        Ok(<_ as TryInto<ScObject>>::try_into(v)?.into())
+    }
+}
+
+#[cfg(feature = "alloc")]
 impl TryFrom<&Vec<u8>> for ScObject {
     type Error = ();
     fn try_from(v: &Vec<u8>) -> Result<Self, Self::Error> {
         Ok(ScObject::Binary(v.try_into().map_err(|_| ())?))
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl TryFrom<&Vec<u8>> for ScVal {
+    type Error = ();
+    fn try_from(v: &Vec<u8>) -> Result<Self, Self::Error> {
+        Ok(<_ as TryInto<ScObject>>::try_into(v)?.into())
     }
 }
 
@@ -173,11 +189,27 @@ impl TryFrom<&[u8]> for ScObject {
     }
 }
 
+#[cfg(feature = "alloc")]
+impl TryFrom<&[u8]> for ScVal {
+    type Error = ();
+    fn try_from(v: &[u8]) -> Result<Self, Self::Error> {
+        Ok(<_ as TryInto<ScObject>>::try_into(v)?.into())
+    }
+}
+
 #[cfg(not(feature = "alloc"))]
 impl TryFrom<&'static [u8]> for ScObject {
     type Error = ();
     fn try_from(v: &'static [u8]) -> Result<Self, Self::Error> {
         Ok(ScObject::Binary(v.try_into().map_err(|_| ())?))
+    }
+}
+
+#[cfg(not(feature = "alloc"))]
+impl TryFrom<&'static [u8]> for ScVal {
+    type Error = ();
+    fn try_from(v: &'static [u8]) -> Result<Self, Self::Error> {
+        Ok(<_ as TryInto<ScObject>>::try_into(v)?.into())
     }
 }
 

--- a/src/scval.rs
+++ b/src/scval.rs
@@ -1,5 +1,10 @@
 use crate::{Hash, PublicKey, ScHash, ScObject, ScStatic, ScStatus, ScVal};
 
+#[cfg(all(not(feature = "std"), feature = "alloc"))]
+extern crate alloc;
+#[cfg(all(not(feature = "std"), feature = "alloc"))]
+use alloc::{string::String, vec::Vec};
+
 impl From<ScStatic> for ScVal {
     fn from(v: ScStatic) -> Self {
         Self::Static(v)
@@ -113,6 +118,22 @@ impl From<PublicKey> for ScVal {
 }
 
 #[cfg(feature = "alloc")]
+impl TryFrom<String> for ScVal {
+    type Error = ();
+    fn try_from(v: String) -> Result<Self, Self::Error> {
+        Ok(ScVal::Symbol(v.try_into().map_err(|_| ())?))
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl TryFrom<&String> for ScVal {
+    type Error = ();
+    fn try_from(v: &String) -> Result<Self, Self::Error> {
+        Ok(ScVal::Symbol(v.try_into().map_err(|_| ())?))
+    }
+}
+
+#[cfg(feature = "alloc")]
 impl TryFrom<&str> for ScVal {
     type Error = ();
     fn try_from(v: &str) -> Result<Self, Self::Error> {
@@ -129,24 +150,39 @@ impl TryFrom<&'static str> for ScVal {
 }
 
 #[cfg(feature = "alloc")]
-impl TryFrom<String> for ScVal {
+impl TryFrom<Vec<u8>> for ScObject {
     type Error = ();
-    fn try_from(v: String) -> Result<Self, Self::Error> {
-        Ok(ScVal::Symbol(v.try_into().map_err(|_| ())?))
+    fn try_from(v: Vec<u8>) -> Result<Self, Self::Error> {
+        Ok(ScObject::Binary(v.try_into().map_err(|_| ())?))
     }
 }
 
 #[cfg(feature = "alloc")]
-impl TryFrom<&String> for ScVal {
+impl TryFrom<&Vec<u8>> for ScObject {
     type Error = ();
-    fn try_from(v: &String) -> Result<Self, Self::Error> {
-        Ok(ScVal::Symbol(v.try_into().map_err(|_| ())?))
+    fn try_from(v: &Vec<u8>) -> Result<Self, Self::Error> {
+        Ok(ScObject::Binary(v.try_into().map_err(|_| ())?))
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl TryFrom<&[u8]> for ScObject {
+    type Error = ();
+    fn try_from(v: &[u8]) -> Result<Self, Self::Error> {
+        Ok(ScObject::Binary(v.try_into().map_err(|_| ())?))
+    }
+}
+
+#[cfg(not(feature = "alloc"))]
+impl TryFrom<&'static [u8]> for ScObject {
+    type Error = ();
+    fn try_from(v: &'static [u8]) -> Result<Self, Self::Error> {
+        Ok(ScObject::Binary(v.try_into().map_err(|_| ())?))
     }
 }
 
 // TODO: Vec(ScVec),
 // TODO: Map(ScMap),
-// TODO: Binary(VecM<u8, 256000>),
 // TODO: BigInt(ScBigInt),
 
 impl<T: Into<ScVal>> From<Option<T>> for ScVal {

--- a/src/scval.rs
+++ b/src/scval.rs
@@ -58,14 +58,6 @@ impl From<i64> for ScVal {
     }
 }
 
-// TODO: Reverse conditions for ScVal/etc => i64.
-
-impl From<u64> for ScVal {
-    fn from(v: u64) -> ScVal {
-        ScObject::U64(v).into()
-    }
-}
-
 // TODO: Reverse conditions for ScVal/etc => u64.
 
 impl From<()> for ScVal {

--- a/src/scval.rs
+++ b/src/scval.rs
@@ -85,15 +85,21 @@ impl From<bool> for ScVal {
 // TODO: Reverse conditions for ScVal/etc => bool.
 
 impl From<i64> for ScObject {
-    fn from(v: i64) -> ScObject {
+    fn from(v: i64) -> Self {
         ScObject::I64(v)
+    }
+}
+
+impl From<i64> for ScVal {
+    fn from(v: i64) -> Self {
+        <_ as Into<ScObject>>::into(v).into()
     }
 }
 
 // TODO: Reverse conditions for ScVal/etc => i64.
 
 impl From<u64> for ScObject {
-    fn from(v: u64) -> ScObject {
+    fn from(v: u64) -> Self {
         ScObject::U64(v)
     }
 }

--- a/src/scval.rs
+++ b/src/scval.rs
@@ -307,8 +307,8 @@ impl From<ScMap> for ScObject {
     }
 }
 
-impl From<ScMMapap for ScVal {
-    fn from(v: ScMMapap -> Self {
+impl From<ScMap> for ScVal {
+    fn from(v: ScMap) -> Self {
         Ok(<_ as TryInto<ScObject>>::into(v).into())
     }
 }

--- a/src/scval.rs
+++ b/src/scval.rs
@@ -147,7 +147,7 @@ impl From<()> for ScVal {
 }
 
 impl From<&()> for ScVal {
-    fn from(_: &()) -> Self {
+    fn from(v: &()) -> Self {
         <_ as Into<ScVal>>::into(*v)
     }
 }

--- a/src/scval.rs
+++ b/src/scval.rs
@@ -14,11 +14,15 @@ impl From<ScStatic> for ScVal {
     }
 }
 
+// TODO: Reverse conditions for ScVal/etc => ScStatic.
+
 impl From<ScObject> for ScVal {
     fn from(v: ScObject) -> Self {
         ScVal::Object(Some(v))
     }
 }
+
+// TODO: Reverse conditions for ScVal/etc => ScObject.
 
 impl From<ScStatus> for ScVal {
     fn from(v: ScStatus) -> Self {
@@ -26,17 +30,23 @@ impl From<ScStatus> for ScVal {
     }
 }
 
+// TODO: Reverse conditions for ScVal/etc => ScStatus.
+
 impl From<i32> for ScVal {
     fn from(v: i32) -> ScVal {
         ScVal::I32(v)
     }
 }
 
+// TODO: Reverse conditions for ScVal/etc => i32.
+
 impl From<u32> for ScVal {
     fn from(v: u32) -> ScVal {
         ScVal::U32(v)
     }
 }
+
+// TODO: Reverse conditions for ScVal/etc => u32.
 
 impl From<i64> for ScVal {
     fn from(v: i64) -> ScVal {
@@ -48,11 +58,15 @@ impl From<i64> for ScVal {
     }
 }
 
+// TODO: Reverse conditions for ScVal/etc => i64.
+
 impl From<u64> for ScVal {
     fn from(v: u64) -> ScVal {
         ScObject::U64(v).into()
     }
 }
+
+// TODO: Reverse conditions for ScVal/etc => u64.
 
 impl From<()> for ScVal {
     fn from(_: ()) -> Self {
@@ -60,11 +74,15 @@ impl From<()> for ScVal {
     }
 }
 
+// TODO: Reverse conditions for ScVal/etc => ().
+
 impl From<bool> for ScVal {
     fn from(v: bool) -> Self {
         if v { ScStatic::True } else { ScStatic::False }.into()
     }
 }
+
+// TODO: Reverse conditions for ScVal/etc => bool.
 
 impl From<i64> for ScObject {
     fn from(v: i64) -> ScObject {
@@ -72,11 +90,15 @@ impl From<i64> for ScObject {
     }
 }
 
+// TODO: Reverse conditions for ScVal/etc => i64.
+
 impl From<u64> for ScObject {
     fn from(v: u64) -> ScObject {
         ScObject::U64(v)
     }
 }
+
+// TODO: Reverse conditions for ScVal/etc => u64.
 
 impl From<ScHash> for ScObject {
     fn from(v: ScHash) -> Self {

--- a/src/scval.rs
+++ b/src/scval.rs
@@ -796,14 +796,11 @@ mod test {
     #[cfg(feature = "alloc")]
     #[test]
     fn vec() {
+        extern crate alloc;
+        use alloc::vec;
+        use alloc::vec::Vec;
         let v = vec![1, 2, 3, 4, 5];
         let val: ScVal = v.clone().try_into().unwrap();
-        assert_eq!(
-            val,
-            ScVal::Object(Some(ScObject::Vec(
-                vec![1, 2, 3, 4, 5].try_into().unwrap()
-            )))
-        );
         let roundtrip: Vec<i32> = val.try_into().unwrap();
         assert_eq!(v, roundtrip);
     }

--- a/src/scval.rs
+++ b/src/scval.rs
@@ -316,6 +316,28 @@ impl From<ScMap> for ScVal {
     }
 }
 
+impl TryFrom<ScObject> for ScMap {
+    type Error = ();
+    fn try_from(v: ScObject) -> Result<Self, Self::Error> {
+        if let ScObject::Map(m) = v {
+            Ok(m)
+        } else {
+            Err(())
+        }
+    }
+}
+
+impl TryFrom<ScVal> for ScMap {
+    type Error = ();
+    fn try_from(v: ScVal) -> Result<Self, Self::Error> {
+        if let ScVal::Object(Some(o)) = v {
+            <_ as TryInto<ScMap>>::try_into(o)
+        } else {
+            Err(())
+        }
+    }
+}
+
 // TODO: Add conversions from std::collections::HashMap, im_rcOrdMap, and other
 // popular map types to ScMap.
 
@@ -372,10 +394,10 @@ impl From<ScBigInt> for BigInt {
 
 #[cfg(feature = "num-bigint")]
 impl TryFrom<ScObject> for BigInt {
-    type Error = ();
+    type Error = <ScBigInt as TryInto<BigInt>>::Error;
     fn try_from(v: ScObject) -> Result<Self, Self::Error> {
         if let ScObject::BigInt(b) = v {
-            Ok(<_ as TryInto<BigInt>>::try_into(b).map_err(|_| ())?)
+            <_ as TryInto<BigInt>>::try_into(b)
         } else {
             Err(())
         }
@@ -384,10 +406,10 @@ impl TryFrom<ScObject> for BigInt {
 
 #[cfg(feature = "num-bigint")]
 impl TryFrom<ScVal> for BigInt {
-    type Error = ();
+    type Error = <ScObject as TryInto<BigInt>>::Error;
     fn try_from(v: ScVal) -> Result<Self, Self::Error> {
         if let ScVal::Object(Some(o)) = v {
-            Ok(<_ as TryInto<BigInt>>::try_into(o).map_err(|_| ())?)
+            <_ as TryInto<BigInt>>::try_into(o)
         } else {
             Err(())
         }
@@ -402,5 +424,16 @@ impl<T: Into<ScVal>> From<Option<T>> for ScVal {
         }
     }
 }
+
+// TODO: Is there a way to provide this conversion without recursion?
+// impl<T: TryFrom<ScVal>> TryFrom<ScVal> for Option<T> {
+//     type Error = T::Error;
+//     fn try_from(v: ScVal) -> Result<Self, Self::Error> {
+//         match v {
+//             ScVal::Static(ScStatic::Void) => Ok(None),
+//             _ => <_ as TryFrom<ScVal>>::try_from(v),
+//         }
+//     }
+// }
 
 // TODO: Add reverse conversions for all types above.

--- a/src/scval.rs
+++ b/src/scval.rs
@@ -82,7 +82,16 @@ impl From<u32> for ScVal {
     }
 }
 
-// TODO: Reverse conditions for ScVal/etc => u32.
+impl TryFrom<ScVal> for u32 {
+    type Error = ();
+    fn try_from(v: ScVal) -> Result<Self, Self::Error> {
+        if let ScVal::U32(i) = v {
+            Ok(i)
+        } else {
+            Err(())
+        }
+    }
+}
 
 impl From<i64> for ScVal {
     fn from(v: i64) -> ScVal {
@@ -94,7 +103,16 @@ impl From<i64> for ScVal {
     }
 }
 
-// TODO: Reverse conditions for ScVal/etc => u64.
+impl TryFrom<ScVal> for i64 {
+    type Error = ();
+    fn try_from(v: ScVal) -> Result<Self, Self::Error> {
+        if let ScVal::U63(i) | ScVal::Object(Some(ScObject::I64(i))) = v {
+            Ok(i)
+        } else {
+            Err(())
+        }
+    }
+}
 
 impl From<()> for ScVal {
     fn from(_: ()) -> Self {
@@ -102,7 +120,16 @@ impl From<()> for ScVal {
     }
 }
 
-// TODO: Reverse conditions for ScVal/etc => ().
+impl TryFrom<ScVal> for () {
+    type Error = ();
+    fn try_from(v: ScVal) -> Result<Self, Self::Error> {
+        if let ScVal::Static(ScStatic::Void) = v {
+            Ok(())
+        } else {
+            Err(())
+        }
+    }
+}
 
 impl From<bool> for ScVal {
     fn from(v: bool) -> Self {
@@ -110,7 +137,16 @@ impl From<bool> for ScVal {
     }
 }
 
-// TODO: Reverse conditions for ScVal/etc => bool.
+impl TryFrom<ScVal> for bool {
+    type Error = ();
+    fn try_from(v: ScVal) -> Result<Self, Self::Error> {
+        match v {
+            ScVal::Static(ScStatic::False) => Ok(false),
+            ScVal::Static(ScStatic::True) => Ok(true),
+            _ => Err(()),
+        }
+    }
+}
 
 impl From<i64> for ScObject {
     fn from(v: i64) -> Self {
@@ -118,7 +154,16 @@ impl From<i64> for ScObject {
     }
 }
 
-// TODO: Reverse conditions for ScVal/etc => i64.
+impl TryFrom<ScObject> for i64 {
+    type Error = ();
+    fn try_from(v: ScObject) -> Result<Self, Self::Error> {
+        if let ScObject::I64(i) = v {
+            Ok(i)
+        } else {
+            Err(())
+        }
+    }
+}
 
 impl From<u64> for ScObject {
     fn from(v: u64) -> Self {
@@ -132,7 +177,27 @@ impl From<u64> for ScVal {
     }
 }
 
-// TODO: Reverse conditions for ScVal/etc => u64.
+impl TryFrom<ScObject> for u64 {
+    type Error = ();
+    fn try_from(v: ScObject) -> Result<Self, Self::Error> {
+        if let ScObject::U64(i) = v {
+            Ok(i)
+        } else {
+            Err(())
+        }
+    }
+}
+
+impl TryFrom<ScVal> for u64 {
+    type Error = ();
+    fn try_from(v: ScVal) -> Result<Self, Self::Error> {
+        if let ScVal::U64() = v {
+            Ok(i)
+        } else {
+            Err(())
+        }
+    }
+}
 
 impl From<ScHash> for ScObject {
     fn from(v: ScHash) -> Self {

--- a/src/scval.rs
+++ b/src/scval.rs
@@ -846,4 +846,16 @@ mod test {
         let roundtrip: Vec<i32> = val.try_into().unwrap();
         assert_eq!(v, roundtrip);
     }
+
+    #[cfg(feature = "num-bigint")]
+    #[test]
+    fn bigint() {
+        use core::str::FromStr;
+        use num_bigint::BigInt;
+
+        let v = BigInt::from_str("18446744073709551616").unwrap();
+        let val: ScVal = v.clone().try_into().unwrap();
+        let roundtrip: BigInt = val.try_into().unwrap();
+        assert_eq!(v, roundtrip);
+    }
 }

--- a/src/scval.rs
+++ b/src/scval.rs
@@ -1,0 +1,147 @@
+use crate::{Hash, ScHash, PublicKey, ScObject, ScStatic, ScStatus, ScVal};
+
+impl From<ScStatic> for ScVal {
+    fn from(v: ScStatic) -> Self {
+        Self::Static(v)
+    }
+}
+
+impl From<ScObject> for ScVal {
+    fn from(v: ScObject) -> Self {
+        ScVal::Object(Some(v))
+    }
+}
+
+impl From<ScStatus> for ScVal {
+    fn from(v: ScStatus) -> Self {
+        ScVal::Status(v)
+    }
+}
+
+impl From<i32> for ScVal {
+    fn from(v: i32) -> ScVal {
+        ScVal::I32(v)
+    }
+}
+
+impl From<u32> for ScVal {
+    fn from(v: u32) -> ScVal {
+        ScVal::U32(v)
+    }
+}
+
+impl From<i64> for ScVal {
+    fn from(v: i64) -> ScVal {
+        if v < 0 {
+            ScObject::I64(v).into()
+        } else {
+            ScVal::U63(v)
+        }
+    }
+}
+
+impl From<u64> for ScVal {
+    fn from(v: u64) -> ScVal {
+        ScObject::U64(v).into()
+    }
+}
+
+impl From<()> for ScVal {
+    fn from(_: ()) -> Self {
+        ScStatic::Void.into()
+    }
+}
+
+impl From<bool> for ScVal {
+    fn from(v: bool) -> Self {
+        if v { ScStatic::True } else { ScStatic::False }.into()
+    }
+}
+
+impl From<i64> for ScObject {
+    fn from(v: i64) -> ScObject {
+        ScObject::I64(v)
+    }
+}
+
+impl From<u64> for ScObject {
+    fn from(v: u64) -> ScObject {
+        ScObject::U64(v)
+    }
+}
+
+impl From<ScHash> for ScObject {
+    fn from(v: ScHash) -> Self {
+        ScObject::Hash(v)
+    }
+}
+
+impl From<ScHash> for ScVal {
+    fn from(v: ScHash) -> Self {
+        <_ as Into<ScObject>>::into(v).into()
+    }
+}
+
+impl From<Hash> for ScHash {
+    fn from(v: Hash) -> Self {
+        ScHash::SchashSha256(v)
+    }
+}
+
+impl From<Hash> for ScObject {
+    fn from(v: Hash) -> Self {
+        <_ as Into<ScHash>>::into(v).into()
+    }
+}
+
+impl From<Hash> for ScVal {
+    fn from(v: Hash) -> Self {
+        <_ as Into<ScObject>>::into(v).into()
+    }
+}
+
+impl From<PublicKey> for ScObject {
+    fn from(v: PublicKey) -> Self {
+        ScObject::PublicKey(v)
+    }
+}
+
+impl From<PublicKey> for ScVal {
+    fn from(v: PublicKey) -> Self {
+        <_ as Into<ScObject>>::into(v).into()
+    }
+}
+
+// Vec(ScVec),
+// Map(ScMap),
+// Binary(VecM<u8, 256000>),
+// BigInt(ScBigInt),
+
+// impl ToScVal for &str {
+//     fn to_scval(&self) -> Result<ScVal, ()> {
+//         let bytes: Vec<u8> = self.as_bytes().iter().cloned().collect();
+//         Ok(ScVal::Symbol(bytes.try_into().map_err(|_| ())?))
+//     }
+// }
+
+// impl FromScVal<bool> for ScVal {
+//     fn from_scval(&self) -> Result<bool, ()> {
+//         match self {
+//             ScVal::Static(ScStatic::False) => Ok(false),
+//             ScVal::Static(ScStatic::True) => Ok(true),
+//             _ => Err(()),
+//         }
+//     }
+// }
+
+impl<T> From<Option<T>> for ScVal
+where
+    T: Into<ScVal>,
+{
+    fn from(v: Option<T>) -> Self {
+        match v {
+            Some(v) => v.into(),
+            None => ().into(),
+        }
+    }
+}

--- a/src/scval.rs
+++ b/src/scval.rs
@@ -1,4 +1,4 @@
-use crate::{Hash, ScHash, PublicKey, ScObject, ScStatic, ScStatus, ScVal};
+use crate::{Hash, PublicKey, ScHash, ScObject, ScStatic, ScStatus, ScVal};
 
 impl From<ScStatic> for ScVal {
     fn from(v: ScStatic) -> Self {
@@ -112,32 +112,44 @@ impl From<PublicKey> for ScVal {
     }
 }
 
-// Vec(ScVec),
-// Map(ScMap),
-// Binary(VecM<u8, 256000>),
-// BigInt(ScBigInt),
+#[cfg(feature = "alloc")]
+impl TryFrom<&str> for ScVal {
+    type Error = ();
+    fn try_from(v: &str) -> Result<Self, Self::Error> {
+        Ok(ScVal::Symbol(v.try_into().map_err(|_| ())?))
+    }
+}
 
-// impl ToScVal for &str {
-//     fn to_scval(&self) -> Result<ScVal, ()> {
-//         let bytes: Vec<u8> = self.as_bytes().iter().cloned().collect();
-//         Ok(ScVal::Symbol(bytes.try_into().map_err(|_| ())?))
-//     }
-// }
+#[cfg(not(feature = "alloc"))]
+impl TryFrom<&'static str> for ScVal {
+    type Error = ();
+    fn try_from(v: &'static str) -> Result<Self, Self::Error> {
+        Ok(ScVal::Symbol(v.try_into().map_err(|_| ())?))
+    }
+}
 
-// impl FromScVal<bool> for ScVal {
-//     fn from_scval(&self) -> Result<bool, ()> {
-//         match self {
-//             ScVal::Static(ScStatic::False) => Ok(false),
-//             ScVal::Static(ScStatic::True) => Ok(true),
-//             _ => Err(()),
-//         }
-//     }
-// }
+#[cfg(feature = "alloc")]
+impl TryFrom<String> for ScVal {
+    type Error = ();
+    fn try_from(v: String) -> Result<Self, Self::Error> {
+        Ok(ScVal::Symbol(v.try_into().map_err(|_| ())?))
+    }
+}
 
-impl<T> From<Option<T>> for ScVal
-where
-    T: Into<ScVal>,
-{
+#[cfg(feature = "alloc")]
+impl TryFrom<&String> for ScVal {
+    type Error = ();
+    fn try_from(v: &String) -> Result<Self, Self::Error> {
+        Ok(ScVal::Symbol(v.try_into().map_err(|_| ())?))
+    }
+}
+
+// TODO: Vec(ScVec),
+// TODO: Map(ScMap),
+// TODO: Binary(VecM<u8, 256000>),
+// TODO: BigInt(ScBigInt),
+
+impl<T: Into<ScVal>> From<Option<T>> for ScVal {
     fn from(v: Option<T>) -> Self {
         match v {
             Some(v) => v.into(),

--- a/src/scval.rs
+++ b/src/scval.rs
@@ -8,6 +8,8 @@ use alloc::{string::String, vec::Vec};
 #[cfg(feature = "num-bigint")]
 use num_bigint::{BigInt, Sign};
 
+// TODO: Add borrow conversions as well.
+
 impl From<ScStatic> for ScVal {
     fn from(v: ScStatic) -> Self {
         Self::Static(v)
@@ -347,7 +349,19 @@ impl TryFrom<&'static str> for ScVal {
     }
 }
 
-// TODO: Reverse conditions for ScVal/etc => String/&str/etc.
+#[cfg(feature = "alloc")]
+impl TryFrom<ScVal> for String {
+    type Error = ();
+    fn try_from(v: ScVal) -> Result<Self, Self::Error> {
+        if let ScVal::Symbol(s) = v {
+            // TODO: It might be worth distinguishing the error case where this
+            // is an invalid symbol with invalid characters.
+            Ok(s.into_string().map_err(|_| ())?)
+        } else {
+            Err(())
+        }
+    }
+}
 
 #[cfg(feature = "alloc")]
 impl TryFrom<Vec<u8>> for ScObject {

--- a/src/scval.rs
+++ b/src/scval.rs
@@ -734,14 +734,3 @@ impl<T: Into<ScVal>> From<Option<T>> for ScVal {
         }
     }
 }
-
-// TODO: Is there a way to provide this conversion without recursion?
-// impl<T: TryFrom<ScVal>> TryFrom<ScVal> for Option<T> {
-//     type Error = T::Error;
-//     fn try_from(v: ScVal) -> Result<Self, Self::Error> {
-//         match v {
-//             ScVal::Static(ScStatic::Void) => Ok(None),
-//             _ => <_ as TryFrom<ScVal>>::try_from(v),
-//         }
-//     }
-// }


### PR DESCRIPTION
### What

Add conversions from/to ScVal types.

### Why

So that contract tests can build XDR conveniently.

This work is inspired by @jonjove's experimentation with the token contract.

Close #104

### Known limitations

Some conversions that are possible are omitted because they're not convenient without the `alloc` feature. This work is primarily concerned with providing types to tests which have access to an allocator.
