### PR TITLE
Remove bump-version make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,8 +77,5 @@ reset-xdr:
 fmt:
 	cargo fmt --all
 
-bump-version:
-	cargo workspaces version --all --force '*' --no-git-commit --yes custom $(VERSION)
-
 publish:
 	cargo workspaces publish --all --force '*' --from-git --yes


### PR DESCRIPTION
### What
Remove bump-version make target.

### Why
It is no longer used because the bump version workflow runs from the stellar/actions repo.