### PR TITLE
Regenerate from stellar-xdr-next@35f1e4e

### DIFF
--- a/src/next.rs
+++ b/src/next.rs
@@ -27,7 +27,7 @@ pub const XDR_FILES_SHA256: [(&str, &str); 9] = [
     ),
     (
         "xdr/next/Stellar-contract.x",
-        "e5d7861ce8a0629daa8d0e71efdc01c345ab96880a939b89fd39a04a9dd84236",
+        "0eb75f128f55a899a9ccecd4c5a2a4dcd7ef0cc56ff068ffeb419f55d1a72f74",
     ),
     (
         "xdr/next/Stellar-ledger-entries.x",
@@ -29626,17 +29626,17 @@ impl WriteXdr for ScUnknownErrorCode {
 //    case SST_UNKNOWN_ERROR:
 //        SCUnknownErrorCode unknownCode;
 //    case SST_HOST_VALUE_ERROR:
-//        SCHostValErrorCode errorCode;
+//        SCHostValErrorCode valCode;
 //    case SST_HOST_OBJECT_ERROR:
-//        SCHostObjErrorCode errorCode;
+//        SCHostObjErrorCode objCode;
 //    case SST_HOST_FUNCTION_ERROR:
-//        SCHostFnErrorCode errorCode;
+//        SCHostFnErrorCode fnCode;
 //    case SST_HOST_STORAGE_ERROR:
-//        SCHostStorageErrorCode errorCode;
+//        SCHostStorageErrorCode storageCode;
 //    case SST_HOST_CONTEXT_ERROR:
-//        SCHostContextErrorCode errorCode;
+//        SCHostContextErrorCode contextCode;
 //    case SST_VM_ERROR:
-//        SCVmErrorCode errorCode;
+//        SCVmErrorCode vmCode;
 //    };
 //
 // union with discriminant ScStatusType

--- a/xdr/next/Stellar-contract.x
+++ b/xdr/next/Stellar-contract.x
@@ -168,17 +168,17 @@ case SST_OK:
 case SST_UNKNOWN_ERROR:
     SCUnknownErrorCode unknownCode;
 case SST_HOST_VALUE_ERROR:
-    SCHostValErrorCode errorCode;
+    SCHostValErrorCode valCode;
 case SST_HOST_OBJECT_ERROR:
-    SCHostObjErrorCode errorCode;
+    SCHostObjErrorCode objCode;
 case SST_HOST_FUNCTION_ERROR:
-    SCHostFnErrorCode errorCode;
+    SCHostFnErrorCode fnCode;
 case SST_HOST_STORAGE_ERROR:
-    SCHostStorageErrorCode errorCode;
+    SCHostStorageErrorCode storageCode;
 case SST_HOST_CONTEXT_ERROR:
-    SCHostContextErrorCode errorCode;
+    SCHostContextErrorCode contextCode;
 case SST_VM_ERROR:
-    SCVmErrorCode errorCode;
+    SCVmErrorCode vmCode;
 };
 
 union SCVal switch (SCValType type)


### PR DESCRIPTION
Regenerate based on changes that landed in stellar-xdr-next and some changes that first landed here and then were ported over to stellar-xdr-next in https://github.com/stellar/stellar-xdr-next/pull/21