### PR TITLE
Update cargo-hack and remove optional-dep work around

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -74,13 +74,13 @@ jobs:
         restore-keys: |
           target-${{ strategy.job-index }}
           target-
-    - run: cargo install --locked --version 0.5.14 cargo-hack
+    - run: cargo install --locked --version 0.5.15 cargo-hack
     - run: >
-        cargo hack clippy --feature-powerset --optional-deps
+        cargo hack clippy --feature-powerset
         --profile ${{ matrix.profile }}
         --target ${{ matrix.sys.target }}
         --all-targets
     - if: matrix.sys.test
       run: >
-        cargo hack test --feature-powerset --optional-deps
+        cargo hack test --feature-powerset
         --profile ${{ matrix.profile }}

--- a/Makefile
+++ b/Makefile
@@ -27,12 +27,6 @@ export RUSTFLAGS=-Dwarnings -Dclippy::all -Dclippy::pedantic
 
 all: build test
 
-# TODO: Remove the `--optional-deps` usage once weak dependencies are recognized
-# by cargo-hack https://github.com/taiki-e/cargo-hack/issues/147 and once the
-# bug with first-class features that have the same name as an optional
-# dependency not being seen as a feature to test
-# https://github.com/taiki-e/cargo-hack/issues/153.
-
 test:
 	cargo hack test --feature-powerset
 

--- a/Makefile
+++ b/Makefile
@@ -34,11 +34,11 @@ all: build test
 # https://github.com/taiki-e/cargo-hack/issues/153.
 
 test:
-	cargo hack test --feature-powerset --optional-deps
+	cargo hack test --feature-powerset
 
 build: generate
-	cargo hack clippy --feature-powerset --optional-deps --all-targets
-	cargo hack clippy --feature-powerset --optional-deps --all-targets --release --target wasm32-unknown-unknown
+	cargo hack clippy --feature-powerset --all-targets
+	cargo hack clippy --feature-powerset --all-targets --release --target wasm32-unknown-unknown
 
 watch:
 	cargo watch --clear --watch-when-idle --shell '$(MAKE)'


### PR DESCRIPTION
### What

Update cargo-hack and remove optional-dep work around.

### Why

A fix for the optional dependency issue (taiki-e/cargo-hack#153) was released in cargo-hack 0.5.15. It is no longer necessary to explicitly ask for optional dependencies to be included so that first-class features that happen to have the same name get included in the powerset. They are included in the powerset by default.

### Known limitations

[TODO or N/A]
