### PR TITLE
Impl From<&u64> for ScVal

### DIFF
--- a/src/scval_conversions.rs
+++ b/src/scval_conversions.rs
@@ -230,6 +230,12 @@ impl From<u64> for ScVal {
     }
 }
 
+impl From<&u64> for ScVal {
+    fn from(v: &u64) -> Self {
+        <_ as Into<ScObject>>::into(v).into()
+    }
+}
+
 impl TryFrom<ScObject> for u64 {
     type Error = ();
     fn try_from(v: ScObject) -> Result<Self, Self::Error> {


### PR DESCRIPTION
### What

`impl From<&u64> for ScVal`

### Why

Related to https://github.com/stellar/rs-soroban-sdk/issues/518. These conversions exist for `i32`, `u32`, and `i64`.

### Known limitations

None