### PR TITLE
Support Arbitrary

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -81,7 +81,7 @@ jobs:
     - if: "github.ref_protected"
       run: echo 'CARGO_HACK_ARGS=--feature-powerset' >> $GITHUB_ENV
     - if: "!github.ref_protected"
-      run: echo 'CARGO_HACK_ARGS=--feature-powerset --exclude-features default --group-features base64,serde,num-bigint' >> $GITHUB_ENV
+      run: echo 'CARGO_HACK_ARGS=--feature-powerset --exclude-features default --group-features base64,serde,num-bigint,arbitrary' >> $GITHUB_ENV
     - run: >
         cargo hack clippy $CARGO_HACK_ARGS
         --target ${{ matrix.sys.target }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "arbitrary"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a7924531f38b1970ff630f03eb20a2fde69db5c590c93b0f3482e95dcc5fd60"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13,6 +22,17 @@ name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9a577516173adb681466d517d39bd468293bc2c2a16439375ef0f35bba45f3d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "num-bigint"
@@ -86,6 +106,7 @@ dependencies = [
 name = "stellar-xdr"
 version = "0.0.1"
 dependencies = [
+ "arbitrary",
  "base64",
  "num-bigint",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ next = []
 base64 = ["std", "dep:base64"]
 serde = ["alloc", "dep:serde"]
 num-bigint = ["alloc", "dep:num-bigint"]
-arbitrary = ["dep:arbitrary"]
+arbitrary = ["std", "dep:arbitrary"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 base64 = { version = "0.13.0", optional = true }
 serde = { version = "1.0.139", features = ["derive"], optional = true }
 num-bigint = { version = "0.4.3", optional = true }
-arbitrary = {version = "1.1.3", features = ["derive"]}
+arbitrary = {version = "1.1.3", features = ["derive"], optional = true}
 
 [features]
 default = ["std"]
@@ -24,6 +24,7 @@ next = []
 base64 = ["std", "dep:base64"]
 serde = ["alloc", "dep:serde"]
 num-bigint = ["alloc", "dep:num-bigint"]
+arbitrary = ["dep:arbitrary"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2021"
 base64 = { version = "0.13.0", optional = true }
 serde = { version = "1.0.139", features = ["derive"], optional = true }
 num-bigint = { version = "0.4.3", optional = true }
+arbitrary = {version = "1.1.3", features = ["derive"]}
 
 [features]
 default = ["std"]

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ XDR_FILES_LOCAL_NEXT=$(addprefix xdr/next/,$(XDR_FILES_NEXT))
 
 export RUSTFLAGS=-Dwarnings -Dclippy::all -Dclippy::pedantic
 
-CARGO_HACK_ARGS=--feature-powerset --exclude-features default --group-features base64,serde,num-bigint
+CARGO_HACK_ARGS=--feature-powerset --exclude-features default --group-features base64,serde,num-bigint,arbitrary
 
 all: build test
 
@@ -45,7 +45,7 @@ src/curr.rs: $(XDR_FILES_LOCAL_CURR)
 	> $@
 	docker run -i --rm -v $$PWD:/wd -w /wd ruby /bin/bash -c '\
 		gem install specific_install -v 0.3.7 && \
-		gem specific_install https://github.com/stellar/xdrgen.git -b master && \
+		gem specific_install https://github.com/stellar/xdrgen.git -b arbitrary-rs && \
 		xdrgen --language rust --namespace curr --output src/ $^ \
 		'
 	rustfmt $@
@@ -54,7 +54,7 @@ src/next.rs: $(XDR_FILES_LOCAL_NEXT)
 	> $@
 	docker run -i --rm -v $$PWD:/wd -w /wd ruby /bin/bash -c '\
 		gem install specific_install -v 0.3.7 && \
-		gem specific_install https://github.com/stellar/xdrgen.git -b master && \
+		gem specific_install https://github.com/stellar/xdrgen.git -b arbitrary-rs && \
 		xdrgen --language rust --namespace next --output src/ $^ \
 		'
 	rustfmt $@

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ src/curr.rs: $(XDR_FILES_LOCAL_CURR)
 	> $@
 	docker run -i --rm -v $$PWD:/wd -w /wd ruby /bin/bash -c '\
 		gem install specific_install -v 0.3.7 && \
-		gem specific_install https://github.com/stellar/xdrgen.git -b arbitrary-rs && \
+		gem specific_install https://github.com/stellar/xdrgen.git -b master && \
 		xdrgen --language rust --namespace curr --output src/ $^ \
 		'
 	rustfmt $@
@@ -54,7 +54,7 @@ src/next.rs: $(XDR_FILES_LOCAL_NEXT)
 	> $@
 	docker run -i --rm -v $$PWD:/wd -w /wd ruby /bin/bash -c '\
 		gem install specific_install -v 0.3.7 && \
-		gem specific_install https://github.com/stellar/xdrgen.git -b arbitrary-rs && \
+		gem specific_install https://github.com/stellar/xdrgen.git -b master && \
 		xdrgen --language rust --namespace next --output src/ $^ \
 		'
 	rustfmt $@

--- a/src/curr.rs
+++ b/src/curr.rs
@@ -36,6 +36,7 @@ pub const XDR_FILES_SHA256: [(&str, &str); 6] = [
     ),
 ];
 
+use arbitrary::Arbitrary;
 use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref, slice};
 
 #[cfg(feature = "std")]
@@ -541,12 +542,12 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 }
 
 #[cfg(feature = "alloc")]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
 #[cfg(not(feature = "alloc"))]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>)
 where
     T: 'static;
@@ -990,7 +991,7 @@ mod tests {
 //
 //   typedef opaque Value<>;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1092,7 +1093,7 @@ impl AsRef<[u8]> for Value {
 //        Value value;    // x
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1133,7 +1134,7 @@ impl WriteXdr for ScpBallot {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1241,7 +1242,7 @@ impl WriteXdr for ScpStatementType {
 //        Value accepted<>;   // Y
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1286,7 +1287,7 @@ impl WriteXdr for ScpNomination {
 //                uint32 nH;                // h.n
 //            }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1339,7 +1340,7 @@ impl WriteXdr for ScpStatementPrepare {
 //                Hash quorumSetHash; // D
 //            }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1387,7 +1388,7 @@ impl WriteXdr for ScpStatementConfirm {
 //                Hash commitQuorumSetHash; // D used before EXTERNALIZE
 //            }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1455,7 +1456,7 @@ impl WriteXdr for ScpStatementExternalize {
 //        }
 //
 // union with discriminant ScpStatementType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1601,7 +1602,7 @@ impl WriteXdr for ScpStatementPledges {
 //        pledges;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1642,7 +1643,7 @@ impl WriteXdr for ScpStatement {
 //        Signature signature;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1681,7 +1682,7 @@ impl WriteXdr for ScpEnvelope {
 //        SCPQuorumSet innerSets<>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1718,7 +1719,7 @@ impl WriteXdr for ScpQuorumSet {
 //
 //   typedef PublicKey AccountID;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1767,7 +1768,7 @@ impl WriteXdr for AccountId {
 //
 //   typedef opaque Thresholds[4];
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1865,7 +1866,7 @@ pub type String64 = VecM<u8, 64>;
 //
 //   typedef int64 SequenceNumber;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1914,7 +1915,7 @@ impl WriteXdr for SequenceNumber {
 //
 //   typedef uint64 TimePoint;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1963,7 +1964,7 @@ impl WriteXdr for TimePoint {
 //
 //   typedef uint64 Duration;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2012,7 +2013,7 @@ impl WriteXdr for Duration {
 //
 //   typedef opaque DataValue<64>;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2110,7 +2111,7 @@ impl AsRef<[u8]> for DataValue {
 //
 //   typedef Hash PoolID;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2159,7 +2160,7 @@ impl WriteXdr for PoolId {
 //
 //   typedef opaque AssetCode4[4];
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2245,7 +2246,7 @@ impl AsRef<[u8]> for AssetCode4 {
 //
 //   typedef opaque AssetCode12[12];
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2338,7 +2339,7 @@ impl AsRef<[u8]> for AssetCode12 {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2451,7 +2452,7 @@ impl WriteXdr for AssetType {
 //    };
 //
 // union with discriminant AssetType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2547,7 +2548,7 @@ impl WriteXdr for AssetCode {
 //        AccountID issuer;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2585,7 +2586,7 @@ impl WriteXdr for AlphaNum4 {
 //        AccountID issuer;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2632,7 +2633,7 @@ impl WriteXdr for AlphaNum12 {
 //    };
 //
 // union with discriminant AssetType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2737,7 +2738,7 @@ impl WriteXdr for Asset {
 //        int32 d; // denominator
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2775,7 +2776,7 @@ impl WriteXdr for Price {
 //        int64 selling;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2816,7 +2817,7 @@ impl WriteXdr for Liabilities {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2928,7 +2929,7 @@ impl WriteXdr for ThresholdIndexes {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3043,7 +3044,7 @@ impl WriteXdr for LedgerEntryType {
 //        uint32 weight; // really only need 1 byte
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3094,7 +3095,7 @@ impl WriteXdr for Signer {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3215,7 +3216,7 @@ pub const MAX_SIGNERS: u64 = 20;
 //
 //   typedef AccountID* SponsorshipDescriptor;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3275,7 +3276,7 @@ impl WriteXdr for SponsorshipDescriptor {
 //        TimePoint seqTime;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3319,7 +3320,7 @@ impl WriteXdr for AccountEntryExtensionV3 {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3425,7 +3426,7 @@ impl WriteXdr for AccountEntryExtensionV2Ext {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3472,7 +3473,7 @@ impl WriteXdr for AccountEntryExtensionV2 {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3576,7 +3577,7 @@ impl WriteXdr for AccountEntryExtensionV1Ext {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3617,7 +3618,7 @@ impl WriteXdr for AccountEntryExtensionV1 {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3736,7 +3737,7 @@ impl WriteXdr for AccountEntryExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3805,7 +3806,7 @@ impl WriteXdr for AccountEntry {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3926,7 +3927,7 @@ pub const MASK_TRUSTLINE_FLAGS_V17: u64 = 7;
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -4031,7 +4032,7 @@ impl WriteXdr for LiquidityPoolType {
 //    };
 //
 // union with discriminant AssetType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -4143,7 +4144,7 @@ impl WriteXdr for TrustLineAsset {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -4240,7 +4241,7 @@ impl WriteXdr for TrustLineEntryExtensionV2Ext {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -4281,7 +4282,7 @@ impl WriteXdr for TrustLineEntryExtensionV2 {
 //                }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -4385,7 +4386,7 @@ impl WriteXdr for TrustLineEntryV1Ext {
 //                ext;
 //            }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -4438,7 +4439,7 @@ impl WriteXdr for TrustLineEntryV1 {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -4561,7 +4562,7 @@ impl WriteXdr for TrustLineEntryExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -4613,7 +4614,7 @@ impl WriteXdr for TrustLineEntry {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -4713,7 +4714,7 @@ pub const MASK_OFFERENTRY_FLAGS: u64 = 1;
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -4823,7 +4824,7 @@ impl WriteXdr for OfferEntryExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -4880,7 +4881,7 @@ impl WriteXdr for OfferEntry {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -4980,7 +4981,7 @@ impl WriteXdr for DataEntryExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -5029,7 +5030,7 @@ impl WriteXdr for DataEntry {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -5156,7 +5157,7 @@ impl WriteXdr for ClaimPredicateType {
 //    };
 //
 // union with discriminant ClaimPredicateType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -5279,7 +5280,7 @@ impl WriteXdr for ClaimPredicate {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -5372,7 +5373,7 @@ impl WriteXdr for ClaimantType {
 //            ClaimPredicate predicate; // Claimable if predicate is true
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -5415,7 +5416,7 @@ impl WriteXdr for ClaimantV0 {
 //    };
 //
 // union with discriminant ClaimantType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -5506,7 +5507,7 @@ impl WriteXdr for Claimant {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -5601,7 +5602,7 @@ impl WriteXdr for ClaimableBalanceIdType {
 //    };
 //
 // union with discriminant ClaimableBalanceIdType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -5697,7 +5698,7 @@ impl WriteXdr for ClaimableBalanceId {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -5798,7 +5799,7 @@ pub const MASK_CLAIMABLE_BALANCE_FLAGS: u64 = 0x1;
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -5895,7 +5896,7 @@ impl WriteXdr for ClaimableBalanceEntryExtensionV1Ext {
 //        uint32 flags; // see ClaimableBalanceFlags
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -5936,7 +5937,7 @@ impl WriteXdr for ClaimableBalanceEntryExtensionV1 {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6051,7 +6052,7 @@ impl WriteXdr for ClaimableBalanceEntryExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6099,7 +6100,7 @@ impl WriteXdr for ClaimableBalanceEntry {
 //        int32 fee; // Fee is in basis points, so the actual rate is (fee/100)%
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6145,7 +6146,7 @@ impl WriteXdr for LiquidityPoolConstantProductParameters {
 //                                                // associated pool shares
 //            }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6202,7 +6203,7 @@ impl WriteXdr for LiquidityPoolEntryConstantProduct {
 //        }
 //
 // union with discriminant LiquidityPoolType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6312,7 +6313,7 @@ impl WriteXdr for LiquidityPoolEntryBody {
 //        body;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6351,7 +6352,7 @@ impl WriteXdr for LiquidityPoolEntry {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6448,7 +6449,7 @@ impl WriteXdr for LedgerEntryExtensionV1Ext {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6497,7 +6498,7 @@ impl WriteXdr for LedgerEntryExtensionV1 {
 //        }
 //
 // union with discriminant LedgerEntryType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6625,7 +6626,7 @@ impl WriteXdr for LedgerEntryData {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6747,7 +6748,7 @@ impl WriteXdr for LedgerEntryExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6787,7 +6788,7 @@ impl WriteXdr for LedgerEntry {
 //            AccountID accountID;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6822,7 +6823,7 @@ impl WriteXdr for LedgerKeyAccount {
 //            TrustLineAsset asset;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6860,7 +6861,7 @@ impl WriteXdr for LedgerKeyTrustLine {
 //            int64 offerID;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6898,7 +6899,7 @@ impl WriteXdr for LedgerKeyOffer {
 //            string64 dataName;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6935,7 +6936,7 @@ impl WriteXdr for LedgerKeyData {
 //            ClaimableBalanceID balanceID;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6969,7 +6970,7 @@ impl WriteXdr for LedgerKeyClaimableBalance {
 //            PoolID liquidityPoolID;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7041,7 +7042,7 @@ impl WriteXdr for LedgerKeyLiquidityPool {
 //    };
 //
 // union with discriminant LedgerEntryType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7175,7 +7176,7 @@ impl WriteXdr for LedgerKey {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7294,7 +7295,7 @@ impl WriteXdr for EnvelopeType {
 //
 //   typedef opaque UpgradeType<128>;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7397,7 +7398,7 @@ impl AsRef<[u8]> for UpgradeType {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7493,7 +7494,7 @@ impl WriteXdr for StellarValueType {
 //        Signature signature; // nodeID's signature
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7534,7 +7535,7 @@ impl WriteXdr for LedgerCloseValueSignature {
 //        }
 //
 // union with discriminant StellarValueType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7647,7 +7648,7 @@ impl WriteXdr for StellarValueExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7699,7 +7700,7 @@ pub const MASK_LEDGER_HEADER_FLAGS: u64 = 0x7;
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7803,7 +7804,7 @@ impl WriteXdr for LedgerHeaderFlags {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7900,7 +7901,7 @@ impl WriteXdr for LedgerHeaderExtensionV1Ext {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7941,7 +7942,7 @@ impl WriteXdr for LedgerHeaderExtensionV1 {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -8071,7 +8072,7 @@ impl WriteXdr for LedgerHeaderExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -8152,7 +8153,7 @@ impl WriteXdr for LedgerHeader {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -8272,7 +8273,7 @@ impl WriteXdr for LedgerUpgradeType {
 //    };
 //
 // union with discriminant LedgerUpgradeType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -8394,7 +8395,7 @@ impl WriteXdr for LedgerUpgrade {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -8502,7 +8503,7 @@ impl WriteXdr for BucketEntryType {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -8601,7 +8602,7 @@ impl WriteXdr for BucketMetadataExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -8646,7 +8647,7 @@ impl WriteXdr for BucketMetadata {
 //    };
 //
 // union with discriminant BucketEntryType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -8759,7 +8760,7 @@ impl WriteXdr for BucketEntry {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -8853,7 +8854,7 @@ impl WriteXdr for TxSetComponentType {
 //        TransactionEnvelope txs<>;
 //      }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -8896,7 +8897,7 @@ impl WriteXdr for TxSetComponentTxsMaybeDiscountedFee {
 //    };
 //
 // union with discriminant TxSetComponentType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -8995,7 +8996,7 @@ impl WriteXdr for TxSetComponent {
 //    };
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9086,7 +9087,7 @@ impl WriteXdr for TransactionPhase {
 //        TransactionEnvelope txs<>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9124,7 +9125,7 @@ impl WriteXdr for TransactionSet {
 //        TransactionPhase phases<>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9164,7 +9165,7 @@ impl WriteXdr for TransactionSetV1 {
 //    };
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9255,7 +9256,7 @@ impl WriteXdr for GeneralizedTransactionSet {
 //        TransactionResult result; // result for the transaction
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9292,7 +9293,7 @@ impl WriteXdr for TransactionResultPair {
 //        TransactionResultPair results<>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9330,7 +9331,7 @@ impl WriteXdr for TransactionResultSet {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9436,7 +9437,7 @@ impl WriteXdr for TransactionHistoryEntryExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9478,7 +9479,7 @@ impl WriteXdr for TransactionHistoryEntry {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9577,7 +9578,7 @@ impl WriteXdr for TransactionHistoryResultEntryExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9619,7 +9620,7 @@ impl WriteXdr for TransactionHistoryResultEntry {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9718,7 +9719,7 @@ impl WriteXdr for LedgerHeaderHistoryEntryExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9759,7 +9760,7 @@ impl WriteXdr for LedgerHeaderHistoryEntry {
 //        SCPEnvelope messages<>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9797,7 +9798,7 @@ impl WriteXdr for LedgerScpMessages {
 //        LedgerSCPMessages ledgerMessages;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9836,7 +9837,7 @@ impl WriteXdr for ScpHistoryEntryV0 {
 //    };
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9930,7 +9931,7 @@ impl WriteXdr for ScpHistoryEntry {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10044,7 +10045,7 @@ impl WriteXdr for LedgerEntryChangeType {
 //    };
 //
 // union with discriminant LedgerEntryChangeType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10151,7 +10152,7 @@ impl WriteXdr for LedgerEntryChange {
 //
 //   typedef LedgerEntryChange LedgerEntryChanges<>;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10252,7 +10253,7 @@ impl AsRef<[LedgerEntryChange]> for LedgerEntryChanges {
 //        LedgerEntryChanges changes;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10287,7 +10288,7 @@ impl WriteXdr for OperationMeta {
 //        OperationMeta operations<>;   // meta for each operation
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10328,7 +10329,7 @@ impl WriteXdr for TransactionMetaV1 {
 //                                            // applied if any
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10374,7 +10375,7 @@ impl WriteXdr for TransactionMetaV2 {
 //    };
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10476,7 +10477,7 @@ impl WriteXdr for TransactionMeta {
 //        TransactionMeta txApplyProcessing;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10517,7 +10518,7 @@ impl WriteXdr for TransactionResultMeta {
 //        LedgerEntryChanges changes;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10567,7 +10568,7 @@ impl WriteXdr for UpgradeEntryMeta {
 //        SCPHistoryEntry scpInfo<>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10626,7 +10627,7 @@ impl WriteXdr for LedgerCloseMetaV0 {
 //        SCPHistoryEntry scpInfo<>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10676,7 +10677,7 @@ impl WriteXdr for LedgerCloseMetaV1 {
 //    };
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10776,7 +10777,7 @@ impl WriteXdr for LedgerCloseMeta {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10887,7 +10888,7 @@ impl WriteXdr for ErrorCode {
 //        string msg<100>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10924,7 +10925,7 @@ impl WriteXdr for SError {
 //        uint32 numMessages;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10960,7 +10961,7 @@ impl WriteXdr for SendMore {
 //        Signature sig;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11008,7 +11009,7 @@ impl WriteXdr for AuthCert {
 //        uint256 nonce;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11068,7 +11069,7 @@ impl WriteXdr for Hello {
 //        int unused;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11104,7 +11105,7 @@ impl WriteXdr for Auth {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11203,7 +11204,7 @@ impl WriteXdr for IpAddrType {
 //        }
 //
 // union with discriminant IpAddrType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11307,7 +11308,7 @@ impl WriteXdr for PeerAddressIp {
 //        uint32 numFailures;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11373,7 +11374,7 @@ impl WriteXdr for PeerAddress {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11532,7 +11533,7 @@ impl WriteXdr for MessageType {
 //        uint256 reqHash;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11570,7 +11571,7 @@ impl WriteXdr for DontHave {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11666,7 +11667,7 @@ impl WriteXdr for SurveyMessageCommandType {
 //        SurveyMessageCommandType commandType;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11713,7 +11714,7 @@ impl WriteXdr for SurveyRequestMessage {
 //        SurveyRequestMessage request;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11747,7 +11748,7 @@ impl WriteXdr for SignedSurveyRequestMessage {
 //
 //   typedef opaque EncryptedBody<64000>;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11852,7 +11853,7 @@ impl AsRef<[u8]> for EncryptedBody {
 //        EncryptedBody encryptedBody;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11899,7 +11900,7 @@ impl WriteXdr for SurveyResponseMessage {
 //        SurveyResponseMessage response;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11952,7 +11953,7 @@ impl WriteXdr for SignedSurveyResponseMessage {
 //        uint64 duplicateFetchMessageRecv;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12025,7 +12026,7 @@ impl WriteXdr for PeerStats {
 //
 //   typedef PeerStats PeerStatList<25>;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12130,7 +12131,7 @@ impl AsRef<[PeerStats]> for PeerStatList {
 //        uint32 totalOutboundPeerCount;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12175,7 +12176,7 @@ impl WriteXdr for TopologyResponseBody {
 //    };
 //
 // union with discriminant SurveyMessageCommandType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12307,7 +12308,7 @@ impl WriteXdr for SurveyResponseBody {
 //    };
 //
 // union with discriminant MessageType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12503,7 +12504,7 @@ impl WriteXdr for StellarMessage {
 //            HmacSha256Mac mac;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12550,7 +12551,7 @@ impl WriteXdr for AuthenticatedMessageV0 {
 //    };
 //
 // union with discriminant u32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12642,7 +12643,7 @@ impl WriteXdr for AuthenticatedMessage {
 //    };
 //
 // union with discriminant LiquidityPoolType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12737,7 +12738,7 @@ impl WriteXdr for LiquidityPoolParameters {
 //            uint256 ed25519;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12782,7 +12783,7 @@ impl WriteXdr for MuxedAccountMed25519 {
 //    };
 //
 // union with discriminant CryptoKeyType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12878,7 +12879,7 @@ impl WriteXdr for MuxedAccount {
 //        Signature signature; // actual signature
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12939,7 +12940,7 @@ impl WriteXdr for DecoratedSignature {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13126,7 +13127,7 @@ impl WriteXdr for OperationType {
 //        int64 startingBalance; // amount they end up with
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13165,7 +13166,7 @@ impl WriteXdr for CreateAccountOp {
 //        int64 amount;             // amount they end up with
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13214,7 +13215,7 @@ impl WriteXdr for PaymentOp {
 //        Asset path<5>; // additional hops it must go through to get there
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13272,7 +13273,7 @@ impl WriteXdr for PathPaymentStrictReceiveOp {
 //        Asset path<5>; // additional hops it must go through to get there
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13327,7 +13328,7 @@ impl WriteXdr for PathPaymentStrictSendOp {
 //        int64 offerID;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13380,7 +13381,7 @@ impl WriteXdr for ManageSellOfferOp {
 //        int64 offerID;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13429,7 +13430,7 @@ impl WriteXdr for ManageBuyOfferOp {
 //        Price price;   // cost of A in terms of B
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13487,7 +13488,7 @@ impl WriteXdr for CreatePassiveSellOfferOp {
 //        Signer* signer;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13558,7 +13559,7 @@ impl WriteXdr for SetOptionsOp {
 //    };
 //
 // union with discriminant AssetType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13671,7 +13672,7 @@ impl WriteXdr for ChangeTrustAsset {
 //        int64 limit;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13712,7 +13713,7 @@ impl WriteXdr for ChangeTrustOp {
 //        uint32 authorize;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13753,7 +13754,7 @@ impl WriteXdr for AllowTrustOp {
 //        DataValue* dataValue; // set to null to clear
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13790,7 +13791,7 @@ impl WriteXdr for ManageDataOp {
 //        SequenceNumber bumpTo;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13826,7 +13827,7 @@ impl WriteXdr for BumpSequenceOp {
 //        Claimant claimants<10>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13866,7 +13867,7 @@ impl WriteXdr for CreateClaimableBalanceOp {
 //        ClaimableBalanceID balanceID;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13900,7 +13901,7 @@ impl WriteXdr for ClaimClaimableBalanceOp {
 //        AccountID sponsoredID;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13936,7 +13937,7 @@ impl WriteXdr for BeginSponsoringFutureReservesOp {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14035,7 +14036,7 @@ impl WriteXdr for RevokeSponsorshipType {
 //            SignerKey signerKey;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14080,7 +14081,7 @@ impl WriteXdr for RevokeSponsorshipOpSigner {
 //    };
 //
 // union with discriminant RevokeSponsorshipType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14180,7 +14181,7 @@ impl WriteXdr for RevokeSponsorshipOp {
 //        int64 amount;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14220,7 +14221,7 @@ impl WriteXdr for ClawbackOp {
 //        ClaimableBalanceID balanceID;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14258,7 +14259,7 @@ impl WriteXdr for ClawbackClaimableBalanceOp {
 //        uint32 setFlags;   // which flags to set
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14311,7 +14312,7 @@ pub const LIQUIDITY_POOL_FEE_V18: u64 = 30;
 //        Price maxPrice;   // maximum depositA/depositB
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14360,7 +14361,7 @@ impl WriteXdr for LiquidityPoolDepositOp {
 //        int64 minAmountB; // minimum amount of second asset to withdraw
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14451,7 +14452,7 @@ impl WriteXdr for LiquidityPoolWithdrawOp {
 //        }
 //
 // union with discriminant OperationType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14761,7 +14762,7 @@ impl WriteXdr for OperationBody {
 //        body;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14800,7 +14801,7 @@ impl WriteXdr for Operation {
 //            uint32 opNum;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14844,7 +14845,7 @@ impl WriteXdr for HashIdPreimageOperationId {
 //            Asset asset;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14906,7 +14907,7 @@ impl WriteXdr for HashIdPreimageRevokeId {
 //    };
 //
 // union with discriminant EnvelopeType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15008,7 +15009,7 @@ impl WriteXdr for HashIdPreimage {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15128,7 +15129,7 @@ impl WriteXdr for MemoType {
 //    };
 //
 // union with discriminant MemoType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15245,7 +15246,7 @@ impl WriteXdr for Memo {
 //        TimePoint maxTime; // 0 here means no maxTime
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15283,7 +15284,7 @@ impl WriteXdr for TimeBounds {
 //        uint32 maxLedger; // 0 here means no maxLedger
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15348,7 +15349,7 @@ impl WriteXdr for LedgerBounds {
 //        SignerKey extraSigners<2>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15400,7 +15401,7 @@ impl WriteXdr for PreconditionsV2 {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15508,7 +15509,7 @@ impl WriteXdr for PreconditionType {
 //    };
 //
 // union with discriminant PreconditionType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15620,7 +15621,7 @@ pub const MAX_OPS_PER_TX: u64 = 100;
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15721,7 +15722,7 @@ impl WriteXdr for TransactionV0Ext {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15776,7 +15777,7 @@ impl WriteXdr for TransactionV0 {
 //        DecoratedSignature signatures<20>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15815,7 +15816,7 @@ impl WriteXdr for TransactionV0Envelope {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15927,7 +15928,7 @@ impl WriteXdr for TransactionExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15982,7 +15983,7 @@ impl WriteXdr for Transaction {
 //        DecoratedSignature signatures<20>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16021,7 +16022,7 @@ impl WriteXdr for TransactionV1Envelope {
 //        }
 //
 // union with discriminant EnvelopeType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16113,7 +16114,7 @@ impl WriteXdr for FeeBumpTransactionInnerTx {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16216,7 +16217,7 @@ impl WriteXdr for FeeBumpTransactionExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16262,7 +16263,7 @@ impl WriteXdr for FeeBumpTransaction {
 //        DecoratedSignature signatures<20>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16305,7 +16306,7 @@ impl WriteXdr for FeeBumpTransactionEnvelope {
 //    };
 //
 // union with discriminant EnvelopeType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16414,7 +16415,7 @@ impl WriteXdr for TransactionEnvelope {
 //        }
 //
 // union with discriminant EnvelopeType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16519,7 +16520,7 @@ impl WriteXdr for TransactionSignaturePayloadTaggedTransaction {
 //        taggedTransaction;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16559,7 +16560,7 @@ impl WriteXdr for TransactionSignaturePayload {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16671,7 +16672,7 @@ impl WriteXdr for ClaimAtomType {
 //        int64 amountBought;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16730,7 +16731,7 @@ impl WriteXdr for ClaimOfferAtomV0 {
 //        int64 amountBought;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16787,7 +16788,7 @@ impl WriteXdr for ClaimOfferAtom {
 //        int64 amountBought;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16839,7 +16840,7 @@ impl WriteXdr for ClaimLiquidityAtom {
 //    };
 //
 // union with discriminant ClaimAtomType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16952,7 +16953,7 @@ impl WriteXdr for ClaimAtom {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -17069,7 +17070,7 @@ impl WriteXdr for CreateAccountResultCode {
 //    };
 //
 // union with discriminant CreateAccountResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -17198,7 +17199,7 @@ impl WriteXdr for CreateAccountResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -17340,7 +17341,7 @@ impl WriteXdr for PaymentResultCode {
 //    };
 //
 // union with discriminant PaymentResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -17511,7 +17512,7 @@ impl WriteXdr for PaymentResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -17656,7 +17657,7 @@ impl WriteXdr for PathPaymentStrictReceiveResultCode {
 //        int64 amount;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -17697,7 +17698,7 @@ impl WriteXdr for SimplePaymentResult {
 //            SimplePaymentResult last;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -17756,7 +17757,7 @@ impl WriteXdr for PathPaymentStrictReceiveResultSuccess {
 //    };
 //
 // union with discriminant PathPaymentStrictReceiveResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -17948,7 +17949,7 @@ impl WriteXdr for PathPaymentStrictReceiveResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -18092,7 +18093,7 @@ impl WriteXdr for PathPaymentStrictSendResultCode {
 //            SimplePaymentResult last;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -18150,7 +18151,7 @@ impl WriteXdr for PathPaymentStrictSendResultSuccess {
 //    };
 //
 // union with discriminant PathPaymentStrictSendResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -18341,7 +18342,7 @@ impl WriteXdr for PathPaymentStrictSendResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -18486,7 +18487,7 @@ impl WriteXdr for ManageSellOfferResultCode {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -18593,7 +18594,7 @@ impl WriteXdr for ManageOfferEffect {
 //        }
 //
 // union with discriminant ManageOfferEffect
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -18708,7 +18709,7 @@ impl WriteXdr for ManageOfferSuccessResultOffer {
 //        offer;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -18760,7 +18761,7 @@ impl WriteXdr for ManageOfferSuccessResult {
 //    };
 //
 // union with discriminant ManageSellOfferResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -18946,7 +18947,7 @@ impl WriteXdr for ManageSellOfferResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -19103,7 +19104,7 @@ impl WriteXdr for ManageBuyOfferResultCode {
 //    };
 //
 // union with discriminant ManageBuyOfferResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -19283,7 +19284,7 @@ impl WriteXdr for ManageBuyOfferResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -19430,7 +19431,7 @@ impl WriteXdr for SetOptionsResultCode {
 //    };
 //
 // union with discriminant SetOptionsResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -19597,7 +19598,7 @@ impl WriteXdr for SetOptionsResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -19734,7 +19735,7 @@ impl WriteXdr for ChangeTrustResultCode {
 //    };
 //
 // union with discriminant ChangeTrustResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -19885,7 +19886,7 @@ impl WriteXdr for ChangeTrustResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -20012,7 +20013,7 @@ impl WriteXdr for AllowTrustResultCode {
 //    };
 //
 // union with discriminant AllowTrustResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -20151,7 +20152,7 @@ impl WriteXdr for AllowTrustResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -20283,7 +20284,7 @@ impl WriteXdr for AccountMergeResultCode {
 //    };
 //
 // union with discriminant AccountMergeResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -20421,7 +20422,7 @@ impl WriteXdr for AccountMergeResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -20518,7 +20519,7 @@ impl WriteXdr for InflationResultCode {
 //        int64 amount;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -20559,7 +20560,7 @@ impl WriteXdr for InflationPayout {
 //    };
 //
 // union with discriminant InflationResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -20664,7 +20665,7 @@ impl WriteXdr for InflationResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -20781,7 +20782,7 @@ impl WriteXdr for ManageDataResultCode {
 //    };
 //
 // union with discriminant ManageDataResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -20901,7 +20902,7 @@ impl WriteXdr for ManageDataResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -21003,7 +21004,7 @@ impl WriteXdr for BumpSequenceResultCode {
 //    };
 //
 // union with discriminant BumpSequenceResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -21107,7 +21108,7 @@ impl WriteXdr for BumpSequenceResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -21231,7 +21232,7 @@ impl WriteXdr for CreateClaimableBalanceResultCode {
 //    };
 //
 // union with discriminant CreateClaimableBalanceResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -21363,7 +21364,7 @@ impl WriteXdr for CreateClaimableBalanceResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -21486,7 +21487,7 @@ impl WriteXdr for ClaimClaimableBalanceResultCode {
 //    };
 //
 // union with discriminant ClaimClaimableBalanceResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -21617,7 +21618,7 @@ impl WriteXdr for ClaimClaimableBalanceResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -21731,7 +21732,7 @@ impl WriteXdr for BeginSponsoringFutureReservesResultCode {
 //    };
 //
 // union with discriminant BeginSponsoringFutureReservesResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -21848,7 +21849,7 @@ impl WriteXdr for BeginSponsoringFutureReservesResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -21952,7 +21953,7 @@ impl WriteXdr for EndSponsoringFutureReservesResultCode {
 //    };
 //
 // union with discriminant EndSponsoringFutureReservesResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -22061,7 +22062,7 @@ impl WriteXdr for EndSponsoringFutureReservesResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -22183,7 +22184,7 @@ impl WriteXdr for RevokeSponsorshipResultCode {
 //    };
 //
 // union with discriminant RevokeSponsorshipResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -22314,7 +22315,7 @@ impl WriteXdr for RevokeSponsorshipResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -22431,7 +22432,7 @@ impl WriteXdr for ClawbackResultCode {
 //    };
 //
 // union with discriminant ClawbackResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -22554,7 +22555,7 @@ impl WriteXdr for ClawbackResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -22668,7 +22669,7 @@ impl WriteXdr for ClawbackClaimableBalanceResultCode {
 //    };
 //
 // union with discriminant ClawbackClaimableBalanceResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -22790,7 +22791,7 @@ impl WriteXdr for ClawbackClaimableBalanceResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -22912,7 +22913,7 @@ impl WriteXdr for SetTrustLineFlagsResultCode {
 //    };
 //
 // union with discriminant SetTrustLineFlagsResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -23050,7 +23051,7 @@ impl WriteXdr for SetTrustLineFlagsResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -23183,7 +23184,7 @@ impl WriteXdr for LiquidityPoolDepositResultCode {
 //    };
 //
 // union with discriminant LiquidityPoolDepositResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -23331,7 +23332,7 @@ impl WriteXdr for LiquidityPoolDepositResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -23454,7 +23455,7 @@ impl WriteXdr for LiquidityPoolWithdrawResultCode {
 //    };
 //
 // union with discriminant LiquidityPoolWithdrawResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -23586,7 +23587,7 @@ impl WriteXdr for LiquidityPoolWithdrawResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -23752,7 +23753,7 @@ impl WriteXdr for OperationResultCode {
 //        }
 //
 // union with discriminant OperationType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -24070,7 +24071,7 @@ impl WriteXdr for OperationResultTr {
 //    };
 //
 // union with discriminant OperationResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -24221,7 +24222,7 @@ impl WriteXdr for OperationResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -24403,7 +24404,7 @@ impl WriteXdr for TransactionResultCode {
 //        }
 //
 // union with discriminant TransactionResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -24591,7 +24592,7 @@ impl WriteXdr for InnerTransactionResultResult {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -24715,7 +24716,7 @@ impl WriteXdr for InnerTransactionResultExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -24756,7 +24757,7 @@ impl WriteXdr for InnerTransactionResult {
 //        InnerTransactionResult result; // result for the inner transaction
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -24815,7 +24816,7 @@ impl WriteXdr for InnerTransactionResultPair {
 //        }
 //
 // union with discriminant TransactionResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -25019,7 +25020,7 @@ impl WriteXdr for TransactionResultResult {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -25144,7 +25145,7 @@ impl WriteXdr for TransactionResultExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -25181,7 +25182,7 @@ impl WriteXdr for TransactionResult {
 //
 //   typedef opaque Hash[32];
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -25267,7 +25268,7 @@ impl AsRef<[u8]> for Hash {
 //
 //   typedef opaque uint256[32];
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -25382,7 +25383,7 @@ pub type Int64 = i64;
 //    };
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -25479,7 +25480,7 @@ impl WriteXdr for ExtensionPoint {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -25590,7 +25591,7 @@ impl WriteXdr for CryptoKeyType {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -25686,7 +25687,7 @@ impl WriteXdr for PublicKeyType {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -25794,7 +25795,7 @@ impl WriteXdr for SignerKeyType {
 //    };
 //
 // union with discriminant PublicKeyType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -25889,7 +25890,7 @@ impl WriteXdr for PublicKey {
 //            opaque payload<64>;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -25942,7 +25943,7 @@ impl WriteXdr for SignerKeyEd25519SignedPayload {
 //    };
 //
 // union with discriminant SignerKeyType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -26051,7 +26052,7 @@ impl WriteXdr for SignerKey {
 //
 //   typedef opaque Signature<64>;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -26149,7 +26150,7 @@ impl AsRef<[u8]> for Signature {
 //
 //   typedef opaque SignatureHint[4];
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -26235,7 +26236,7 @@ impl AsRef<[u8]> for SignatureHint {
 //
 //   typedef PublicKey NodeID;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -26287,7 +26288,7 @@ impl WriteXdr for NodeId {
 //        opaque key[32];
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -26321,7 +26322,7 @@ impl WriteXdr for Curve25519Secret {
 //        opaque key[32];
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -26355,7 +26356,7 @@ impl WriteXdr for Curve25519Public {
 //        opaque key[32];
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -26389,7 +26390,7 @@ impl WriteXdr for HmacSha256Key {
 //        opaque mac[32];
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),

--- a/src/curr.rs
+++ b/src/curr.rs
@@ -36,7 +36,6 @@ pub const XDR_FILES_SHA256: [(&str, &str); 6] = [
     ),
 ];
 
-use arbitrary::Arbitrary;
 use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref, slice};
 
 #[cfg(feature = "std")]
@@ -68,6 +67,9 @@ use alloc::{
 };
 #[cfg(all(feature = "std"))]
 use std::string::FromUtf8Error;
+
+#[cfg(feature = "arbitrary")]
+use arbitrary::Arbitrary;
 
 // TODO: Add support for read/write xdr fns when std not available.
 
@@ -542,12 +544,14 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 }
 
 #[cfg(feature = "alloc")]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
 #[cfg(not(feature = "alloc"))]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>)
 where
     T: 'static;
@@ -991,7 +995,9 @@ mod tests {
 //
 //   typedef opaque Value<>;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[derive(Default)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1093,7 +1099,8 @@ impl AsRef<[u8]> for Value {
 //        Value value;    // x
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1134,7 +1141,8 @@ impl WriteXdr for ScpBallot {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1242,7 +1250,8 @@ impl WriteXdr for ScpStatementType {
 //        Value accepted<>;   // Y
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1287,7 +1296,8 @@ impl WriteXdr for ScpNomination {
 //                uint32 nH;                // h.n
 //            }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1340,7 +1350,8 @@ impl WriteXdr for ScpStatementPrepare {
 //                Hash quorumSetHash; // D
 //            }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1388,7 +1399,8 @@ impl WriteXdr for ScpStatementConfirm {
 //                Hash commitQuorumSetHash; // D used before EXTERNALIZE
 //            }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1456,7 +1468,8 @@ impl WriteXdr for ScpStatementExternalize {
 //        }
 //
 // union with discriminant ScpStatementType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1602,7 +1615,8 @@ impl WriteXdr for ScpStatementPledges {
 //        pledges;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1643,7 +1657,8 @@ impl WriteXdr for ScpStatement {
 //        Signature signature;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1682,7 +1697,8 @@ impl WriteXdr for ScpEnvelope {
 //        SCPQuorumSet innerSets<>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1719,7 +1735,8 @@ impl WriteXdr for ScpQuorumSet {
 //
 //   typedef PublicKey AccountID;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1768,7 +1785,8 @@ impl WriteXdr for AccountId {
 //
 //   typedef opaque Thresholds[4];
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1866,7 +1884,8 @@ pub type String64 = VecM<u8, 64>;
 //
 //   typedef int64 SequenceNumber;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1915,7 +1934,8 @@ impl WriteXdr for SequenceNumber {
 //
 //   typedef uint64 TimePoint;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1964,7 +1984,8 @@ impl WriteXdr for TimePoint {
 //
 //   typedef uint64 Duration;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2013,7 +2034,9 @@ impl WriteXdr for Duration {
 //
 //   typedef opaque DataValue<64>;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[derive(Default)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2111,7 +2134,8 @@ impl AsRef<[u8]> for DataValue {
 //
 //   typedef Hash PoolID;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2160,7 +2184,8 @@ impl WriteXdr for PoolId {
 //
 //   typedef opaque AssetCode4[4];
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2246,7 +2271,8 @@ impl AsRef<[u8]> for AssetCode4 {
 //
 //   typedef opaque AssetCode12[12];
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2339,7 +2365,8 @@ impl AsRef<[u8]> for AssetCode12 {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2452,7 +2479,8 @@ impl WriteXdr for AssetType {
 //    };
 //
 // union with discriminant AssetType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2548,7 +2576,8 @@ impl WriteXdr for AssetCode {
 //        AccountID issuer;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2586,7 +2615,8 @@ impl WriteXdr for AlphaNum4 {
 //        AccountID issuer;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2633,7 +2663,8 @@ impl WriteXdr for AlphaNum12 {
 //    };
 //
 // union with discriminant AssetType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2738,7 +2769,8 @@ impl WriteXdr for Asset {
 //        int32 d; // denominator
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2776,7 +2808,8 @@ impl WriteXdr for Price {
 //        int64 selling;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2817,7 +2850,8 @@ impl WriteXdr for Liabilities {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2929,7 +2963,8 @@ impl WriteXdr for ThresholdIndexes {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3044,7 +3079,8 @@ impl WriteXdr for LedgerEntryType {
 //        uint32 weight; // really only need 1 byte
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3095,7 +3131,8 @@ impl WriteXdr for Signer {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3216,7 +3253,8 @@ pub const MAX_SIGNERS: u64 = 20;
 //
 //   typedef AccountID* SponsorshipDescriptor;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3276,7 +3314,8 @@ impl WriteXdr for SponsorshipDescriptor {
 //        TimePoint seqTime;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3320,7 +3359,8 @@ impl WriteXdr for AccountEntryExtensionV3 {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3426,7 +3466,8 @@ impl WriteXdr for AccountEntryExtensionV2Ext {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3473,7 +3514,8 @@ impl WriteXdr for AccountEntryExtensionV2 {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3577,7 +3619,8 @@ impl WriteXdr for AccountEntryExtensionV1Ext {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3618,7 +3661,8 @@ impl WriteXdr for AccountEntryExtensionV1 {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3737,7 +3781,8 @@ impl WriteXdr for AccountEntryExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3806,7 +3851,8 @@ impl WriteXdr for AccountEntry {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3927,7 +3973,8 @@ pub const MASK_TRUSTLINE_FLAGS_V17: u64 = 7;
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -4032,7 +4079,8 @@ impl WriteXdr for LiquidityPoolType {
 //    };
 //
 // union with discriminant AssetType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -4144,7 +4192,8 @@ impl WriteXdr for TrustLineAsset {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -4241,7 +4290,8 @@ impl WriteXdr for TrustLineEntryExtensionV2Ext {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -4282,7 +4332,8 @@ impl WriteXdr for TrustLineEntryExtensionV2 {
 //                }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -4386,7 +4437,8 @@ impl WriteXdr for TrustLineEntryV1Ext {
 //                ext;
 //            }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -4439,7 +4491,8 @@ impl WriteXdr for TrustLineEntryV1 {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -4562,7 +4615,8 @@ impl WriteXdr for TrustLineEntryExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -4614,7 +4668,8 @@ impl WriteXdr for TrustLineEntry {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -4714,7 +4769,8 @@ pub const MASK_OFFERENTRY_FLAGS: u64 = 1;
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -4824,7 +4880,8 @@ impl WriteXdr for OfferEntryExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -4881,7 +4938,8 @@ impl WriteXdr for OfferEntry {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -4981,7 +5039,8 @@ impl WriteXdr for DataEntryExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -5030,7 +5089,8 @@ impl WriteXdr for DataEntry {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -5157,7 +5217,8 @@ impl WriteXdr for ClaimPredicateType {
 //    };
 //
 // union with discriminant ClaimPredicateType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -5280,7 +5341,8 @@ impl WriteXdr for ClaimPredicate {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -5373,7 +5435,8 @@ impl WriteXdr for ClaimantType {
 //            ClaimPredicate predicate; // Claimable if predicate is true
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -5416,7 +5479,8 @@ impl WriteXdr for ClaimantV0 {
 //    };
 //
 // union with discriminant ClaimantType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -5507,7 +5571,8 @@ impl WriteXdr for Claimant {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -5602,7 +5667,8 @@ impl WriteXdr for ClaimableBalanceIdType {
 //    };
 //
 // union with discriminant ClaimableBalanceIdType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -5698,7 +5764,8 @@ impl WriteXdr for ClaimableBalanceId {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -5799,7 +5866,8 @@ pub const MASK_CLAIMABLE_BALANCE_FLAGS: u64 = 0x1;
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -5896,7 +5964,8 @@ impl WriteXdr for ClaimableBalanceEntryExtensionV1Ext {
 //        uint32 flags; // see ClaimableBalanceFlags
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -5937,7 +6006,8 @@ impl WriteXdr for ClaimableBalanceEntryExtensionV1 {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6052,7 +6122,8 @@ impl WriteXdr for ClaimableBalanceEntryExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6100,7 +6171,8 @@ impl WriteXdr for ClaimableBalanceEntry {
 //        int32 fee; // Fee is in basis points, so the actual rate is (fee/100)%
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6146,7 +6218,8 @@ impl WriteXdr for LiquidityPoolConstantProductParameters {
 //                                                // associated pool shares
 //            }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6203,7 +6276,8 @@ impl WriteXdr for LiquidityPoolEntryConstantProduct {
 //        }
 //
 // union with discriminant LiquidityPoolType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6313,7 +6387,8 @@ impl WriteXdr for LiquidityPoolEntryBody {
 //        body;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6352,7 +6427,8 @@ impl WriteXdr for LiquidityPoolEntry {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6449,7 +6525,8 @@ impl WriteXdr for LedgerEntryExtensionV1Ext {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6498,7 +6575,8 @@ impl WriteXdr for LedgerEntryExtensionV1 {
 //        }
 //
 // union with discriminant LedgerEntryType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6626,7 +6704,8 @@ impl WriteXdr for LedgerEntryData {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6748,7 +6827,8 @@ impl WriteXdr for LedgerEntryExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6788,7 +6868,8 @@ impl WriteXdr for LedgerEntry {
 //            AccountID accountID;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6823,7 +6904,8 @@ impl WriteXdr for LedgerKeyAccount {
 //            TrustLineAsset asset;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6861,7 +6943,8 @@ impl WriteXdr for LedgerKeyTrustLine {
 //            int64 offerID;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6899,7 +6982,8 @@ impl WriteXdr for LedgerKeyOffer {
 //            string64 dataName;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6936,7 +7020,8 @@ impl WriteXdr for LedgerKeyData {
 //            ClaimableBalanceID balanceID;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6970,7 +7055,8 @@ impl WriteXdr for LedgerKeyClaimableBalance {
 //            PoolID liquidityPoolID;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7042,7 +7128,8 @@ impl WriteXdr for LedgerKeyLiquidityPool {
 //    };
 //
 // union with discriminant LedgerEntryType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7176,7 +7263,8 @@ impl WriteXdr for LedgerKey {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7295,7 +7383,9 @@ impl WriteXdr for EnvelopeType {
 //
 //   typedef opaque UpgradeType<128>;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[derive(Default)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7398,7 +7488,8 @@ impl AsRef<[u8]> for UpgradeType {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7494,7 +7585,8 @@ impl WriteXdr for StellarValueType {
 //        Signature signature; // nodeID's signature
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7535,7 +7627,8 @@ impl WriteXdr for LedgerCloseValueSignature {
 //        }
 //
 // union with discriminant StellarValueType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7648,7 +7741,8 @@ impl WriteXdr for StellarValueExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7700,7 +7794,8 @@ pub const MASK_LEDGER_HEADER_FLAGS: u64 = 0x7;
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7804,7 +7899,8 @@ impl WriteXdr for LedgerHeaderFlags {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7901,7 +7997,8 @@ impl WriteXdr for LedgerHeaderExtensionV1Ext {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7942,7 +8039,8 @@ impl WriteXdr for LedgerHeaderExtensionV1 {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -8072,7 +8170,8 @@ impl WriteXdr for LedgerHeaderExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -8153,7 +8252,8 @@ impl WriteXdr for LedgerHeader {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -8273,7 +8373,8 @@ impl WriteXdr for LedgerUpgradeType {
 //    };
 //
 // union with discriminant LedgerUpgradeType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -8395,7 +8496,8 @@ impl WriteXdr for LedgerUpgrade {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -8503,7 +8605,8 @@ impl WriteXdr for BucketEntryType {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -8602,7 +8705,8 @@ impl WriteXdr for BucketMetadataExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -8647,7 +8751,8 @@ impl WriteXdr for BucketMetadata {
 //    };
 //
 // union with discriminant BucketEntryType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -8760,7 +8865,8 @@ impl WriteXdr for BucketEntry {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -8854,7 +8960,8 @@ impl WriteXdr for TxSetComponentType {
 //        TransactionEnvelope txs<>;
 //      }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -8897,7 +9004,8 @@ impl WriteXdr for TxSetComponentTxsMaybeDiscountedFee {
 //    };
 //
 // union with discriminant TxSetComponentType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -8996,7 +9104,8 @@ impl WriteXdr for TxSetComponent {
 //    };
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9087,7 +9196,8 @@ impl WriteXdr for TransactionPhase {
 //        TransactionEnvelope txs<>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9125,7 +9235,8 @@ impl WriteXdr for TransactionSet {
 //        TransactionPhase phases<>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9165,7 +9276,8 @@ impl WriteXdr for TransactionSetV1 {
 //    };
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9256,7 +9368,8 @@ impl WriteXdr for GeneralizedTransactionSet {
 //        TransactionResult result; // result for the transaction
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9293,7 +9406,8 @@ impl WriteXdr for TransactionResultPair {
 //        TransactionResultPair results<>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9331,7 +9445,8 @@ impl WriteXdr for TransactionResultSet {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9437,7 +9552,8 @@ impl WriteXdr for TransactionHistoryEntryExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9479,7 +9595,8 @@ impl WriteXdr for TransactionHistoryEntry {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9578,7 +9695,8 @@ impl WriteXdr for TransactionHistoryResultEntryExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9620,7 +9738,8 @@ impl WriteXdr for TransactionHistoryResultEntry {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9719,7 +9838,8 @@ impl WriteXdr for LedgerHeaderHistoryEntryExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9760,7 +9880,8 @@ impl WriteXdr for LedgerHeaderHistoryEntry {
 //        SCPEnvelope messages<>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9798,7 +9919,8 @@ impl WriteXdr for LedgerScpMessages {
 //        LedgerSCPMessages ledgerMessages;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9837,7 +9959,8 @@ impl WriteXdr for ScpHistoryEntryV0 {
 //    };
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9931,7 +10054,8 @@ impl WriteXdr for ScpHistoryEntry {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10045,7 +10169,8 @@ impl WriteXdr for LedgerEntryChangeType {
 //    };
 //
 // union with discriminant LedgerEntryChangeType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10152,7 +10277,9 @@ impl WriteXdr for LedgerEntryChange {
 //
 //   typedef LedgerEntryChange LedgerEntryChanges<>;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[derive(Default)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10253,7 +10380,8 @@ impl AsRef<[LedgerEntryChange]> for LedgerEntryChanges {
 //        LedgerEntryChanges changes;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10288,7 +10416,8 @@ impl WriteXdr for OperationMeta {
 //        OperationMeta operations<>;   // meta for each operation
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10329,7 +10458,8 @@ impl WriteXdr for TransactionMetaV1 {
 //                                            // applied if any
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10375,7 +10505,8 @@ impl WriteXdr for TransactionMetaV2 {
 //    };
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10477,7 +10608,8 @@ impl WriteXdr for TransactionMeta {
 //        TransactionMeta txApplyProcessing;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10518,7 +10650,8 @@ impl WriteXdr for TransactionResultMeta {
 //        LedgerEntryChanges changes;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10568,7 +10701,8 @@ impl WriteXdr for UpgradeEntryMeta {
 //        SCPHistoryEntry scpInfo<>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10627,7 +10761,8 @@ impl WriteXdr for LedgerCloseMetaV0 {
 //        SCPHistoryEntry scpInfo<>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10677,7 +10812,8 @@ impl WriteXdr for LedgerCloseMetaV1 {
 //    };
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10777,7 +10913,8 @@ impl WriteXdr for LedgerCloseMeta {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10888,7 +11025,8 @@ impl WriteXdr for ErrorCode {
 //        string msg<100>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10925,7 +11063,8 @@ impl WriteXdr for SError {
 //        uint32 numMessages;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10961,7 +11100,8 @@ impl WriteXdr for SendMore {
 //        Signature sig;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11009,7 +11149,8 @@ impl WriteXdr for AuthCert {
 //        uint256 nonce;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11069,7 +11210,8 @@ impl WriteXdr for Hello {
 //        int unused;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11105,7 +11247,8 @@ impl WriteXdr for Auth {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11204,7 +11347,8 @@ impl WriteXdr for IpAddrType {
 //        }
 //
 // union with discriminant IpAddrType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11308,7 +11452,8 @@ impl WriteXdr for PeerAddressIp {
 //        uint32 numFailures;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11374,7 +11519,8 @@ impl WriteXdr for PeerAddress {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11533,7 +11679,8 @@ impl WriteXdr for MessageType {
 //        uint256 reqHash;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11571,7 +11718,8 @@ impl WriteXdr for DontHave {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11667,7 +11815,8 @@ impl WriteXdr for SurveyMessageCommandType {
 //        SurveyMessageCommandType commandType;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11714,7 +11863,8 @@ impl WriteXdr for SurveyRequestMessage {
 //        SurveyRequestMessage request;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11748,7 +11898,9 @@ impl WriteXdr for SignedSurveyRequestMessage {
 //
 //   typedef opaque EncryptedBody<64000>;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[derive(Default)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11853,7 +12005,8 @@ impl AsRef<[u8]> for EncryptedBody {
 //        EncryptedBody encryptedBody;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11900,7 +12053,8 @@ impl WriteXdr for SurveyResponseMessage {
 //        SurveyResponseMessage response;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11953,7 +12107,8 @@ impl WriteXdr for SignedSurveyResponseMessage {
 //        uint64 duplicateFetchMessageRecv;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12026,7 +12181,9 @@ impl WriteXdr for PeerStats {
 //
 //   typedef PeerStats PeerStatList<25>;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[derive(Default)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12131,7 +12288,8 @@ impl AsRef<[PeerStats]> for PeerStatList {
 //        uint32 totalOutboundPeerCount;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12176,7 +12334,8 @@ impl WriteXdr for TopologyResponseBody {
 //    };
 //
 // union with discriminant SurveyMessageCommandType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12308,7 +12467,8 @@ impl WriteXdr for SurveyResponseBody {
 //    };
 //
 // union with discriminant MessageType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12504,7 +12664,8 @@ impl WriteXdr for StellarMessage {
 //            HmacSha256Mac mac;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12551,7 +12712,8 @@ impl WriteXdr for AuthenticatedMessageV0 {
 //    };
 //
 // union with discriminant u32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12643,7 +12805,8 @@ impl WriteXdr for AuthenticatedMessage {
 //    };
 //
 // union with discriminant LiquidityPoolType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12738,7 +12901,8 @@ impl WriteXdr for LiquidityPoolParameters {
 //            uint256 ed25519;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12783,7 +12947,8 @@ impl WriteXdr for MuxedAccountMed25519 {
 //    };
 //
 // union with discriminant CryptoKeyType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12879,7 +13044,8 @@ impl WriteXdr for MuxedAccount {
 //        Signature signature; // actual signature
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12940,7 +13106,8 @@ impl WriteXdr for DecoratedSignature {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13127,7 +13294,8 @@ impl WriteXdr for OperationType {
 //        int64 startingBalance; // amount they end up with
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13166,7 +13334,8 @@ impl WriteXdr for CreateAccountOp {
 //        int64 amount;             // amount they end up with
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13215,7 +13384,8 @@ impl WriteXdr for PaymentOp {
 //        Asset path<5>; // additional hops it must go through to get there
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13273,7 +13443,8 @@ impl WriteXdr for PathPaymentStrictReceiveOp {
 //        Asset path<5>; // additional hops it must go through to get there
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13328,7 +13499,8 @@ impl WriteXdr for PathPaymentStrictSendOp {
 //        int64 offerID;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13381,7 +13553,8 @@ impl WriteXdr for ManageSellOfferOp {
 //        int64 offerID;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13430,7 +13603,8 @@ impl WriteXdr for ManageBuyOfferOp {
 //        Price price;   // cost of A in terms of B
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13488,7 +13662,8 @@ impl WriteXdr for CreatePassiveSellOfferOp {
 //        Signer* signer;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13559,7 +13734,8 @@ impl WriteXdr for SetOptionsOp {
 //    };
 //
 // union with discriminant AssetType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13672,7 +13848,8 @@ impl WriteXdr for ChangeTrustAsset {
 //        int64 limit;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13713,7 +13890,8 @@ impl WriteXdr for ChangeTrustOp {
 //        uint32 authorize;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13754,7 +13932,8 @@ impl WriteXdr for AllowTrustOp {
 //        DataValue* dataValue; // set to null to clear
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13791,7 +13970,8 @@ impl WriteXdr for ManageDataOp {
 //        SequenceNumber bumpTo;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13827,7 +14007,8 @@ impl WriteXdr for BumpSequenceOp {
 //        Claimant claimants<10>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13867,7 +14048,8 @@ impl WriteXdr for CreateClaimableBalanceOp {
 //        ClaimableBalanceID balanceID;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13901,7 +14083,8 @@ impl WriteXdr for ClaimClaimableBalanceOp {
 //        AccountID sponsoredID;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13937,7 +14120,8 @@ impl WriteXdr for BeginSponsoringFutureReservesOp {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14036,7 +14220,8 @@ impl WriteXdr for RevokeSponsorshipType {
 //            SignerKey signerKey;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14081,7 +14266,8 @@ impl WriteXdr for RevokeSponsorshipOpSigner {
 //    };
 //
 // union with discriminant RevokeSponsorshipType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14181,7 +14367,8 @@ impl WriteXdr for RevokeSponsorshipOp {
 //        int64 amount;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14221,7 +14408,8 @@ impl WriteXdr for ClawbackOp {
 //        ClaimableBalanceID balanceID;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14259,7 +14447,8 @@ impl WriteXdr for ClawbackClaimableBalanceOp {
 //        uint32 setFlags;   // which flags to set
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14312,7 +14501,8 @@ pub const LIQUIDITY_POOL_FEE_V18: u64 = 30;
 //        Price maxPrice;   // maximum depositA/depositB
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14361,7 +14551,8 @@ impl WriteXdr for LiquidityPoolDepositOp {
 //        int64 minAmountB; // minimum amount of second asset to withdraw
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14452,7 +14643,8 @@ impl WriteXdr for LiquidityPoolWithdrawOp {
 //        }
 //
 // union with discriminant OperationType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14762,7 +14954,8 @@ impl WriteXdr for OperationBody {
 //        body;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14801,7 +14994,8 @@ impl WriteXdr for Operation {
 //            uint32 opNum;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14845,7 +15039,8 @@ impl WriteXdr for HashIdPreimageOperationId {
 //            Asset asset;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14907,7 +15102,8 @@ impl WriteXdr for HashIdPreimageRevokeId {
 //    };
 //
 // union with discriminant EnvelopeType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15009,7 +15205,8 @@ impl WriteXdr for HashIdPreimage {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15129,7 +15326,8 @@ impl WriteXdr for MemoType {
 //    };
 //
 // union with discriminant MemoType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15246,7 +15444,8 @@ impl WriteXdr for Memo {
 //        TimePoint maxTime; // 0 here means no maxTime
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15284,7 +15483,8 @@ impl WriteXdr for TimeBounds {
 //        uint32 maxLedger; // 0 here means no maxLedger
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15349,7 +15549,8 @@ impl WriteXdr for LedgerBounds {
 //        SignerKey extraSigners<2>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15401,7 +15602,8 @@ impl WriteXdr for PreconditionsV2 {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15509,7 +15711,8 @@ impl WriteXdr for PreconditionType {
 //    };
 //
 // union with discriminant PreconditionType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15621,7 +15824,8 @@ pub const MAX_OPS_PER_TX: u64 = 100;
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15722,7 +15926,8 @@ impl WriteXdr for TransactionV0Ext {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15777,7 +15982,8 @@ impl WriteXdr for TransactionV0 {
 //        DecoratedSignature signatures<20>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15816,7 +16022,8 @@ impl WriteXdr for TransactionV0Envelope {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15928,7 +16135,8 @@ impl WriteXdr for TransactionExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15983,7 +16191,8 @@ impl WriteXdr for Transaction {
 //        DecoratedSignature signatures<20>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16022,7 +16231,8 @@ impl WriteXdr for TransactionV1Envelope {
 //        }
 //
 // union with discriminant EnvelopeType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16114,7 +16324,8 @@ impl WriteXdr for FeeBumpTransactionInnerTx {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16217,7 +16428,8 @@ impl WriteXdr for FeeBumpTransactionExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16263,7 +16475,8 @@ impl WriteXdr for FeeBumpTransaction {
 //        DecoratedSignature signatures<20>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16306,7 +16519,8 @@ impl WriteXdr for FeeBumpTransactionEnvelope {
 //    };
 //
 // union with discriminant EnvelopeType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16415,7 +16629,8 @@ impl WriteXdr for TransactionEnvelope {
 //        }
 //
 // union with discriminant EnvelopeType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16520,7 +16735,8 @@ impl WriteXdr for TransactionSignaturePayloadTaggedTransaction {
 //        taggedTransaction;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16560,7 +16776,8 @@ impl WriteXdr for TransactionSignaturePayload {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16672,7 +16889,8 @@ impl WriteXdr for ClaimAtomType {
 //        int64 amountBought;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16731,7 +16949,8 @@ impl WriteXdr for ClaimOfferAtomV0 {
 //        int64 amountBought;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16788,7 +17007,8 @@ impl WriteXdr for ClaimOfferAtom {
 //        int64 amountBought;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16840,7 +17060,8 @@ impl WriteXdr for ClaimLiquidityAtom {
 //    };
 //
 // union with discriminant ClaimAtomType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16953,7 +17174,8 @@ impl WriteXdr for ClaimAtom {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -17070,7 +17292,8 @@ impl WriteXdr for CreateAccountResultCode {
 //    };
 //
 // union with discriminant CreateAccountResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -17199,7 +17422,8 @@ impl WriteXdr for CreateAccountResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -17341,7 +17565,8 @@ impl WriteXdr for PaymentResultCode {
 //    };
 //
 // union with discriminant PaymentResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -17512,7 +17737,8 @@ impl WriteXdr for PaymentResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -17657,7 +17883,8 @@ impl WriteXdr for PathPaymentStrictReceiveResultCode {
 //        int64 amount;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -17698,7 +17925,8 @@ impl WriteXdr for SimplePaymentResult {
 //            SimplePaymentResult last;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -17757,7 +17985,8 @@ impl WriteXdr for PathPaymentStrictReceiveResultSuccess {
 //    };
 //
 // union with discriminant PathPaymentStrictReceiveResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -17949,7 +18178,8 @@ impl WriteXdr for PathPaymentStrictReceiveResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -18093,7 +18323,8 @@ impl WriteXdr for PathPaymentStrictSendResultCode {
 //            SimplePaymentResult last;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -18151,7 +18382,8 @@ impl WriteXdr for PathPaymentStrictSendResultSuccess {
 //    };
 //
 // union with discriminant PathPaymentStrictSendResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -18342,7 +18574,8 @@ impl WriteXdr for PathPaymentStrictSendResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -18487,7 +18720,8 @@ impl WriteXdr for ManageSellOfferResultCode {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -18594,7 +18828,8 @@ impl WriteXdr for ManageOfferEffect {
 //        }
 //
 // union with discriminant ManageOfferEffect
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -18709,7 +18944,8 @@ impl WriteXdr for ManageOfferSuccessResultOffer {
 //        offer;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -18761,7 +18997,8 @@ impl WriteXdr for ManageOfferSuccessResult {
 //    };
 //
 // union with discriminant ManageSellOfferResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -18947,7 +19184,8 @@ impl WriteXdr for ManageSellOfferResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -19104,7 +19342,8 @@ impl WriteXdr for ManageBuyOfferResultCode {
 //    };
 //
 // union with discriminant ManageBuyOfferResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -19284,7 +19523,8 @@ impl WriteXdr for ManageBuyOfferResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -19431,7 +19671,8 @@ impl WriteXdr for SetOptionsResultCode {
 //    };
 //
 // union with discriminant SetOptionsResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -19598,7 +19839,8 @@ impl WriteXdr for SetOptionsResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -19735,7 +19977,8 @@ impl WriteXdr for ChangeTrustResultCode {
 //    };
 //
 // union with discriminant ChangeTrustResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -19886,7 +20129,8 @@ impl WriteXdr for ChangeTrustResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -20013,7 +20257,8 @@ impl WriteXdr for AllowTrustResultCode {
 //    };
 //
 // union with discriminant AllowTrustResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -20152,7 +20397,8 @@ impl WriteXdr for AllowTrustResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -20284,7 +20530,8 @@ impl WriteXdr for AccountMergeResultCode {
 //    };
 //
 // union with discriminant AccountMergeResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -20422,7 +20669,8 @@ impl WriteXdr for AccountMergeResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -20519,7 +20767,8 @@ impl WriteXdr for InflationResultCode {
 //        int64 amount;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -20560,7 +20809,8 @@ impl WriteXdr for InflationPayout {
 //    };
 //
 // union with discriminant InflationResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -20665,7 +20915,8 @@ impl WriteXdr for InflationResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -20782,7 +21033,8 @@ impl WriteXdr for ManageDataResultCode {
 //    };
 //
 // union with discriminant ManageDataResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -20902,7 +21154,8 @@ impl WriteXdr for ManageDataResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -21004,7 +21257,8 @@ impl WriteXdr for BumpSequenceResultCode {
 //    };
 //
 // union with discriminant BumpSequenceResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -21108,7 +21362,8 @@ impl WriteXdr for BumpSequenceResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -21232,7 +21487,8 @@ impl WriteXdr for CreateClaimableBalanceResultCode {
 //    };
 //
 // union with discriminant CreateClaimableBalanceResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -21364,7 +21620,8 @@ impl WriteXdr for CreateClaimableBalanceResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -21487,7 +21744,8 @@ impl WriteXdr for ClaimClaimableBalanceResultCode {
 //    };
 //
 // union with discriminant ClaimClaimableBalanceResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -21618,7 +21876,8 @@ impl WriteXdr for ClaimClaimableBalanceResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -21732,7 +21991,8 @@ impl WriteXdr for BeginSponsoringFutureReservesResultCode {
 //    };
 //
 // union with discriminant BeginSponsoringFutureReservesResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -21849,7 +22109,8 @@ impl WriteXdr for BeginSponsoringFutureReservesResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -21953,7 +22214,8 @@ impl WriteXdr for EndSponsoringFutureReservesResultCode {
 //    };
 //
 // union with discriminant EndSponsoringFutureReservesResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -22062,7 +22324,8 @@ impl WriteXdr for EndSponsoringFutureReservesResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -22184,7 +22447,8 @@ impl WriteXdr for RevokeSponsorshipResultCode {
 //    };
 //
 // union with discriminant RevokeSponsorshipResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -22315,7 +22579,8 @@ impl WriteXdr for RevokeSponsorshipResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -22432,7 +22697,8 @@ impl WriteXdr for ClawbackResultCode {
 //    };
 //
 // union with discriminant ClawbackResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -22555,7 +22821,8 @@ impl WriteXdr for ClawbackResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -22669,7 +22936,8 @@ impl WriteXdr for ClawbackClaimableBalanceResultCode {
 //    };
 //
 // union with discriminant ClawbackClaimableBalanceResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -22791,7 +23059,8 @@ impl WriteXdr for ClawbackClaimableBalanceResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -22913,7 +23182,8 @@ impl WriteXdr for SetTrustLineFlagsResultCode {
 //    };
 //
 // union with discriminant SetTrustLineFlagsResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -23051,7 +23321,8 @@ impl WriteXdr for SetTrustLineFlagsResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -23184,7 +23455,8 @@ impl WriteXdr for LiquidityPoolDepositResultCode {
 //    };
 //
 // union with discriminant LiquidityPoolDepositResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -23332,7 +23604,8 @@ impl WriteXdr for LiquidityPoolDepositResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -23455,7 +23728,8 @@ impl WriteXdr for LiquidityPoolWithdrawResultCode {
 //    };
 //
 // union with discriminant LiquidityPoolWithdrawResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -23587,7 +23861,8 @@ impl WriteXdr for LiquidityPoolWithdrawResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -23753,7 +24028,8 @@ impl WriteXdr for OperationResultCode {
 //        }
 //
 // union with discriminant OperationType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -24071,7 +24347,8 @@ impl WriteXdr for OperationResultTr {
 //    };
 //
 // union with discriminant OperationResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -24222,7 +24499,8 @@ impl WriteXdr for OperationResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -24404,7 +24682,8 @@ impl WriteXdr for TransactionResultCode {
 //        }
 //
 // union with discriminant TransactionResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -24592,7 +24871,8 @@ impl WriteXdr for InnerTransactionResultResult {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -24716,7 +24996,8 @@ impl WriteXdr for InnerTransactionResultExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -24757,7 +25038,8 @@ impl WriteXdr for InnerTransactionResult {
 //        InnerTransactionResult result; // result for the inner transaction
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -24816,7 +25098,8 @@ impl WriteXdr for InnerTransactionResultPair {
 //        }
 //
 // union with discriminant TransactionResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -25020,7 +25303,8 @@ impl WriteXdr for TransactionResultResult {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -25145,7 +25429,8 @@ impl WriteXdr for TransactionResultExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -25182,7 +25467,8 @@ impl WriteXdr for TransactionResult {
 //
 //   typedef opaque Hash[32];
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -25268,7 +25554,8 @@ impl AsRef<[u8]> for Hash {
 //
 //   typedef opaque uint256[32];
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -25383,7 +25670,8 @@ pub type Int64 = i64;
 //    };
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -25480,7 +25768,8 @@ impl WriteXdr for ExtensionPoint {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -25591,7 +25880,8 @@ impl WriteXdr for CryptoKeyType {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -25687,7 +25977,8 @@ impl WriteXdr for PublicKeyType {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -25795,7 +26086,8 @@ impl WriteXdr for SignerKeyType {
 //    };
 //
 // union with discriminant PublicKeyType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -25890,7 +26182,8 @@ impl WriteXdr for PublicKey {
 //            opaque payload<64>;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -25943,7 +26236,8 @@ impl WriteXdr for SignerKeyEd25519SignedPayload {
 //    };
 //
 // union with discriminant SignerKeyType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -26052,7 +26346,9 @@ impl WriteXdr for SignerKey {
 //
 //   typedef opaque Signature<64>;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[derive(Default)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -26150,7 +26446,8 @@ impl AsRef<[u8]> for Signature {
 //
 //   typedef opaque SignatureHint[4];
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -26236,7 +26533,8 @@ impl AsRef<[u8]> for SignatureHint {
 //
 //   typedef PublicKey NodeID;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -26288,7 +26586,8 @@ impl WriteXdr for NodeId {
 //        opaque key[32];
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -26322,7 +26621,8 @@ impl WriteXdr for Curve25519Secret {
 //        opaque key[32];
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -26356,7 +26656,8 @@ impl WriteXdr for Curve25519Public {
 //        opaque key[32];
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -26390,7 +26691,8 @@ impl WriteXdr for HmacSha256Key {
 //        opaque mac[32];
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),

--- a/src/next.rs
+++ b/src/next.rs
@@ -51,7 +51,6 @@ pub const XDR_FILES_SHA256: [(&str, &str); 9] = [
     ),
 ];
 
-use arbitrary::Arbitrary;
 use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref, slice};
 
 #[cfg(feature = "std")]
@@ -83,6 +82,9 @@ use alloc::{
 };
 #[cfg(all(feature = "std"))]
 use std::string::FromUtf8Error;
+
+#[cfg(feature = "arbitrary")]
+use arbitrary::Arbitrary;
 
 // TODO: Add support for read/write xdr fns when std not available.
 
@@ -557,12 +559,14 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 }
 
 #[cfg(feature = "alloc")]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
 #[cfg(not(feature = "alloc"))]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>)
 where
     T: 'static;
@@ -1006,7 +1010,9 @@ mod tests {
 //
 //   typedef opaque Value<>;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[derive(Default)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1108,7 +1114,8 @@ impl AsRef<[u8]> for Value {
 //        Value value;    // x
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1149,7 +1156,8 @@ impl WriteXdr for ScpBallot {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1257,7 +1265,8 @@ impl WriteXdr for ScpStatementType {
 //        Value accepted<>;   // Y
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1302,7 +1311,8 @@ impl WriteXdr for ScpNomination {
 //                uint32 nH;                // h.n
 //            }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1355,7 +1365,8 @@ impl WriteXdr for ScpStatementPrepare {
 //                Hash quorumSetHash; // D
 //            }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1403,7 +1414,8 @@ impl WriteXdr for ScpStatementConfirm {
 //                Hash commitQuorumSetHash; // D used before EXTERNALIZE
 //            }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1471,7 +1483,8 @@ impl WriteXdr for ScpStatementExternalize {
 //        }
 //
 // union with discriminant ScpStatementType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1617,7 +1630,8 @@ impl WriteXdr for ScpStatementPledges {
 //        pledges;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1658,7 +1672,8 @@ impl WriteXdr for ScpStatement {
 //        Signature signature;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1697,7 +1712,8 @@ impl WriteXdr for ScpEnvelope {
 //        SCPQuorumSet innerSets<>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1734,7 +1750,8 @@ impl WriteXdr for ScpQuorumSet {
 //
 //   typedef PublicKey AccountID;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1783,7 +1800,8 @@ impl WriteXdr for AccountId {
 //
 //   typedef opaque Thresholds[4];
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1881,7 +1899,8 @@ pub type String64 = VecM<u8, 64>;
 //
 //   typedef int64 SequenceNumber;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1930,7 +1949,8 @@ impl WriteXdr for SequenceNumber {
 //
 //   typedef uint64 TimePoint;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1979,7 +1999,8 @@ impl WriteXdr for TimePoint {
 //
 //   typedef uint64 Duration;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2028,7 +2049,9 @@ impl WriteXdr for Duration {
 //
 //   typedef opaque DataValue<64>;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[derive(Default)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2126,7 +2149,8 @@ impl AsRef<[u8]> for DataValue {
 //
 //   typedef Hash PoolID;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2175,7 +2199,8 @@ impl WriteXdr for PoolId {
 //
 //   typedef opaque AssetCode4[4];
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2261,7 +2286,8 @@ impl AsRef<[u8]> for AssetCode4 {
 //
 //   typedef opaque AssetCode12[12];
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2354,7 +2380,8 @@ impl AsRef<[u8]> for AssetCode12 {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2467,7 +2494,8 @@ impl WriteXdr for AssetType {
 //    };
 //
 // union with discriminant AssetType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2563,7 +2591,8 @@ impl WriteXdr for AssetCode {
 //        AccountID issuer;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2601,7 +2630,8 @@ impl WriteXdr for AlphaNum4 {
 //        AccountID issuer;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2648,7 +2678,8 @@ impl WriteXdr for AlphaNum12 {
 //    };
 //
 // union with discriminant AssetType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2753,7 +2784,8 @@ impl WriteXdr for Asset {
 //        int32 d; // denominator
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2791,7 +2823,8 @@ impl WriteXdr for Price {
 //        int64 selling;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2832,7 +2865,8 @@ impl WriteXdr for Liabilities {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2946,7 +2980,8 @@ impl WriteXdr for ThresholdIndexes {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3069,7 +3104,8 @@ impl WriteXdr for LedgerEntryType {
 //        uint32 weight; // really only need 1 byte
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3120,7 +3156,8 @@ impl WriteXdr for Signer {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3241,7 +3278,8 @@ pub const MAX_SIGNERS: u64 = 20;
 //
 //   typedef AccountID* SponsorshipDescriptor;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3301,7 +3339,8 @@ impl WriteXdr for SponsorshipDescriptor {
 //        TimePoint seqTime;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3345,7 +3384,8 @@ impl WriteXdr for AccountEntryExtensionV3 {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3451,7 +3491,8 @@ impl WriteXdr for AccountEntryExtensionV2Ext {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3498,7 +3539,8 @@ impl WriteXdr for AccountEntryExtensionV2 {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3602,7 +3644,8 @@ impl WriteXdr for AccountEntryExtensionV1Ext {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3643,7 +3686,8 @@ impl WriteXdr for AccountEntryExtensionV1 {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3762,7 +3806,8 @@ impl WriteXdr for AccountEntryExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3831,7 +3876,8 @@ impl WriteXdr for AccountEntry {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3952,7 +3998,8 @@ pub const MASK_TRUSTLINE_FLAGS_V17: u64 = 7;
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -4057,7 +4104,8 @@ impl WriteXdr for LiquidityPoolType {
 //    };
 //
 // union with discriminant AssetType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -4169,7 +4217,8 @@ impl WriteXdr for TrustLineAsset {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -4266,7 +4315,8 @@ impl WriteXdr for TrustLineEntryExtensionV2Ext {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -4307,7 +4357,8 @@ impl WriteXdr for TrustLineEntryExtensionV2 {
 //                }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -4411,7 +4462,8 @@ impl WriteXdr for TrustLineEntryV1Ext {
 //                ext;
 //            }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -4464,7 +4516,8 @@ impl WriteXdr for TrustLineEntryV1 {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -4587,7 +4640,8 @@ impl WriteXdr for TrustLineEntryExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -4639,7 +4693,8 @@ impl WriteXdr for TrustLineEntry {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -4739,7 +4794,8 @@ pub const MASK_OFFERENTRY_FLAGS: u64 = 1;
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -4849,7 +4905,8 @@ impl WriteXdr for OfferEntryExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -4906,7 +4963,8 @@ impl WriteXdr for OfferEntry {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -5006,7 +5064,8 @@ impl WriteXdr for DataEntryExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -5055,7 +5114,8 @@ impl WriteXdr for DataEntry {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -5182,7 +5242,8 @@ impl WriteXdr for ClaimPredicateType {
 //    };
 //
 // union with discriminant ClaimPredicateType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -5305,7 +5366,8 @@ impl WriteXdr for ClaimPredicate {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -5398,7 +5460,8 @@ impl WriteXdr for ClaimantType {
 //            ClaimPredicate predicate; // Claimable if predicate is true
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -5441,7 +5504,8 @@ impl WriteXdr for ClaimantV0 {
 //    };
 //
 // union with discriminant ClaimantType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -5532,7 +5596,8 @@ impl WriteXdr for Claimant {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -5627,7 +5692,8 @@ impl WriteXdr for ClaimableBalanceIdType {
 //    };
 //
 // union with discriminant ClaimableBalanceIdType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -5723,7 +5789,8 @@ impl WriteXdr for ClaimableBalanceId {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -5824,7 +5891,8 @@ pub const MASK_CLAIMABLE_BALANCE_FLAGS: u64 = 0x1;
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -5921,7 +5989,8 @@ impl WriteXdr for ClaimableBalanceEntryExtensionV1Ext {
 //        uint32 flags; // see ClaimableBalanceFlags
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -5962,7 +6031,8 @@ impl WriteXdr for ClaimableBalanceEntryExtensionV1 {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6077,7 +6147,8 @@ impl WriteXdr for ClaimableBalanceEntryExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6125,7 +6196,8 @@ impl WriteXdr for ClaimableBalanceEntry {
 //        int32 fee; // Fee is in basis points, so the actual rate is (fee/100)%
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6171,7 +6243,8 @@ impl WriteXdr for LiquidityPoolConstantProductParameters {
 //                                                // associated pool shares
 //            }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6228,7 +6301,8 @@ impl WriteXdr for LiquidityPoolEntryConstantProduct {
 //        }
 //
 // union with discriminant LiquidityPoolType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6338,7 +6412,8 @@ impl WriteXdr for LiquidityPoolEntryBody {
 //        body;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6376,7 +6451,8 @@ impl WriteXdr for LiquidityPoolEntry {
 //        SCVal val;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6417,7 +6493,8 @@ impl WriteXdr for ContractDataEntry {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6511,7 +6588,8 @@ impl WriteXdr for ConfigSettingType {
 //    };
 //
 // union with discriminant ConfigSettingType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6604,7 +6682,8 @@ impl WriteXdr for ConfigSetting {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6698,7 +6777,8 @@ impl WriteXdr for ConfigSettingId {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6796,7 +6876,8 @@ impl WriteXdr for ConfigSettingEntryExt {
 //        ConfigSetting setting;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6838,7 +6919,8 @@ impl WriteXdr for ConfigSettingEntry {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6935,7 +7017,8 @@ impl WriteXdr for LedgerEntryExtensionV1Ext {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6988,7 +7071,8 @@ impl WriteXdr for LedgerEntryExtensionV1 {
 //        }
 //
 // union with discriminant LedgerEntryType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7128,7 +7212,8 @@ impl WriteXdr for LedgerEntryData {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7254,7 +7339,8 @@ impl WriteXdr for LedgerEntryExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7294,7 +7380,8 @@ impl WriteXdr for LedgerEntry {
 //            AccountID accountID;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7329,7 +7416,8 @@ impl WriteXdr for LedgerKeyAccount {
 //            TrustLineAsset asset;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7367,7 +7455,8 @@ impl WriteXdr for LedgerKeyTrustLine {
 //            int64 offerID;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7405,7 +7494,8 @@ impl WriteXdr for LedgerKeyOffer {
 //            string64 dataName;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7442,7 +7532,8 @@ impl WriteXdr for LedgerKeyData {
 //            ClaimableBalanceID balanceID;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7476,7 +7567,8 @@ impl WriteXdr for LedgerKeyClaimableBalance {
 //            PoolID liquidityPoolID;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7511,7 +7603,8 @@ impl WriteXdr for LedgerKeyLiquidityPool {
 //            SCVal key;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7548,7 +7641,8 @@ impl WriteXdr for LedgerKeyContractData {
 //            ConfigSettingID configSettingID;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7631,7 +7725,8 @@ impl WriteXdr for LedgerKeyConfigSetting {
 //    };
 //
 // union with discriminant LedgerEntryType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7783,7 +7878,8 @@ impl WriteXdr for LedgerKey {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7910,7 +8006,9 @@ impl WriteXdr for EnvelopeType {
 //
 //   typedef opaque UpgradeType<128>;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[derive(Default)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -8013,7 +8111,8 @@ impl AsRef<[u8]> for UpgradeType {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -8109,7 +8208,8 @@ impl WriteXdr for StellarValueType {
 //        Signature signature; // nodeID's signature
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -8150,7 +8250,8 @@ impl WriteXdr for LedgerCloseValueSignature {
 //        }
 //
 // union with discriminant StellarValueType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -8263,7 +8364,8 @@ impl WriteXdr for StellarValueExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -8319,7 +8421,8 @@ pub const MASK_LEDGER_HEADER_FLAGS: u64 = 0x7F;
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -8439,7 +8542,8 @@ impl WriteXdr for LedgerHeaderFlags {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -8536,7 +8640,8 @@ impl WriteXdr for LedgerHeaderExtensionV1Ext {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -8577,7 +8682,8 @@ impl WriteXdr for LedgerHeaderExtensionV1 {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -8707,7 +8813,8 @@ impl WriteXdr for LedgerHeaderExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -8789,7 +8896,8 @@ impl WriteXdr for LedgerHeader {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -8904,7 +9012,8 @@ impl WriteXdr for LedgerUpgradeType {
 //            ConfigSetting setting; // new value
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -8957,7 +9066,8 @@ impl WriteXdr for LedgerUpgradeConfigSetting {
 //    };
 //
 // union with discriminant LedgerUpgradeType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9085,7 +9195,8 @@ impl WriteXdr for LedgerUpgrade {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9193,7 +9304,8 @@ impl WriteXdr for BucketEntryType {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9292,7 +9404,8 @@ impl WriteXdr for BucketMetadataExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9337,7 +9450,8 @@ impl WriteXdr for BucketMetadata {
 //    };
 //
 // union with discriminant BucketEntryType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9450,7 +9564,8 @@ impl WriteXdr for BucketEntry {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9544,7 +9659,8 @@ impl WriteXdr for TxSetComponentType {
 //        TransactionEnvelope txs<>;
 //      }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9587,7 +9703,8 @@ impl WriteXdr for TxSetComponentTxsMaybeDiscountedFee {
 //    };
 //
 // union with discriminant TxSetComponentType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9686,7 +9803,8 @@ impl WriteXdr for TxSetComponent {
 //    };
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9777,7 +9895,8 @@ impl WriteXdr for TransactionPhase {
 //        TransactionEnvelope txs<>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9815,7 +9934,8 @@ impl WriteXdr for TransactionSet {
 //        TransactionPhase phases<>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9855,7 +9975,8 @@ impl WriteXdr for TransactionSetV1 {
 //    };
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9946,7 +10067,8 @@ impl WriteXdr for GeneralizedTransactionSet {
 //        TransactionResult result; // result for the transaction
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9983,7 +10105,8 @@ impl WriteXdr for TransactionResultPair {
 //        TransactionResultPair results<>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10021,7 +10144,8 @@ impl WriteXdr for TransactionResultSet {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10127,7 +10251,8 @@ impl WriteXdr for TransactionHistoryEntryExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10169,7 +10294,8 @@ impl WriteXdr for TransactionHistoryEntry {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10268,7 +10394,8 @@ impl WriteXdr for TransactionHistoryResultEntryExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10310,7 +10437,8 @@ impl WriteXdr for TransactionHistoryResultEntry {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10409,7 +10537,8 @@ impl WriteXdr for LedgerHeaderHistoryEntryExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10450,7 +10579,8 @@ impl WriteXdr for LedgerHeaderHistoryEntry {
 //        SCPEnvelope messages<>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10488,7 +10618,8 @@ impl WriteXdr for LedgerScpMessages {
 //        LedgerSCPMessages ledgerMessages;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10527,7 +10658,8 @@ impl WriteXdr for ScpHistoryEntryV0 {
 //    };
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10621,7 +10753,8 @@ impl WriteXdr for ScpHistoryEntry {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10735,7 +10868,8 @@ impl WriteXdr for LedgerEntryChangeType {
 //    };
 //
 // union with discriminant LedgerEntryChangeType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10842,7 +10976,9 @@ impl WriteXdr for LedgerEntryChange {
 //
 //   typedef LedgerEntryChange LedgerEntryChanges<>;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[derive(Default)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10943,7 +11079,8 @@ impl AsRef<[LedgerEntryChange]> for LedgerEntryChanges {
 //        LedgerEntryChanges changes;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10978,7 +11115,8 @@ impl WriteXdr for OperationMeta {
 //        OperationMeta operations<>;   // meta for each operation
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11019,7 +11157,8 @@ impl WriteXdr for TransactionMetaV1 {
 //                                            // applied if any
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11065,7 +11204,8 @@ impl WriteXdr for TransactionMetaV2 {
 //    };
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11167,7 +11307,8 @@ impl WriteXdr for TransactionMeta {
 //        TransactionMeta txApplyProcessing;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11208,7 +11349,8 @@ impl WriteXdr for TransactionResultMeta {
 //        LedgerEntryChanges changes;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11258,7 +11400,8 @@ impl WriteXdr for UpgradeEntryMeta {
 //        SCPHistoryEntry scpInfo<>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11317,7 +11460,8 @@ impl WriteXdr for LedgerCloseMetaV0 {
 //        SCPHistoryEntry scpInfo<>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11367,7 +11511,8 @@ impl WriteXdr for LedgerCloseMetaV1 {
 //    };
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11467,7 +11612,8 @@ impl WriteXdr for LedgerCloseMeta {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11578,7 +11724,8 @@ impl WriteXdr for ErrorCode {
 //        string msg<100>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11615,7 +11762,8 @@ impl WriteXdr for SError {
 //        uint32 numMessages;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11651,7 +11799,8 @@ impl WriteXdr for SendMore {
 //        Signature sig;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11699,7 +11848,8 @@ impl WriteXdr for AuthCert {
 //        uint256 nonce;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11759,7 +11909,8 @@ impl WriteXdr for Hello {
 //        int unused;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11795,7 +11946,8 @@ impl WriteXdr for Auth {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11894,7 +12046,8 @@ impl WriteXdr for IpAddrType {
 //        }
 //
 // union with discriminant IpAddrType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11998,7 +12151,8 @@ impl WriteXdr for PeerAddressIp {
 //        uint32 numFailures;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12064,7 +12218,8 @@ impl WriteXdr for PeerAddress {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12223,7 +12378,8 @@ impl WriteXdr for MessageType {
 //        uint256 reqHash;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12261,7 +12417,8 @@ impl WriteXdr for DontHave {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12357,7 +12514,8 @@ impl WriteXdr for SurveyMessageCommandType {
 //        SurveyMessageCommandType commandType;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12404,7 +12562,8 @@ impl WriteXdr for SurveyRequestMessage {
 //        SurveyRequestMessage request;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12438,7 +12597,9 @@ impl WriteXdr for SignedSurveyRequestMessage {
 //
 //   typedef opaque EncryptedBody<64000>;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[derive(Default)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12543,7 +12704,8 @@ impl AsRef<[u8]> for EncryptedBody {
 //        EncryptedBody encryptedBody;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12590,7 +12752,8 @@ impl WriteXdr for SurveyResponseMessage {
 //        SurveyResponseMessage response;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12643,7 +12806,8 @@ impl WriteXdr for SignedSurveyResponseMessage {
 //        uint64 duplicateFetchMessageRecv;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12716,7 +12880,9 @@ impl WriteXdr for PeerStats {
 //
 //   typedef PeerStats PeerStatList<25>;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[derive(Default)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12821,7 +12987,8 @@ impl AsRef<[PeerStats]> for PeerStatList {
 //        uint32 totalOutboundPeerCount;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12866,7 +13033,8 @@ impl WriteXdr for TopologyResponseBody {
 //    };
 //
 // union with discriminant SurveyMessageCommandType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12998,7 +13166,8 @@ impl WriteXdr for SurveyResponseBody {
 //    };
 //
 // union with discriminant MessageType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13194,7 +13363,8 @@ impl WriteXdr for StellarMessage {
 //            HmacSha256Mac mac;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13241,7 +13411,8 @@ impl WriteXdr for AuthenticatedMessageV0 {
 //    };
 //
 // union with discriminant u32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13333,7 +13504,8 @@ impl WriteXdr for AuthenticatedMessage {
 //    };
 //
 // union with discriminant LiquidityPoolType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13428,7 +13600,8 @@ impl WriteXdr for LiquidityPoolParameters {
 //            uint256 ed25519;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13473,7 +13646,8 @@ impl WriteXdr for MuxedAccountMed25519 {
 //    };
 //
 // union with discriminant CryptoKeyType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13569,7 +13743,8 @@ impl WriteXdr for MuxedAccount {
 //        Signature signature; // actual signature
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13607,7 +13782,8 @@ impl WriteXdr for DecoratedSignature {
 //        LedgerKey readWrite<>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13669,7 +13845,8 @@ impl WriteXdr for LedgerFootprint {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13860,7 +14037,8 @@ impl WriteXdr for OperationType {
 //        int64 startingBalance; // amount they end up with
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13899,7 +14077,8 @@ impl WriteXdr for CreateAccountOp {
 //        int64 amount;             // amount they end up with
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13948,7 +14127,8 @@ impl WriteXdr for PaymentOp {
 //        Asset path<5>; // additional hops it must go through to get there
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14006,7 +14186,8 @@ impl WriteXdr for PathPaymentStrictReceiveOp {
 //        Asset path<5>; // additional hops it must go through to get there
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14061,7 +14242,8 @@ impl WriteXdr for PathPaymentStrictSendOp {
 //        int64 offerID;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14114,7 +14296,8 @@ impl WriteXdr for ManageSellOfferOp {
 //        int64 offerID;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14163,7 +14346,8 @@ impl WriteXdr for ManageBuyOfferOp {
 //        Price price;   // cost of A in terms of B
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14221,7 +14405,8 @@ impl WriteXdr for CreatePassiveSellOfferOp {
 //        Signer* signer;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14292,7 +14477,8 @@ impl WriteXdr for SetOptionsOp {
 //    };
 //
 // union with discriminant AssetType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14405,7 +14591,8 @@ impl WriteXdr for ChangeTrustAsset {
 //        int64 limit;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14446,7 +14633,8 @@ impl WriteXdr for ChangeTrustOp {
 //        uint32 authorize;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14487,7 +14675,8 @@ impl WriteXdr for AllowTrustOp {
 //        DataValue* dataValue; // set to null to clear
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14524,7 +14713,8 @@ impl WriteXdr for ManageDataOp {
 //        SequenceNumber bumpTo;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14560,7 +14750,8 @@ impl WriteXdr for BumpSequenceOp {
 //        Claimant claimants<10>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14600,7 +14791,8 @@ impl WriteXdr for CreateClaimableBalanceOp {
 //        ClaimableBalanceID balanceID;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14634,7 +14826,8 @@ impl WriteXdr for ClaimClaimableBalanceOp {
 //        AccountID sponsoredID;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14670,7 +14863,8 @@ impl WriteXdr for BeginSponsoringFutureReservesOp {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14769,7 +14963,8 @@ impl WriteXdr for RevokeSponsorshipType {
 //            SignerKey signerKey;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14814,7 +15009,8 @@ impl WriteXdr for RevokeSponsorshipOpSigner {
 //    };
 //
 // union with discriminant RevokeSponsorshipType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14914,7 +15110,8 @@ impl WriteXdr for RevokeSponsorshipOp {
 //        int64 amount;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14954,7 +15151,8 @@ impl WriteXdr for ClawbackOp {
 //        ClaimableBalanceID balanceID;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14992,7 +15190,8 @@ impl WriteXdr for ClawbackClaimableBalanceOp {
 //        uint32 setFlags;   // which flags to set
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15045,7 +15244,8 @@ pub const LIQUIDITY_POOL_FEE_V18: u64 = 30;
 //        Price maxPrice;   // maximum depositA/depositB
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15094,7 +15294,8 @@ impl WriteXdr for LiquidityPoolDepositOp {
 //        int64 minAmountB; // minimum amount of second asset to withdraw
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15139,7 +15340,8 @@ impl WriteXdr for LiquidityPoolWithdrawOp {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15241,7 +15443,8 @@ impl WriteXdr for HostFunction {
 //        LedgerFootprint footprint;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15331,7 +15534,8 @@ impl WriteXdr for InvokeHostFunctionOp {
 //        }
 //
 // union with discriminant OperationType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15651,7 +15855,8 @@ impl WriteXdr for OperationBody {
 //        body;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15690,7 +15895,8 @@ impl WriteXdr for Operation {
 //            uint32 opNum;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15734,7 +15940,8 @@ impl WriteXdr for HashIdPreimageOperationId {
 //            Asset asset;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15781,7 +15988,8 @@ impl WriteXdr for HashIdPreimageRevokeId {
 //            uint256 salt;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15819,7 +16027,8 @@ impl WriteXdr for HashIdPreimageEd25519ContractId {
 //            uint256 salt;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15884,7 +16093,8 @@ impl WriteXdr for HashIdPreimageContractId {
 //    };
 //
 // union with discriminant EnvelopeType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16005,7 +16215,8 @@ impl WriteXdr for HashIdPreimage {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16125,7 +16336,8 @@ impl WriteXdr for MemoType {
 //    };
 //
 // union with discriminant MemoType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16242,7 +16454,8 @@ impl WriteXdr for Memo {
 //        TimePoint maxTime; // 0 here means no maxTime
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16280,7 +16493,8 @@ impl WriteXdr for TimeBounds {
 //        uint32 maxLedger; // 0 here means no maxLedger
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16345,7 +16559,8 @@ impl WriteXdr for LedgerBounds {
 //        SignerKey extraSigners<2>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16397,7 +16612,8 @@ impl WriteXdr for PreconditionsV2 {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16505,7 +16721,8 @@ impl WriteXdr for PreconditionType {
 //    };
 //
 // union with discriminant PreconditionType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16617,7 +16834,8 @@ pub const MAX_OPS_PER_TX: u64 = 100;
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16718,7 +16936,8 @@ impl WriteXdr for TransactionV0Ext {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16773,7 +16992,8 @@ impl WriteXdr for TransactionV0 {
 //        DecoratedSignature signatures<20>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16812,7 +17032,8 @@ impl WriteXdr for TransactionV0Envelope {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16924,7 +17145,8 @@ impl WriteXdr for TransactionExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16979,7 +17201,8 @@ impl WriteXdr for Transaction {
 //        DecoratedSignature signatures<20>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -17018,7 +17241,8 @@ impl WriteXdr for TransactionV1Envelope {
 //        }
 //
 // union with discriminant EnvelopeType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -17110,7 +17334,8 @@ impl WriteXdr for FeeBumpTransactionInnerTx {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -17213,7 +17438,8 @@ impl WriteXdr for FeeBumpTransactionExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -17259,7 +17485,8 @@ impl WriteXdr for FeeBumpTransaction {
 //        DecoratedSignature signatures<20>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -17302,7 +17529,8 @@ impl WriteXdr for FeeBumpTransactionEnvelope {
 //    };
 //
 // union with discriminant EnvelopeType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -17411,7 +17639,8 @@ impl WriteXdr for TransactionEnvelope {
 //        }
 //
 // union with discriminant EnvelopeType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -17516,7 +17745,8 @@ impl WriteXdr for TransactionSignaturePayloadTaggedTransaction {
 //        taggedTransaction;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -17556,7 +17786,8 @@ impl WriteXdr for TransactionSignaturePayload {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -17668,7 +17899,8 @@ impl WriteXdr for ClaimAtomType {
 //        int64 amountBought;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -17727,7 +17959,8 @@ impl WriteXdr for ClaimOfferAtomV0 {
 //        int64 amountBought;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -17784,7 +18017,8 @@ impl WriteXdr for ClaimOfferAtom {
 //        int64 amountBought;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -17836,7 +18070,8 @@ impl WriteXdr for ClaimLiquidityAtom {
 //    };
 //
 // union with discriminant ClaimAtomType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -17949,7 +18184,8 @@ impl WriteXdr for ClaimAtom {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -18066,7 +18302,8 @@ impl WriteXdr for CreateAccountResultCode {
 //    };
 //
 // union with discriminant CreateAccountResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -18195,7 +18432,8 @@ impl WriteXdr for CreateAccountResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -18337,7 +18575,8 @@ impl WriteXdr for PaymentResultCode {
 //    };
 //
 // union with discriminant PaymentResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -18508,7 +18747,8 @@ impl WriteXdr for PaymentResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -18653,7 +18893,8 @@ impl WriteXdr for PathPaymentStrictReceiveResultCode {
 //        int64 amount;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -18694,7 +18935,8 @@ impl WriteXdr for SimplePaymentResult {
 //            SimplePaymentResult last;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -18753,7 +18995,8 @@ impl WriteXdr for PathPaymentStrictReceiveResultSuccess {
 //    };
 //
 // union with discriminant PathPaymentStrictReceiveResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -18945,7 +19188,8 @@ impl WriteXdr for PathPaymentStrictReceiveResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -19089,7 +19333,8 @@ impl WriteXdr for PathPaymentStrictSendResultCode {
 //            SimplePaymentResult last;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -19147,7 +19392,8 @@ impl WriteXdr for PathPaymentStrictSendResultSuccess {
 //    };
 //
 // union with discriminant PathPaymentStrictSendResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -19338,7 +19584,8 @@ impl WriteXdr for PathPaymentStrictSendResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -19483,7 +19730,8 @@ impl WriteXdr for ManageSellOfferResultCode {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -19590,7 +19838,8 @@ impl WriteXdr for ManageOfferEffect {
 //        }
 //
 // union with discriminant ManageOfferEffect
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -19705,7 +19954,8 @@ impl WriteXdr for ManageOfferSuccessResultOffer {
 //        offer;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -19757,7 +20007,8 @@ impl WriteXdr for ManageOfferSuccessResult {
 //    };
 //
 // union with discriminant ManageSellOfferResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -19943,7 +20194,8 @@ impl WriteXdr for ManageSellOfferResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -20100,7 +20352,8 @@ impl WriteXdr for ManageBuyOfferResultCode {
 //    };
 //
 // union with discriminant ManageBuyOfferResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -20280,7 +20533,8 @@ impl WriteXdr for ManageBuyOfferResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -20427,7 +20681,8 @@ impl WriteXdr for SetOptionsResultCode {
 //    };
 //
 // union with discriminant SetOptionsResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -20594,7 +20849,8 @@ impl WriteXdr for SetOptionsResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -20731,7 +20987,8 @@ impl WriteXdr for ChangeTrustResultCode {
 //    };
 //
 // union with discriminant ChangeTrustResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -20882,7 +21139,8 @@ impl WriteXdr for ChangeTrustResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -21009,7 +21267,8 @@ impl WriteXdr for AllowTrustResultCode {
 //    };
 //
 // union with discriminant AllowTrustResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -21148,7 +21407,8 @@ impl WriteXdr for AllowTrustResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -21280,7 +21540,8 @@ impl WriteXdr for AccountMergeResultCode {
 //    };
 //
 // union with discriminant AccountMergeResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -21418,7 +21679,8 @@ impl WriteXdr for AccountMergeResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -21515,7 +21777,8 @@ impl WriteXdr for InflationResultCode {
 //        int64 amount;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -21556,7 +21819,8 @@ impl WriteXdr for InflationPayout {
 //    };
 //
 // union with discriminant InflationResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -21661,7 +21925,8 @@ impl WriteXdr for InflationResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -21778,7 +22043,8 @@ impl WriteXdr for ManageDataResultCode {
 //    };
 //
 // union with discriminant ManageDataResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -21898,7 +22164,8 @@ impl WriteXdr for ManageDataResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -22000,7 +22267,8 @@ impl WriteXdr for BumpSequenceResultCode {
 //    };
 //
 // union with discriminant BumpSequenceResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -22104,7 +22372,8 @@ impl WriteXdr for BumpSequenceResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -22228,7 +22497,8 @@ impl WriteXdr for CreateClaimableBalanceResultCode {
 //    };
 //
 // union with discriminant CreateClaimableBalanceResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -22360,7 +22630,8 @@ impl WriteXdr for CreateClaimableBalanceResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -22483,7 +22754,8 @@ impl WriteXdr for ClaimClaimableBalanceResultCode {
 //    };
 //
 // union with discriminant ClaimClaimableBalanceResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -22614,7 +22886,8 @@ impl WriteXdr for ClaimClaimableBalanceResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -22728,7 +23001,8 @@ impl WriteXdr for BeginSponsoringFutureReservesResultCode {
 //    };
 //
 // union with discriminant BeginSponsoringFutureReservesResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -22845,7 +23119,8 @@ impl WriteXdr for BeginSponsoringFutureReservesResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -22949,7 +23224,8 @@ impl WriteXdr for EndSponsoringFutureReservesResultCode {
 //    };
 //
 // union with discriminant EndSponsoringFutureReservesResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -23058,7 +23334,8 @@ impl WriteXdr for EndSponsoringFutureReservesResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -23180,7 +23457,8 @@ impl WriteXdr for RevokeSponsorshipResultCode {
 //    };
 //
 // union with discriminant RevokeSponsorshipResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -23311,7 +23589,8 @@ impl WriteXdr for RevokeSponsorshipResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -23428,7 +23707,8 @@ impl WriteXdr for ClawbackResultCode {
 //    };
 //
 // union with discriminant ClawbackResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -23551,7 +23831,8 @@ impl WriteXdr for ClawbackResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -23665,7 +23946,8 @@ impl WriteXdr for ClawbackClaimableBalanceResultCode {
 //    };
 //
 // union with discriminant ClawbackClaimableBalanceResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -23787,7 +24069,8 @@ impl WriteXdr for ClawbackClaimableBalanceResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -23909,7 +24192,8 @@ impl WriteXdr for SetTrustLineFlagsResultCode {
 //    };
 //
 // union with discriminant SetTrustLineFlagsResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -24047,7 +24331,8 @@ impl WriteXdr for SetTrustLineFlagsResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -24180,7 +24465,8 @@ impl WriteXdr for LiquidityPoolDepositResultCode {
 //    };
 //
 // union with discriminant LiquidityPoolDepositResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -24328,7 +24614,8 @@ impl WriteXdr for LiquidityPoolDepositResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -24451,7 +24738,8 @@ impl WriteXdr for LiquidityPoolWithdrawResultCode {
 //    };
 //
 // union with discriminant LiquidityPoolWithdrawResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -24581,7 +24869,8 @@ impl WriteXdr for LiquidityPoolWithdrawResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -24689,7 +24978,8 @@ impl WriteXdr for InvokeHostFunctionResultCode {
 //    };
 //
 // union with discriminant InvokeHostFunctionResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -24802,7 +25092,8 @@ impl WriteXdr for InvokeHostFunctionResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -24970,7 +25261,8 @@ impl WriteXdr for OperationResultCode {
 //        }
 //
 // union with discriminant OperationType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -25298,7 +25590,8 @@ impl WriteXdr for OperationResultTr {
 //    };
 //
 // union with discriminant OperationResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -25449,7 +25742,8 @@ impl WriteXdr for OperationResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -25631,7 +25925,8 @@ impl WriteXdr for TransactionResultCode {
 //        }
 //
 // union with discriminant TransactionResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -25819,7 +26114,8 @@ impl WriteXdr for InnerTransactionResultResult {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -25943,7 +26239,8 @@ impl WriteXdr for InnerTransactionResultExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -25984,7 +26281,8 @@ impl WriteXdr for InnerTransactionResult {
 //        InnerTransactionResult result; // result for the inner transaction
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -26043,7 +26341,8 @@ impl WriteXdr for InnerTransactionResultPair {
 //        }
 //
 // union with discriminant TransactionResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -26247,7 +26546,8 @@ impl WriteXdr for TransactionResultResult {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -26372,7 +26672,8 @@ impl WriteXdr for TransactionResultExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -26409,7 +26710,8 @@ impl WriteXdr for TransactionResult {
 //
 //   typedef opaque Hash[32];
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -26495,7 +26797,8 @@ impl AsRef<[u8]> for Hash {
 //
 //   typedef opaque uint256[32];
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -26610,7 +26913,8 @@ pub type Int64 = i64;
 //    };
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -26707,7 +27011,8 @@ impl WriteXdr for ExtensionPoint {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -26818,7 +27123,8 @@ impl WriteXdr for CryptoKeyType {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -26914,7 +27220,8 @@ impl WriteXdr for PublicKeyType {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -27022,7 +27329,8 @@ impl WriteXdr for SignerKeyType {
 //    };
 //
 // union with discriminant PublicKeyType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -27117,7 +27425,8 @@ impl WriteXdr for PublicKey {
 //            opaque payload<64>;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -27170,7 +27479,8 @@ impl WriteXdr for SignerKeyEd25519SignedPayload {
 //    };
 //
 // union with discriminant SignerKeyType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -27279,7 +27589,9 @@ impl WriteXdr for SignerKey {
 //
 //   typedef opaque Signature<64>;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[derive(Default)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -27377,7 +27689,8 @@ impl AsRef<[u8]> for Signature {
 //
 //   typedef opaque SignatureHint[4];
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -27463,7 +27776,8 @@ impl AsRef<[u8]> for SignatureHint {
 //
 //   typedef PublicKey NodeID;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -27515,7 +27829,8 @@ impl WriteXdr for NodeId {
 //        opaque key[32];
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -27549,7 +27864,8 @@ impl WriteXdr for Curve25519Secret {
 //        opaque key[32];
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -27583,7 +27899,8 @@ impl WriteXdr for Curve25519Public {
 //        opaque key[32];
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -27617,7 +27934,8 @@ impl WriteXdr for HmacSha256Key {
 //        opaque mac[32];
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -27665,7 +27983,8 @@ pub type ScSymbol = VecM<u8, 10>;
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -27791,7 +28110,8 @@ impl WriteXdr for ScValType {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -27906,7 +28226,8 @@ impl WriteXdr for ScStatic {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -28040,7 +28361,8 @@ impl WriteXdr for ScStatusType {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -28185,7 +28507,8 @@ impl WriteXdr for ScHostValErrorCode {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -28308,7 +28631,8 @@ impl WriteXdr for ScHostObjErrorCode {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -28424,7 +28748,8 @@ impl WriteXdr for ScHostFnErrorCode {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -28540,7 +28865,8 @@ impl WriteXdr for ScHostStorageErrorCode {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -28656,7 +28982,8 @@ impl WriteXdr for ScHostContextErrorCode {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -28824,7 +29151,8 @@ impl WriteXdr for ScVmErrorCode {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -28936,7 +29264,8 @@ impl WriteXdr for ScUnknownErrorCode {
 //    };
 //
 // union with discriminant ScStatusType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -29094,7 +29423,8 @@ impl WriteXdr for ScStatus {
 //    };
 //
 // union with discriminant ScValType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -29241,7 +29571,8 @@ impl WriteXdr for ScVal {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -29364,7 +29695,8 @@ impl WriteXdr for ScObjectType {
 //        SCVal val;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -29404,7 +29736,9 @@ pub const SCVAL_LIMIT: u64 = 256000;
 //
 //   typedef SCVal SCVec<SCVAL_LIMIT>;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[derive(Default)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -29502,7 +29836,9 @@ impl AsRef<[ScVal]> for ScVec {
 //
 //   typedef SCMapEntry SCMap<SCVAL_LIMIT>;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[derive(Default)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -29606,7 +29942,8 @@ impl AsRef<[ScMapEntry]> for ScMap {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -29710,7 +30047,8 @@ impl WriteXdr for ScNumSign {
 //    };
 //
 // union with discriminant ScNumSign
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -29812,7 +30150,8 @@ impl WriteXdr for ScBigInt {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -29906,7 +30245,8 @@ impl WriteXdr for ScHashType {
 //    };
 //
 // union with discriminant ScHashType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -30012,7 +30352,8 @@ impl WriteXdr for ScHash {
 //    };
 //
 // union with discriminant ScObjectType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -30147,7 +30488,8 @@ impl WriteXdr for ScObject {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -30241,7 +30583,8 @@ impl WriteXdr for ScEnvMetaKind {
 //    };
 //
 // union with discriminant ScEnvMetaKind
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -30355,7 +30698,8 @@ impl WriteXdr for ScEnvMetaEntry {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -30513,7 +30857,8 @@ impl WriteXdr for ScSpecType {
 //        SCSpecTypeDef valueType;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -30548,7 +30893,8 @@ impl WriteXdr for ScSpecTypeOption {
 //        SCSpecTypeDef errorType;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -30585,7 +30931,8 @@ impl WriteXdr for ScSpecTypeResult {
 //        SCSpecTypeDef elementType;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -30620,7 +30967,8 @@ impl WriteXdr for ScSpecTypeVec {
 //        SCSpecTypeDef valueType;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -30657,7 +31005,8 @@ impl WriteXdr for ScSpecTypeMap {
 //        SCSpecTypeDef elementType;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -30691,7 +31040,8 @@ impl WriteXdr for ScSpecTypeSet {
 //        SCSpecTypeDef valueTypes<12>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -30725,7 +31075,8 @@ impl WriteXdr for ScSpecTypeTuple {
 //        string name<60>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -30784,7 +31135,8 @@ impl WriteXdr for ScSpecTypeUdt {
 //    };
 //
 // union with discriminant ScSpecType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -30973,7 +31325,8 @@ impl WriteXdr for ScSpecTypeDef {
 //        SCSpecTypeDef type;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -31011,7 +31364,8 @@ impl WriteXdr for ScSpecUdtStructFieldV0 {
 //        SCSpecUDTStructFieldV0 fields<40>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -31049,7 +31403,8 @@ impl WriteXdr for ScSpecUdtStructV0 {
 //        SCSpecTypeDef *type;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -31087,7 +31442,8 @@ impl WriteXdr for ScSpecUdtUnionCaseV0 {
 //        SCSpecUDTUnionCaseV0 cases<50>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -31126,7 +31482,8 @@ impl WriteXdr for ScSpecUdtUnionV0 {
 //        SCSpecTypeDef outputTypes<1>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -31169,7 +31526,8 @@ impl WriteXdr for ScSpecFunctionV0 {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -31277,7 +31635,8 @@ impl WriteXdr for ScSpecEntryKind {
 //    };
 //
 // union with discriminant ScSpecEntryKind
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),

--- a/src/next.rs
+++ b/src/next.rs
@@ -51,6 +51,7 @@ pub const XDR_FILES_SHA256: [(&str, &str); 9] = [
     ),
 ];
 
+use arbitrary::Arbitrary;
 use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref, slice};
 
 #[cfg(feature = "std")]
@@ -556,12 +557,12 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 }
 
 #[cfg(feature = "alloc")]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
 #[cfg(not(feature = "alloc"))]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>)
 where
     T: 'static;
@@ -1005,7 +1006,7 @@ mod tests {
 //
 //   typedef opaque Value<>;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1107,7 +1108,7 @@ impl AsRef<[u8]> for Value {
 //        Value value;    // x
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1148,7 +1149,7 @@ impl WriteXdr for ScpBallot {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1256,7 +1257,7 @@ impl WriteXdr for ScpStatementType {
 //        Value accepted<>;   // Y
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1301,7 +1302,7 @@ impl WriteXdr for ScpNomination {
 //                uint32 nH;                // h.n
 //            }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1354,7 +1355,7 @@ impl WriteXdr for ScpStatementPrepare {
 //                Hash quorumSetHash; // D
 //            }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1402,7 +1403,7 @@ impl WriteXdr for ScpStatementConfirm {
 //                Hash commitQuorumSetHash; // D used before EXTERNALIZE
 //            }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1470,7 +1471,7 @@ impl WriteXdr for ScpStatementExternalize {
 //        }
 //
 // union with discriminant ScpStatementType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1616,7 +1617,7 @@ impl WriteXdr for ScpStatementPledges {
 //        pledges;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1657,7 +1658,7 @@ impl WriteXdr for ScpStatement {
 //        Signature signature;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1696,7 +1697,7 @@ impl WriteXdr for ScpEnvelope {
 //        SCPQuorumSet innerSets<>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1733,7 +1734,7 @@ impl WriteXdr for ScpQuorumSet {
 //
 //   typedef PublicKey AccountID;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1782,7 +1783,7 @@ impl WriteXdr for AccountId {
 //
 //   typedef opaque Thresholds[4];
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1880,7 +1881,7 @@ pub type String64 = VecM<u8, 64>;
 //
 //   typedef int64 SequenceNumber;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1929,7 +1930,7 @@ impl WriteXdr for SequenceNumber {
 //
 //   typedef uint64 TimePoint;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -1978,7 +1979,7 @@ impl WriteXdr for TimePoint {
 //
 //   typedef uint64 Duration;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2027,7 +2028,7 @@ impl WriteXdr for Duration {
 //
 //   typedef opaque DataValue<64>;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2125,7 +2126,7 @@ impl AsRef<[u8]> for DataValue {
 //
 //   typedef Hash PoolID;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2174,7 +2175,7 @@ impl WriteXdr for PoolId {
 //
 //   typedef opaque AssetCode4[4];
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2260,7 +2261,7 @@ impl AsRef<[u8]> for AssetCode4 {
 //
 //   typedef opaque AssetCode12[12];
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2353,7 +2354,7 @@ impl AsRef<[u8]> for AssetCode12 {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2466,7 +2467,7 @@ impl WriteXdr for AssetType {
 //    };
 //
 // union with discriminant AssetType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2562,7 +2563,7 @@ impl WriteXdr for AssetCode {
 //        AccountID issuer;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2600,7 +2601,7 @@ impl WriteXdr for AlphaNum4 {
 //        AccountID issuer;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2647,7 +2648,7 @@ impl WriteXdr for AlphaNum12 {
 //    };
 //
 // union with discriminant AssetType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2752,7 +2753,7 @@ impl WriteXdr for Asset {
 //        int32 d; // denominator
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2790,7 +2791,7 @@ impl WriteXdr for Price {
 //        int64 selling;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2831,7 +2832,7 @@ impl WriteXdr for Liabilities {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -2945,7 +2946,7 @@ impl WriteXdr for ThresholdIndexes {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3068,7 +3069,7 @@ impl WriteXdr for LedgerEntryType {
 //        uint32 weight; // really only need 1 byte
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3119,7 +3120,7 @@ impl WriteXdr for Signer {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3240,7 +3241,7 @@ pub const MAX_SIGNERS: u64 = 20;
 //
 //   typedef AccountID* SponsorshipDescriptor;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3300,7 +3301,7 @@ impl WriteXdr for SponsorshipDescriptor {
 //        TimePoint seqTime;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3344,7 +3345,7 @@ impl WriteXdr for AccountEntryExtensionV3 {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3450,7 +3451,7 @@ impl WriteXdr for AccountEntryExtensionV2Ext {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3497,7 +3498,7 @@ impl WriteXdr for AccountEntryExtensionV2 {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3601,7 +3602,7 @@ impl WriteXdr for AccountEntryExtensionV1Ext {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3642,7 +3643,7 @@ impl WriteXdr for AccountEntryExtensionV1 {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3761,7 +3762,7 @@ impl WriteXdr for AccountEntryExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3830,7 +3831,7 @@ impl WriteXdr for AccountEntry {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -3951,7 +3952,7 @@ pub const MASK_TRUSTLINE_FLAGS_V17: u64 = 7;
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -4056,7 +4057,7 @@ impl WriteXdr for LiquidityPoolType {
 //    };
 //
 // union with discriminant AssetType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -4168,7 +4169,7 @@ impl WriteXdr for TrustLineAsset {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -4265,7 +4266,7 @@ impl WriteXdr for TrustLineEntryExtensionV2Ext {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -4306,7 +4307,7 @@ impl WriteXdr for TrustLineEntryExtensionV2 {
 //                }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -4410,7 +4411,7 @@ impl WriteXdr for TrustLineEntryV1Ext {
 //                ext;
 //            }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -4463,7 +4464,7 @@ impl WriteXdr for TrustLineEntryV1 {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -4586,7 +4587,7 @@ impl WriteXdr for TrustLineEntryExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -4638,7 +4639,7 @@ impl WriteXdr for TrustLineEntry {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -4738,7 +4739,7 @@ pub const MASK_OFFERENTRY_FLAGS: u64 = 1;
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -4848,7 +4849,7 @@ impl WriteXdr for OfferEntryExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -4905,7 +4906,7 @@ impl WriteXdr for OfferEntry {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -5005,7 +5006,7 @@ impl WriteXdr for DataEntryExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -5054,7 +5055,7 @@ impl WriteXdr for DataEntry {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -5181,7 +5182,7 @@ impl WriteXdr for ClaimPredicateType {
 //    };
 //
 // union with discriminant ClaimPredicateType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -5304,7 +5305,7 @@ impl WriteXdr for ClaimPredicate {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -5397,7 +5398,7 @@ impl WriteXdr for ClaimantType {
 //            ClaimPredicate predicate; // Claimable if predicate is true
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -5440,7 +5441,7 @@ impl WriteXdr for ClaimantV0 {
 //    };
 //
 // union with discriminant ClaimantType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -5531,7 +5532,7 @@ impl WriteXdr for Claimant {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -5626,7 +5627,7 @@ impl WriteXdr for ClaimableBalanceIdType {
 //    };
 //
 // union with discriminant ClaimableBalanceIdType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -5722,7 +5723,7 @@ impl WriteXdr for ClaimableBalanceId {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -5823,7 +5824,7 @@ pub const MASK_CLAIMABLE_BALANCE_FLAGS: u64 = 0x1;
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -5920,7 +5921,7 @@ impl WriteXdr for ClaimableBalanceEntryExtensionV1Ext {
 //        uint32 flags; // see ClaimableBalanceFlags
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -5961,7 +5962,7 @@ impl WriteXdr for ClaimableBalanceEntryExtensionV1 {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6076,7 +6077,7 @@ impl WriteXdr for ClaimableBalanceEntryExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6124,7 +6125,7 @@ impl WriteXdr for ClaimableBalanceEntry {
 //        int32 fee; // Fee is in basis points, so the actual rate is (fee/100)%
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6170,7 +6171,7 @@ impl WriteXdr for LiquidityPoolConstantProductParameters {
 //                                                // associated pool shares
 //            }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6227,7 +6228,7 @@ impl WriteXdr for LiquidityPoolEntryConstantProduct {
 //        }
 //
 // union with discriminant LiquidityPoolType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6337,7 +6338,7 @@ impl WriteXdr for LiquidityPoolEntryBody {
 //        body;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6375,7 +6376,7 @@ impl WriteXdr for LiquidityPoolEntry {
 //        SCVal val;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6416,7 +6417,7 @@ impl WriteXdr for ContractDataEntry {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6510,7 +6511,7 @@ impl WriteXdr for ConfigSettingType {
 //    };
 //
 // union with discriminant ConfigSettingType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6603,7 +6604,7 @@ impl WriteXdr for ConfigSetting {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6697,7 +6698,7 @@ impl WriteXdr for ConfigSettingId {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6795,7 +6796,7 @@ impl WriteXdr for ConfigSettingEntryExt {
 //        ConfigSetting setting;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6837,7 +6838,7 @@ impl WriteXdr for ConfigSettingEntry {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6934,7 +6935,7 @@ impl WriteXdr for LedgerEntryExtensionV1Ext {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -6987,7 +6988,7 @@ impl WriteXdr for LedgerEntryExtensionV1 {
 //        }
 //
 // union with discriminant LedgerEntryType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7127,7 +7128,7 @@ impl WriteXdr for LedgerEntryData {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7253,7 +7254,7 @@ impl WriteXdr for LedgerEntryExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7293,7 +7294,7 @@ impl WriteXdr for LedgerEntry {
 //            AccountID accountID;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7328,7 +7329,7 @@ impl WriteXdr for LedgerKeyAccount {
 //            TrustLineAsset asset;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7366,7 +7367,7 @@ impl WriteXdr for LedgerKeyTrustLine {
 //            int64 offerID;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7404,7 +7405,7 @@ impl WriteXdr for LedgerKeyOffer {
 //            string64 dataName;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7441,7 +7442,7 @@ impl WriteXdr for LedgerKeyData {
 //            ClaimableBalanceID balanceID;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7475,7 +7476,7 @@ impl WriteXdr for LedgerKeyClaimableBalance {
 //            PoolID liquidityPoolID;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7510,7 +7511,7 @@ impl WriteXdr for LedgerKeyLiquidityPool {
 //            SCVal key;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7547,7 +7548,7 @@ impl WriteXdr for LedgerKeyContractData {
 //            ConfigSettingID configSettingID;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7630,7 +7631,7 @@ impl WriteXdr for LedgerKeyConfigSetting {
 //    };
 //
 // union with discriminant LedgerEntryType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7782,7 +7783,7 @@ impl WriteXdr for LedgerKey {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -7909,7 +7910,7 @@ impl WriteXdr for EnvelopeType {
 //
 //   typedef opaque UpgradeType<128>;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -8012,7 +8013,7 @@ impl AsRef<[u8]> for UpgradeType {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -8108,7 +8109,7 @@ impl WriteXdr for StellarValueType {
 //        Signature signature; // nodeID's signature
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -8149,7 +8150,7 @@ impl WriteXdr for LedgerCloseValueSignature {
 //        }
 //
 // union with discriminant StellarValueType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -8262,7 +8263,7 @@ impl WriteXdr for StellarValueExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -8318,7 +8319,7 @@ pub const MASK_LEDGER_HEADER_FLAGS: u64 = 0x7F;
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -8438,7 +8439,7 @@ impl WriteXdr for LedgerHeaderFlags {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -8535,7 +8536,7 @@ impl WriteXdr for LedgerHeaderExtensionV1Ext {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -8576,7 +8577,7 @@ impl WriteXdr for LedgerHeaderExtensionV1 {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -8706,7 +8707,7 @@ impl WriteXdr for LedgerHeaderExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -8788,7 +8789,7 @@ impl WriteXdr for LedgerHeader {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -8903,7 +8904,7 @@ impl WriteXdr for LedgerUpgradeType {
 //            ConfigSetting setting; // new value
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -8956,7 +8957,7 @@ impl WriteXdr for LedgerUpgradeConfigSetting {
 //    };
 //
 // union with discriminant LedgerUpgradeType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9084,7 +9085,7 @@ impl WriteXdr for LedgerUpgrade {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9192,7 +9193,7 @@ impl WriteXdr for BucketEntryType {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9291,7 +9292,7 @@ impl WriteXdr for BucketMetadataExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9336,7 +9337,7 @@ impl WriteXdr for BucketMetadata {
 //    };
 //
 // union with discriminant BucketEntryType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9449,7 +9450,7 @@ impl WriteXdr for BucketEntry {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9543,7 +9544,7 @@ impl WriteXdr for TxSetComponentType {
 //        TransactionEnvelope txs<>;
 //      }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9586,7 +9587,7 @@ impl WriteXdr for TxSetComponentTxsMaybeDiscountedFee {
 //    };
 //
 // union with discriminant TxSetComponentType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9685,7 +9686,7 @@ impl WriteXdr for TxSetComponent {
 //    };
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9776,7 +9777,7 @@ impl WriteXdr for TransactionPhase {
 //        TransactionEnvelope txs<>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9814,7 +9815,7 @@ impl WriteXdr for TransactionSet {
 //        TransactionPhase phases<>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9854,7 +9855,7 @@ impl WriteXdr for TransactionSetV1 {
 //    };
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9945,7 +9946,7 @@ impl WriteXdr for GeneralizedTransactionSet {
 //        TransactionResult result; // result for the transaction
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -9982,7 +9983,7 @@ impl WriteXdr for TransactionResultPair {
 //        TransactionResultPair results<>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10020,7 +10021,7 @@ impl WriteXdr for TransactionResultSet {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10126,7 +10127,7 @@ impl WriteXdr for TransactionHistoryEntryExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10168,7 +10169,7 @@ impl WriteXdr for TransactionHistoryEntry {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10267,7 +10268,7 @@ impl WriteXdr for TransactionHistoryResultEntryExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10309,7 +10310,7 @@ impl WriteXdr for TransactionHistoryResultEntry {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10408,7 +10409,7 @@ impl WriteXdr for LedgerHeaderHistoryEntryExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10449,7 +10450,7 @@ impl WriteXdr for LedgerHeaderHistoryEntry {
 //        SCPEnvelope messages<>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10487,7 +10488,7 @@ impl WriteXdr for LedgerScpMessages {
 //        LedgerSCPMessages ledgerMessages;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10526,7 +10527,7 @@ impl WriteXdr for ScpHistoryEntryV0 {
 //    };
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10620,7 +10621,7 @@ impl WriteXdr for ScpHistoryEntry {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10734,7 +10735,7 @@ impl WriteXdr for LedgerEntryChangeType {
 //    };
 //
 // union with discriminant LedgerEntryChangeType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10841,7 +10842,7 @@ impl WriteXdr for LedgerEntryChange {
 //
 //   typedef LedgerEntryChange LedgerEntryChanges<>;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10942,7 +10943,7 @@ impl AsRef<[LedgerEntryChange]> for LedgerEntryChanges {
 //        LedgerEntryChanges changes;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -10977,7 +10978,7 @@ impl WriteXdr for OperationMeta {
 //        OperationMeta operations<>;   // meta for each operation
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11018,7 +11019,7 @@ impl WriteXdr for TransactionMetaV1 {
 //                                            // applied if any
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11064,7 +11065,7 @@ impl WriteXdr for TransactionMetaV2 {
 //    };
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11166,7 +11167,7 @@ impl WriteXdr for TransactionMeta {
 //        TransactionMeta txApplyProcessing;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11207,7 +11208,7 @@ impl WriteXdr for TransactionResultMeta {
 //        LedgerEntryChanges changes;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11257,7 +11258,7 @@ impl WriteXdr for UpgradeEntryMeta {
 //        SCPHistoryEntry scpInfo<>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11316,7 +11317,7 @@ impl WriteXdr for LedgerCloseMetaV0 {
 //        SCPHistoryEntry scpInfo<>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11366,7 +11367,7 @@ impl WriteXdr for LedgerCloseMetaV1 {
 //    };
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11466,7 +11467,7 @@ impl WriteXdr for LedgerCloseMeta {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11577,7 +11578,7 @@ impl WriteXdr for ErrorCode {
 //        string msg<100>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11614,7 +11615,7 @@ impl WriteXdr for SError {
 //        uint32 numMessages;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11650,7 +11651,7 @@ impl WriteXdr for SendMore {
 //        Signature sig;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11698,7 +11699,7 @@ impl WriteXdr for AuthCert {
 //        uint256 nonce;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11758,7 +11759,7 @@ impl WriteXdr for Hello {
 //        int unused;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11794,7 +11795,7 @@ impl WriteXdr for Auth {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11893,7 +11894,7 @@ impl WriteXdr for IpAddrType {
 //        }
 //
 // union with discriminant IpAddrType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -11997,7 +11998,7 @@ impl WriteXdr for PeerAddressIp {
 //        uint32 numFailures;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12063,7 +12064,7 @@ impl WriteXdr for PeerAddress {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12222,7 +12223,7 @@ impl WriteXdr for MessageType {
 //        uint256 reqHash;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12260,7 +12261,7 @@ impl WriteXdr for DontHave {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12356,7 +12357,7 @@ impl WriteXdr for SurveyMessageCommandType {
 //        SurveyMessageCommandType commandType;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12403,7 +12404,7 @@ impl WriteXdr for SurveyRequestMessage {
 //        SurveyRequestMessage request;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12437,7 +12438,7 @@ impl WriteXdr for SignedSurveyRequestMessage {
 //
 //   typedef opaque EncryptedBody<64000>;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12542,7 +12543,7 @@ impl AsRef<[u8]> for EncryptedBody {
 //        EncryptedBody encryptedBody;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12589,7 +12590,7 @@ impl WriteXdr for SurveyResponseMessage {
 //        SurveyResponseMessage response;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12642,7 +12643,7 @@ impl WriteXdr for SignedSurveyResponseMessage {
 //        uint64 duplicateFetchMessageRecv;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12715,7 +12716,7 @@ impl WriteXdr for PeerStats {
 //
 //   typedef PeerStats PeerStatList<25>;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12820,7 +12821,7 @@ impl AsRef<[PeerStats]> for PeerStatList {
 //        uint32 totalOutboundPeerCount;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12865,7 +12866,7 @@ impl WriteXdr for TopologyResponseBody {
 //    };
 //
 // union with discriminant SurveyMessageCommandType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -12997,7 +12998,7 @@ impl WriteXdr for SurveyResponseBody {
 //    };
 //
 // union with discriminant MessageType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13193,7 +13194,7 @@ impl WriteXdr for StellarMessage {
 //            HmacSha256Mac mac;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13240,7 +13241,7 @@ impl WriteXdr for AuthenticatedMessageV0 {
 //    };
 //
 // union with discriminant u32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13332,7 +13333,7 @@ impl WriteXdr for AuthenticatedMessage {
 //    };
 //
 // union with discriminant LiquidityPoolType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13427,7 +13428,7 @@ impl WriteXdr for LiquidityPoolParameters {
 //            uint256 ed25519;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13472,7 +13473,7 @@ impl WriteXdr for MuxedAccountMed25519 {
 //    };
 //
 // union with discriminant CryptoKeyType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13568,7 +13569,7 @@ impl WriteXdr for MuxedAccount {
 //        Signature signature; // actual signature
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13606,7 +13607,7 @@ impl WriteXdr for DecoratedSignature {
 //        LedgerKey readWrite<>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13668,7 +13669,7 @@ impl WriteXdr for LedgerFootprint {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13859,7 +13860,7 @@ impl WriteXdr for OperationType {
 //        int64 startingBalance; // amount they end up with
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13898,7 +13899,7 @@ impl WriteXdr for CreateAccountOp {
 //        int64 amount;             // amount they end up with
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -13947,7 +13948,7 @@ impl WriteXdr for PaymentOp {
 //        Asset path<5>; // additional hops it must go through to get there
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14005,7 +14006,7 @@ impl WriteXdr for PathPaymentStrictReceiveOp {
 //        Asset path<5>; // additional hops it must go through to get there
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14060,7 +14061,7 @@ impl WriteXdr for PathPaymentStrictSendOp {
 //        int64 offerID;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14113,7 +14114,7 @@ impl WriteXdr for ManageSellOfferOp {
 //        int64 offerID;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14162,7 +14163,7 @@ impl WriteXdr for ManageBuyOfferOp {
 //        Price price;   // cost of A in terms of B
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14220,7 +14221,7 @@ impl WriteXdr for CreatePassiveSellOfferOp {
 //        Signer* signer;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14291,7 +14292,7 @@ impl WriteXdr for SetOptionsOp {
 //    };
 //
 // union with discriminant AssetType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14404,7 +14405,7 @@ impl WriteXdr for ChangeTrustAsset {
 //        int64 limit;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14445,7 +14446,7 @@ impl WriteXdr for ChangeTrustOp {
 //        uint32 authorize;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14486,7 +14487,7 @@ impl WriteXdr for AllowTrustOp {
 //        DataValue* dataValue; // set to null to clear
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14523,7 +14524,7 @@ impl WriteXdr for ManageDataOp {
 //        SequenceNumber bumpTo;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14559,7 +14560,7 @@ impl WriteXdr for BumpSequenceOp {
 //        Claimant claimants<10>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14599,7 +14600,7 @@ impl WriteXdr for CreateClaimableBalanceOp {
 //        ClaimableBalanceID balanceID;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14633,7 +14634,7 @@ impl WriteXdr for ClaimClaimableBalanceOp {
 //        AccountID sponsoredID;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14669,7 +14670,7 @@ impl WriteXdr for BeginSponsoringFutureReservesOp {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14768,7 +14769,7 @@ impl WriteXdr for RevokeSponsorshipType {
 //            SignerKey signerKey;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14813,7 +14814,7 @@ impl WriteXdr for RevokeSponsorshipOpSigner {
 //    };
 //
 // union with discriminant RevokeSponsorshipType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14913,7 +14914,7 @@ impl WriteXdr for RevokeSponsorshipOp {
 //        int64 amount;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14953,7 +14954,7 @@ impl WriteXdr for ClawbackOp {
 //        ClaimableBalanceID balanceID;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -14991,7 +14992,7 @@ impl WriteXdr for ClawbackClaimableBalanceOp {
 //        uint32 setFlags;   // which flags to set
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15044,7 +15045,7 @@ pub const LIQUIDITY_POOL_FEE_V18: u64 = 30;
 //        Price maxPrice;   // maximum depositA/depositB
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15093,7 +15094,7 @@ impl WriteXdr for LiquidityPoolDepositOp {
 //        int64 minAmountB; // minimum amount of second asset to withdraw
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15138,7 +15139,7 @@ impl WriteXdr for LiquidityPoolWithdrawOp {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15240,7 +15241,7 @@ impl WriteXdr for HostFunction {
 //        LedgerFootprint footprint;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15330,7 +15331,7 @@ impl WriteXdr for InvokeHostFunctionOp {
 //        }
 //
 // union with discriminant OperationType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15650,7 +15651,7 @@ impl WriteXdr for OperationBody {
 //        body;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15689,7 +15690,7 @@ impl WriteXdr for Operation {
 //            uint32 opNum;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15733,7 +15734,7 @@ impl WriteXdr for HashIdPreimageOperationId {
 //            Asset asset;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15780,7 +15781,7 @@ impl WriteXdr for HashIdPreimageRevokeId {
 //            uint256 salt;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15818,7 +15819,7 @@ impl WriteXdr for HashIdPreimageEd25519ContractId {
 //            uint256 salt;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -15883,7 +15884,7 @@ impl WriteXdr for HashIdPreimageContractId {
 //    };
 //
 // union with discriminant EnvelopeType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16004,7 +16005,7 @@ impl WriteXdr for HashIdPreimage {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16124,7 +16125,7 @@ impl WriteXdr for MemoType {
 //    };
 //
 // union with discriminant MemoType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16241,7 +16242,7 @@ impl WriteXdr for Memo {
 //        TimePoint maxTime; // 0 here means no maxTime
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16279,7 +16280,7 @@ impl WriteXdr for TimeBounds {
 //        uint32 maxLedger; // 0 here means no maxLedger
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16344,7 +16345,7 @@ impl WriteXdr for LedgerBounds {
 //        SignerKey extraSigners<2>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16396,7 +16397,7 @@ impl WriteXdr for PreconditionsV2 {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16504,7 +16505,7 @@ impl WriteXdr for PreconditionType {
 //    };
 //
 // union with discriminant PreconditionType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16616,7 +16617,7 @@ pub const MAX_OPS_PER_TX: u64 = 100;
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16717,7 +16718,7 @@ impl WriteXdr for TransactionV0Ext {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16772,7 +16773,7 @@ impl WriteXdr for TransactionV0 {
 //        DecoratedSignature signatures<20>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16811,7 +16812,7 @@ impl WriteXdr for TransactionV0Envelope {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16923,7 +16924,7 @@ impl WriteXdr for TransactionExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -16978,7 +16979,7 @@ impl WriteXdr for Transaction {
 //        DecoratedSignature signatures<20>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -17017,7 +17018,7 @@ impl WriteXdr for TransactionV1Envelope {
 //        }
 //
 // union with discriminant EnvelopeType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -17109,7 +17110,7 @@ impl WriteXdr for FeeBumpTransactionInnerTx {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -17212,7 +17213,7 @@ impl WriteXdr for FeeBumpTransactionExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -17258,7 +17259,7 @@ impl WriteXdr for FeeBumpTransaction {
 //        DecoratedSignature signatures<20>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -17301,7 +17302,7 @@ impl WriteXdr for FeeBumpTransactionEnvelope {
 //    };
 //
 // union with discriminant EnvelopeType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -17410,7 +17411,7 @@ impl WriteXdr for TransactionEnvelope {
 //        }
 //
 // union with discriminant EnvelopeType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -17515,7 +17516,7 @@ impl WriteXdr for TransactionSignaturePayloadTaggedTransaction {
 //        taggedTransaction;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -17555,7 +17556,7 @@ impl WriteXdr for TransactionSignaturePayload {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -17667,7 +17668,7 @@ impl WriteXdr for ClaimAtomType {
 //        int64 amountBought;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -17726,7 +17727,7 @@ impl WriteXdr for ClaimOfferAtomV0 {
 //        int64 amountBought;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -17783,7 +17784,7 @@ impl WriteXdr for ClaimOfferAtom {
 //        int64 amountBought;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -17835,7 +17836,7 @@ impl WriteXdr for ClaimLiquidityAtom {
 //    };
 //
 // union with discriminant ClaimAtomType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -17948,7 +17949,7 @@ impl WriteXdr for ClaimAtom {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -18065,7 +18066,7 @@ impl WriteXdr for CreateAccountResultCode {
 //    };
 //
 // union with discriminant CreateAccountResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -18194,7 +18195,7 @@ impl WriteXdr for CreateAccountResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -18336,7 +18337,7 @@ impl WriteXdr for PaymentResultCode {
 //    };
 //
 // union with discriminant PaymentResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -18507,7 +18508,7 @@ impl WriteXdr for PaymentResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -18652,7 +18653,7 @@ impl WriteXdr for PathPaymentStrictReceiveResultCode {
 //        int64 amount;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -18693,7 +18694,7 @@ impl WriteXdr for SimplePaymentResult {
 //            SimplePaymentResult last;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -18752,7 +18753,7 @@ impl WriteXdr for PathPaymentStrictReceiveResultSuccess {
 //    };
 //
 // union with discriminant PathPaymentStrictReceiveResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -18944,7 +18945,7 @@ impl WriteXdr for PathPaymentStrictReceiveResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -19088,7 +19089,7 @@ impl WriteXdr for PathPaymentStrictSendResultCode {
 //            SimplePaymentResult last;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -19146,7 +19147,7 @@ impl WriteXdr for PathPaymentStrictSendResultSuccess {
 //    };
 //
 // union with discriminant PathPaymentStrictSendResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -19337,7 +19338,7 @@ impl WriteXdr for PathPaymentStrictSendResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -19482,7 +19483,7 @@ impl WriteXdr for ManageSellOfferResultCode {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -19589,7 +19590,7 @@ impl WriteXdr for ManageOfferEffect {
 //        }
 //
 // union with discriminant ManageOfferEffect
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -19704,7 +19705,7 @@ impl WriteXdr for ManageOfferSuccessResultOffer {
 //        offer;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -19756,7 +19757,7 @@ impl WriteXdr for ManageOfferSuccessResult {
 //    };
 //
 // union with discriminant ManageSellOfferResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -19942,7 +19943,7 @@ impl WriteXdr for ManageSellOfferResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -20099,7 +20100,7 @@ impl WriteXdr for ManageBuyOfferResultCode {
 //    };
 //
 // union with discriminant ManageBuyOfferResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -20279,7 +20280,7 @@ impl WriteXdr for ManageBuyOfferResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -20426,7 +20427,7 @@ impl WriteXdr for SetOptionsResultCode {
 //    };
 //
 // union with discriminant SetOptionsResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -20593,7 +20594,7 @@ impl WriteXdr for SetOptionsResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -20730,7 +20731,7 @@ impl WriteXdr for ChangeTrustResultCode {
 //    };
 //
 // union with discriminant ChangeTrustResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -20881,7 +20882,7 @@ impl WriteXdr for ChangeTrustResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -21008,7 +21009,7 @@ impl WriteXdr for AllowTrustResultCode {
 //    };
 //
 // union with discriminant AllowTrustResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -21147,7 +21148,7 @@ impl WriteXdr for AllowTrustResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -21279,7 +21280,7 @@ impl WriteXdr for AccountMergeResultCode {
 //    };
 //
 // union with discriminant AccountMergeResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -21417,7 +21418,7 @@ impl WriteXdr for AccountMergeResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -21514,7 +21515,7 @@ impl WriteXdr for InflationResultCode {
 //        int64 amount;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -21555,7 +21556,7 @@ impl WriteXdr for InflationPayout {
 //    };
 //
 // union with discriminant InflationResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -21660,7 +21661,7 @@ impl WriteXdr for InflationResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -21777,7 +21778,7 @@ impl WriteXdr for ManageDataResultCode {
 //    };
 //
 // union with discriminant ManageDataResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -21897,7 +21898,7 @@ impl WriteXdr for ManageDataResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -21999,7 +22000,7 @@ impl WriteXdr for BumpSequenceResultCode {
 //    };
 //
 // union with discriminant BumpSequenceResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -22103,7 +22104,7 @@ impl WriteXdr for BumpSequenceResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -22227,7 +22228,7 @@ impl WriteXdr for CreateClaimableBalanceResultCode {
 //    };
 //
 // union with discriminant CreateClaimableBalanceResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -22359,7 +22360,7 @@ impl WriteXdr for CreateClaimableBalanceResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -22482,7 +22483,7 @@ impl WriteXdr for ClaimClaimableBalanceResultCode {
 //    };
 //
 // union with discriminant ClaimClaimableBalanceResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -22613,7 +22614,7 @@ impl WriteXdr for ClaimClaimableBalanceResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -22727,7 +22728,7 @@ impl WriteXdr for BeginSponsoringFutureReservesResultCode {
 //    };
 //
 // union with discriminant BeginSponsoringFutureReservesResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -22844,7 +22845,7 @@ impl WriteXdr for BeginSponsoringFutureReservesResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -22948,7 +22949,7 @@ impl WriteXdr for EndSponsoringFutureReservesResultCode {
 //    };
 //
 // union with discriminant EndSponsoringFutureReservesResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -23057,7 +23058,7 @@ impl WriteXdr for EndSponsoringFutureReservesResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -23179,7 +23180,7 @@ impl WriteXdr for RevokeSponsorshipResultCode {
 //    };
 //
 // union with discriminant RevokeSponsorshipResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -23310,7 +23311,7 @@ impl WriteXdr for RevokeSponsorshipResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -23427,7 +23428,7 @@ impl WriteXdr for ClawbackResultCode {
 //    };
 //
 // union with discriminant ClawbackResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -23550,7 +23551,7 @@ impl WriteXdr for ClawbackResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -23664,7 +23665,7 @@ impl WriteXdr for ClawbackClaimableBalanceResultCode {
 //    };
 //
 // union with discriminant ClawbackClaimableBalanceResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -23786,7 +23787,7 @@ impl WriteXdr for ClawbackClaimableBalanceResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -23908,7 +23909,7 @@ impl WriteXdr for SetTrustLineFlagsResultCode {
 //    };
 //
 // union with discriminant SetTrustLineFlagsResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -24046,7 +24047,7 @@ impl WriteXdr for SetTrustLineFlagsResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -24179,7 +24180,7 @@ impl WriteXdr for LiquidityPoolDepositResultCode {
 //    };
 //
 // union with discriminant LiquidityPoolDepositResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -24327,7 +24328,7 @@ impl WriteXdr for LiquidityPoolDepositResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -24450,7 +24451,7 @@ impl WriteXdr for LiquidityPoolWithdrawResultCode {
 //    };
 //
 // union with discriminant LiquidityPoolWithdrawResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -24580,7 +24581,7 @@ impl WriteXdr for LiquidityPoolWithdrawResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -24688,7 +24689,7 @@ impl WriteXdr for InvokeHostFunctionResultCode {
 //    };
 //
 // union with discriminant InvokeHostFunctionResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -24801,7 +24802,7 @@ impl WriteXdr for InvokeHostFunctionResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -24969,7 +24970,7 @@ impl WriteXdr for OperationResultCode {
 //        }
 //
 // union with discriminant OperationType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -25297,7 +25298,7 @@ impl WriteXdr for OperationResultTr {
 //    };
 //
 // union with discriminant OperationResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -25448,7 +25449,7 @@ impl WriteXdr for OperationResult {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -25630,7 +25631,7 @@ impl WriteXdr for TransactionResultCode {
 //        }
 //
 // union with discriminant TransactionResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -25818,7 +25819,7 @@ impl WriteXdr for InnerTransactionResultResult {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -25942,7 +25943,7 @@ impl WriteXdr for InnerTransactionResultExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -25983,7 +25984,7 @@ impl WriteXdr for InnerTransactionResult {
 //        InnerTransactionResult result; // result for the inner transaction
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -26042,7 +26043,7 @@ impl WriteXdr for InnerTransactionResultPair {
 //        }
 //
 // union with discriminant TransactionResultCode
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -26246,7 +26247,7 @@ impl WriteXdr for TransactionResultResult {
 //        }
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -26371,7 +26372,7 @@ impl WriteXdr for TransactionResultExt {
 //        ext;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -26408,7 +26409,7 @@ impl WriteXdr for TransactionResult {
 //
 //   typedef opaque Hash[32];
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -26494,7 +26495,7 @@ impl AsRef<[u8]> for Hash {
 //
 //   typedef opaque uint256[32];
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -26609,7 +26610,7 @@ pub type Int64 = i64;
 //    };
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -26706,7 +26707,7 @@ impl WriteXdr for ExtensionPoint {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -26817,7 +26818,7 @@ impl WriteXdr for CryptoKeyType {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -26913,7 +26914,7 @@ impl WriteXdr for PublicKeyType {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -27021,7 +27022,7 @@ impl WriteXdr for SignerKeyType {
 //    };
 //
 // union with discriminant PublicKeyType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -27116,7 +27117,7 @@ impl WriteXdr for PublicKey {
 //            opaque payload<64>;
 //        }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -27169,7 +27170,7 @@ impl WriteXdr for SignerKeyEd25519SignedPayload {
 //    };
 //
 // union with discriminant SignerKeyType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -27278,7 +27279,7 @@ impl WriteXdr for SignerKey {
 //
 //   typedef opaque Signature<64>;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -27376,7 +27377,7 @@ impl AsRef<[u8]> for Signature {
 //
 //   typedef opaque SignatureHint[4];
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -27462,7 +27463,7 @@ impl AsRef<[u8]> for SignatureHint {
 //
 //   typedef PublicKey NodeID;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -27514,7 +27515,7 @@ impl WriteXdr for NodeId {
 //        opaque key[32];
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -27548,7 +27549,7 @@ impl WriteXdr for Curve25519Secret {
 //        opaque key[32];
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -27582,7 +27583,7 @@ impl WriteXdr for Curve25519Public {
 //        opaque key[32];
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -27616,7 +27617,7 @@ impl WriteXdr for HmacSha256Key {
 //        opaque mac[32];
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -27664,7 +27665,7 @@ pub type ScSymbol = VecM<u8, 10>;
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -27790,7 +27791,7 @@ impl WriteXdr for ScValType {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -27905,7 +27906,7 @@ impl WriteXdr for ScStatic {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -28039,7 +28040,7 @@ impl WriteXdr for ScStatusType {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -28184,7 +28185,7 @@ impl WriteXdr for ScHostValErrorCode {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -28307,7 +28308,7 @@ impl WriteXdr for ScHostObjErrorCode {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -28423,7 +28424,7 @@ impl WriteXdr for ScHostFnErrorCode {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -28539,7 +28540,7 @@ impl WriteXdr for ScHostStorageErrorCode {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -28655,7 +28656,7 @@ impl WriteXdr for ScHostContextErrorCode {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -28823,7 +28824,7 @@ impl WriteXdr for ScVmErrorCode {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -28935,7 +28936,7 @@ impl WriteXdr for ScUnknownErrorCode {
 //    };
 //
 // union with discriminant ScStatusType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -29093,7 +29094,7 @@ impl WriteXdr for ScStatus {
 //    };
 //
 // union with discriminant ScValType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -29240,7 +29241,7 @@ impl WriteXdr for ScVal {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -29363,7 +29364,7 @@ impl WriteXdr for ScObjectType {
 //        SCVal val;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -29403,7 +29404,7 @@ pub const SCVAL_LIMIT: u64 = 256000;
 //
 //   typedef SCVal SCVec<SCVAL_LIMIT>;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -29501,7 +29502,7 @@ impl AsRef<[ScVal]> for ScVec {
 //
 //   typedef SCMapEntry SCMap<SCVAL_LIMIT>;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -29605,7 +29606,7 @@ impl AsRef<[ScMapEntry]> for ScMap {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -29709,7 +29710,7 @@ impl WriteXdr for ScNumSign {
 //    };
 //
 // union with discriminant ScNumSign
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -29811,7 +29812,7 @@ impl WriteXdr for ScBigInt {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -29905,7 +29906,7 @@ impl WriteXdr for ScHashType {
 //    };
 //
 // union with discriminant ScHashType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -30011,7 +30012,7 @@ impl WriteXdr for ScHash {
 //    };
 //
 // union with discriminant ScObjectType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -30146,7 +30147,7 @@ impl WriteXdr for ScObject {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -30240,7 +30241,7 @@ impl WriteXdr for ScEnvMetaKind {
 //    };
 //
 // union with discriminant ScEnvMetaKind
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -30354,7 +30355,7 @@ impl WriteXdr for ScEnvMetaEntry {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -30512,7 +30513,7 @@ impl WriteXdr for ScSpecType {
 //        SCSpecTypeDef valueType;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -30547,7 +30548,7 @@ impl WriteXdr for ScSpecTypeOption {
 //        SCSpecTypeDef errorType;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -30584,7 +30585,7 @@ impl WriteXdr for ScSpecTypeResult {
 //        SCSpecTypeDef elementType;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -30619,7 +30620,7 @@ impl WriteXdr for ScSpecTypeVec {
 //        SCSpecTypeDef valueType;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -30656,7 +30657,7 @@ impl WriteXdr for ScSpecTypeMap {
 //        SCSpecTypeDef elementType;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -30690,7 +30691,7 @@ impl WriteXdr for ScSpecTypeSet {
 //        SCSpecTypeDef valueTypes<12>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -30724,7 +30725,7 @@ impl WriteXdr for ScSpecTypeTuple {
 //        string name<60>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -30783,7 +30784,7 @@ impl WriteXdr for ScSpecTypeUdt {
 //    };
 //
 // union with discriminant ScSpecType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -30972,7 +30973,7 @@ impl WriteXdr for ScSpecTypeDef {
 //        SCSpecTypeDef type;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -31010,7 +31011,7 @@ impl WriteXdr for ScSpecUdtStructFieldV0 {
 //        SCSpecUDTStructFieldV0 fields<40>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -31048,7 +31049,7 @@ impl WriteXdr for ScSpecUdtStructV0 {
 //        SCSpecTypeDef *type;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -31086,7 +31087,7 @@ impl WriteXdr for ScSpecUdtUnionCaseV0 {
 //        SCSpecUDTUnionCaseV0 cases<50>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -31125,7 +31126,7 @@ impl WriteXdr for ScSpecUdtUnionV0 {
 //        SCSpecTypeDef outputTypes<1>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -31168,7 +31169,7 @@ impl WriteXdr for ScSpecFunctionV0 {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),
@@ -31276,7 +31277,7 @@ impl WriteXdr for ScSpecEntryKind {
 //    };
 //
 // union with discriminant ScSpecEntryKind
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
     derive(serde::Serialize, serde::Deserialize),

--- a/tests/arbitrary.rs
+++ b/tests/arbitrary.rs
@@ -1,3 +1,5 @@
+#![cfg(all(feature = "next", feature = "arbitrary"))]
+
 use arbitrary::{Arbitrary, Unstructured};
 use stellar_xdr::ScMap;
 
@@ -7,6 +9,6 @@ fn arb() {
     let mut unstructured = Unstructured::new(&bytes);
     for _ in 1..10 {
         let x: ScMap = ScMap::arbitrary(&mut unstructured).unwrap();
-        eprintln!("{:?}", x);    
+        eprintln!("{:?}", x);
     }
 }

--- a/tests/arbitrary.rs
+++ b/tests/arbitrary.rs
@@ -1,0 +1,12 @@
+use arbitrary::{Arbitrary, Unstructured};
+use stellar_xdr::ScMap;
+
+#[test]
+fn arb() {
+    let bytes: Vec<u8> = (1u8..255).collect();
+    let mut unstructured = Unstructured::new(&bytes);
+    for _ in 1..10 {
+        let x: ScMap = ScMap::arbitrary(&mut unstructured).unwrap();
+        eprintln!("{:?}", x);    
+    }
+}


### PR DESCRIPTION
Obviously this needs to move upstream to xdrgen (I will post a version of the minimal change needed there too) but this is a sketch of what support for `Arbitrary` looks like. Very straightforward -- the only question I think I have is whether @leighmcculloch you'd like it to be cfg'ed behind another feature or not. Argument for feature-cfg'ing is that obviously "it's more code" people might not want to compile; argument against is that "every feature makes a larger powerset".