### PR TITLE
Add VecM::to_string_lossy

### DIFF
--- a/src/curr.rs
+++ b/src/curr.rs
@@ -608,6 +608,18 @@ impl<const MAX: u32> VecM<u8, MAX> {
     pub fn into_string(self) -> Result<String> {
         self.try_into()
     }
+
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn to_string_lossy(&self) -> String {
+        String::from_utf8_lossy(&self.0).into_owned()
+    }
+
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn into_string_lossy(self) -> String {
+        String::from_utf8_lossy(&self.0).into_owned()
+    }
 }
 
 impl<T: Clone> VecM<T, 1> {

--- a/src/next.rs
+++ b/src/next.rs
@@ -623,6 +623,18 @@ impl<const MAX: u32> VecM<u8, MAX> {
     pub fn into_string(self) -> Result<String> {
         self.try_into()
     }
+
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn to_string_lossy(&self) -> String {
+        String::from_utf8_lossy(&self.0).into_owned()
+    }
+
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn into_string_lossy(self) -> String {
+        String::from_utf8_lossy(&self.0).into_owned()
+    }
 }
 
 impl<T: Clone> VecM<T, 1> {


### PR DESCRIPTION
### What
Add VecM::to_string_lossy.

### Why
For convenient conversion of VecM to String's in scenarios where losing or ignoring non-utf8 characters is unimportant.