### PR TITLE
Fix complete job in ci

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,6 +14,8 @@ jobs:
     # if: always()
     needs: [generate, fmt, cargo]
     runs-on: ubuntu-latest
+    steps:
+    - run: exit 0
     # steps:
     # - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
     #   run: exit 1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
     needs: [generate, fmt, cargo]
     runs-on: ubuntu-latest
     steps:
-    - if: contains(needs.*.result, 'failure')
+    - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
       run: exit 1
 
   generate:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,12 +11,12 @@ env:
 jobs:
 
   complete:
-    if: always()
+    # if: always()
     needs: [generate, fmt, cargo]
     runs-on: ubuntu-latest
-    steps:
-    - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
-      run: exit 1
+    # steps:
+    # - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+    #   run: exit 1
 
   generate:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,14 +11,10 @@ env:
 jobs:
 
   complete:
-    # if: always()
     needs: [generate, fmt, cargo]
     runs-on: ubuntu-latest
     steps:
     - run: exit 0
-    # steps:
-    # - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
-    #   run: exit 1
 
   generate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### What
Make the complete job fail for cancelled builds, by having it run only if all the prior jobs succeed.

### Why
The complete job checks if any of the jobs failed, but they might have been cancelled rather than failed. This causes the complete job to succeed when a needed job was cancelled. You can see how this build played out where a cancelled job resulted in a merged PR: https://github.com/stellar/rs-stellar-xdr/pull/130.