### PR TITLE
Add test for ScVal binary conversion

### DIFF
--- a/src/scval_conversions.rs
+++ b/src/scval_conversions.rs
@@ -1022,6 +1022,31 @@ mod test {
 
     #[cfg(feature = "alloc")]
     #[test]
+    fn binary() {
+        extern crate alloc;
+        use alloc::vec;
+
+        let v = [1, 2, 3, 4, 5];
+        let val: ScVal = v.try_into().unwrap();
+        assert_eq!(
+            val,
+            ScVal::Object(Some(ScObject::Binary(
+                vec![1, 2, 3, 4, 5].try_into().unwrap()
+            )))
+        );
+
+        let v = &[1, 2, 3, 4, 5];
+        let val: ScVal = v.try_into().unwrap();
+        assert_eq!(
+            val,
+            ScVal::Object(Some(ScObject::Binary(
+                vec![1, 2, 3, 4, 5].try_into().unwrap()
+            )))
+        );
+    }
+
+    #[cfg(feature = "alloc")]
+    #[test]
     fn vec() {
         extern crate alloc;
         use alloc::vec;


### PR DESCRIPTION
### What

Add test for ScVal binary conversion with fixed size arrays.

### Why

I'm having problems with conversions between fixed size arrays and binaries and added this test to try and narrow down the problem. The test didn't yield anything helpful, but we can keep the test.

### Known limitations

[TODO or N/A]
