### PR TITLE
Update cargo-hack

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,7 +77,7 @@ jobs:
           ${{ github.job }}-target-
     - if: github.ref_protected
       run: rm -fr target
-    - run: cargo install --locked --version 0.5.15 cargo-hack
+    - run: cargo install --locked --version 0.5.16 cargo-hack
     - if: "github.ref_protected"
       run: echo 'CARGO_HACK_ARGS=--feature-powerset' >> $GITHUB_ENV
     - if: "!github.ref_protected"


### PR DESCRIPTION
### What
Update cargo-hack to 0.5.16.

### Why
v0.5.16 fixes a bug where warnings were being emitted unnecessarilly in logs.