### PR TITLE
Make Vec to/from ScVal conversions compatible with more types

### DIFF
--- a/src/scval_conversions.rs
+++ b/src/scval_conversions.rs
@@ -835,6 +835,36 @@ macro_rules! impl_for_tuple {
                 ))
             }
         }
+
+        impl<$($typ),*> TryFrom<ScObject> for ($($typ,)*)
+        where
+            $($typ: TryFrom<ScVal> + Clone),*
+        {
+            type Error = ();
+
+            fn try_from(obj: ScObject) -> Result<Self, Self::Error> {
+                if let ScObject::Vec(vec) = obj {
+                    <_ as TryFrom<ScVec>>::try_from(vec)
+                } else {
+                    Err(())
+                }
+            }
+        }
+
+        impl<$($typ),*> TryFrom<ScVal> for ($($typ,)*)
+        where
+            $($typ: TryFrom<ScVal> + Clone),*
+        {
+            type Error = ();
+
+            fn try_from(val: ScVal) -> Result<Self, Self::Error> {
+                if let ScVal::Object(Some(obj)) = val {
+                    <_ as TryFrom<ScObject>>::try_from(obj)
+                } else {
+                    Err(())
+                }
+            }
+        }
     };
 }
 

--- a/src/scval_conversions.rs
+++ b/src/scval_conversions.rs
@@ -813,21 +813,41 @@ macro_rules! impl_for_tuple {
                 ScVal::Object(Some(<_ as Into<ScObject>>::into(v)))
             }
         }
+
+        impl<$($typ),*> TryFrom<ScVec> for ($($typ,)*)
+        where
+            $($typ: TryFrom<ScVal> + Clone),*
+        {
+            type Error = ();
+
+            fn try_from(vec: ScVec) -> Result<Self, Self::Error> {
+                if vec.len() != $count {
+                    return Err(());
+                }
+                Ok((
+                    $({
+                        let idx: usize = $idx;
+                        let val = vec[idx].clone();
+                        $typ::try_from(val).map_err(|_| ())?
+                    },)*
+                ))
+            }
+        }
     };
 }
 
-impl_for_tuple! {  1_u32 T0 0 }
-impl_for_tuple! {  2_u32 T0 0 T1 1 }
-impl_for_tuple! {  3_u32 T0 0 T1 1 T2 2 }
-impl_for_tuple! {  4_u32 T0 0 T1 1 T2 2 T3 3 }
-impl_for_tuple! {  5_u32 T0 0 T1 1 T2 2 T3 3 T4 4 }
-impl_for_tuple! {  6_u32 T0 0 T1 1 T2 2 T3 3 T4 4 T5 5 }
-impl_for_tuple! {  7_u32 T0 0 T1 1 T2 2 T3 3 T4 4 T5 5 T6 6 }
-impl_for_tuple! {  8_u32 T0 0 T1 1 T2 2 T3 3 T4 4 T5 5 T6 6 T7 7 }
-impl_for_tuple! {  9_u32 T0 0 T1 1 T2 2 T3 3 T4 4 T5 5 T6 6 T7 7 T8 8 }
-impl_for_tuple! { 10_u32 T0 0 T1 1 T2 2 T3 3 T4 4 T5 5 T6 6 T7 7 T8 8 T9 9 }
-impl_for_tuple! { 11_u32 T0 0 T1 1 T2 2 T3 3 T4 4 T5 5 T6 6 T7 7 T8 8 T9 9 T10 10 }
-impl_for_tuple! { 12_u32 T0 0 T1 1 T2 2 T3 3 T4 4 T5 5 T6 6 T7 7 T8 8 T9 9 T10 10 T11 11 }
+impl_for_tuple! {  1 T0 0 }
+impl_for_tuple! {  2 T0 0 T1 1 }
+impl_for_tuple! {  3 T0 0 T1 1 T2 2 }
+impl_for_tuple! {  4 T0 0 T1 1 T2 2 T3 3 }
+impl_for_tuple! {  5 T0 0 T1 1 T2 2 T3 3 T4 4 }
+impl_for_tuple! {  6 T0 0 T1 1 T2 2 T3 3 T4 4 T5 5 }
+impl_for_tuple! {  7 T0 0 T1 1 T2 2 T3 3 T4 4 T5 5 T6 6 }
+impl_for_tuple! {  8 T0 0 T1 1 T2 2 T3 3 T4 4 T5 5 T6 6 T7 7 }
+impl_for_tuple! {  9 T0 0 T1 1 T2 2 T3 3 T4 4 T5 5 T6 6 T7 7 T8 8 }
+impl_for_tuple! { 10 T0 0 T1 1 T2 2 T3 3 T4 4 T5 5 T6 6 T7 7 T8 8 T9 9 }
+impl_for_tuple! { 11 T0 0 T1 1 T2 2 T3 3 T4 4 T5 5 T6 6 T7 7 T8 8 T9 9 T10 10 }
+impl_for_tuple! { 12 T0 0 T1 1 T2 2 T3 3 T4 4 T5 5 T6 6 T7 7 T8 8 T9 9 T10 10 T11 11 }
 
 #[cfg(test)]
 mod test {

--- a/src/scval_conversions.rs
+++ b/src/scval_conversions.rs
@@ -953,6 +953,18 @@ mod test {
         assert_eq!(v, roundtrip);
     }
 
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn tuple() {
+        extern crate alloc;
+        use alloc::vec;
+        use alloc::vec::Vec;
+        let v = (1i32, 2i64, vec![true, false]);
+        let val: ScVal = v.clone().into();
+        let roundtrip: (i32, i64, Vec<bool>) = val.try_into().unwrap();
+        assert_eq!(v, roundtrip);
+    }
+
     #[cfg(feature = "num-bigint")]
     #[test]
     fn bigint() {

--- a/src/scval_conversions.rs
+++ b/src/scval_conversions.rs
@@ -971,18 +971,6 @@ mod test {
         assert_eq!(v, roundtrip);
     }
 
-    #[cfg(feature = "alloc")]
-    #[test]
-    fn tuple() {
-        extern crate alloc;
-        use alloc::vec;
-        use alloc::vec::Vec;
-        let v = (1i32, 2i64, vec![true, false]);
-        let val: ScVal = v.clone().try_into().unwrap();
-        let roundtrip: (i32, i64, Vec<bool>) = val.try_into().unwrap();
-        assert_eq!(v, roundtrip);
-    }
-
     #[cfg(feature = "num-bigint")]
     #[test]
     fn bigint() {

--- a/src/scval_conversions.rs
+++ b/src/scval_conversions.rs
@@ -816,6 +816,8 @@ macro_rules! impl_for_tuple {
 
         impl<$($typ),*> TryFrom<ScVec> for ($($typ,)*)
         where
+            // TODO: Consider removing the Clone constraint by changing the
+            // try_from to use a reference.
             $($typ: TryFrom<ScVal> + Clone),*
         {
             type Error = ();


### PR DESCRIPTION
### What

Make conversion from `Vec` to `ScVal` compatible with types that implement `TryInto<ScVal>` and not `Into<ScVal>`.

### Why

Some types, such as Vec itself, don't support a non-erroring `Into<ScVal>` conversion, and with the current implementation of the conversions are not supported when converting Vecs.

### Known limitations

[TODO or N/A]
