### PR TITLE
Disable macOS builds, and speed up builds

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,21 +60,22 @@ jobs:
     - uses: actions/checkout@v3
     - run: rustup update
     - run: rustup target add ${{ matrix.sys.target }}
-    - uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-        key: cargo-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: cargo-
-    - uses: actions/cache@v3
-      with:
-        path: target/
-        key: target-${{ strategy.job-index }}-${{ github.sha }}
-        restore-keys: |
-          target-${{ strategy.job-index }}
-          target-
+    # TODO: Investigate cache bloat and re-enable.
+    # - uses: actions/cache@v3
+    #   with:
+    #     path: |
+    #       ~/.cargo/registry/index/
+    #       ~/.cargo/registry/cache/
+    #       ~/.cargo/git/db/
+    #     key: cargo-${{ hashFiles('**/Cargo.lock') }}
+    #     restore-keys: cargo-
+    # - uses: actions/cache@v3
+    #   with:
+    #     path: target/
+    #     key: target-${{ strategy.job-index }}-${{ github.sha }}
+    #     restore-keys: |
+    #       target-${{ strategy.job-index }}
+    #       target-
     - run: cargo install --locked --version 0.5.15 cargo-hack
     - run: >
         cargo hack clippy --feature-powerset

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,12 +45,13 @@ jobs:
         - os: ubuntu-latest
           target: x86_64-unknown-linux-gnu
           test: true
-        - os: macos-latest
-          target: x86_64-apple-darwin
-          test: true
-        - os: macos-latest
-          target: aarch64-apple-darwin
-          test: false
+        # TODO: Address GitHub Actions concurrency limits and re-enable.
+        # - os: macos-latest
+        #   target: x86_64-apple-darwin
+        #   test: true
+        # - os: macos-latest
+        #   target: aarch64-apple-darwin
+        #   test: false
         # TODO: Address disk space usage problems and re-enable.
         # - os: windows-latest
         #   target: x86_64-pc-windows-msvc

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,7 +37,6 @@ jobs:
   cargo:
     strategy:
       matrix:
-        profile: [dev, release]
         sys:
         - os: ubuntu-latest
           target: wasm32-unknown-unknown
@@ -79,10 +78,8 @@ jobs:
     - run: cargo install --locked --version 0.5.15 cargo-hack
     - run: >
         cargo hack clippy --feature-powerset
-        --profile ${{ matrix.profile }}
         --target ${{ matrix.sys.target }}
         --all-targets
     - if: matrix.sys.test
       run: >
         cargo hack test --feature-powerset
-        --profile ${{ matrix.profile }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,10 @@ std = ["alloc"]
 alloc = []
 next = []
 
-# Features dependent on optional dependencies.
-base64 = ["std", "dep:base64"]
-serde = ["alloc", "dep:serde"]
-num-bigint = ["alloc", "dep:num-bigint"]
+# Extensions enables non-core behavior that are useful to some applications.
+extensions = [
+    "std",
+    "dep:base64",
+    "dep:serde",
+    "dep:num-bigint",
+]


### PR DESCRIPTION
### What

Temporarily disable macOS builds, and remove caching and profile testing from builds.

### Why

We are constantly hitting GitHub Actions concurrency limits which is drastically slowing down builds. The gain we get from validating our builds against don't outsize the cost of slowing down builds at this point.

Also, just recently our cache sizes have exploded to the point where storing and restoring caches, along with the additional burden old cached files place on the compiler, seem to be slowing builds down rather than speeding them up.

### Known limitations

[TODO or N/A]
