### PR TITLE
Add `ContractEvent` and `ContractEventType` definitions from CAP-56

### DIFF
--- a/xdr/next/Stellar-ledger.x
+++ b/xdr/next/Stellar-ledger.x
@@ -359,6 +359,33 @@ struct TransactionMetaV2
                                         // applied if any
 };
 
+enum ContractEventType
+{
+    SYSTEM = 0,
+    CONTRACT = 1
+};
+
+struct ContractEvent
+{
+    // We can use this to add more fields, or because it
+    // is first, to change ContractEvent into a union.
+    ExtensionPoint ext;
+
+    Hash contractID;
+    ContractEventType type;
+
+    union switch (int v)
+    {
+    case 0:
+        struct
+        {
+            SCVec topics;
+            SCVal data;
+        } v0;
+    }
+    body;
+};
+
 // this is the meta produced when applying transactions
 // it does not include pre-apply updates such as fees
 union TransactionMeta switch (int v)


### PR DESCRIPTION
### What

Add `ContractEvent` and `ContractEventType`  from https://github.com/stellar/stellar-protocol/blob/master/core/cap-0056.md#xdr-changes, 

This is good for now as it unblocks the contract event changes on the host env. 

### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]
