### PR TITLE
Set the target-dir for cargo installs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,7 +63,7 @@ jobs:
     - uses: stellar/actions/rust-cache@main
     - run: rustup update
     - run: rustup target add ${{ matrix.sys.target }}
-    - run: cargo install --locked --version 0.5.16 cargo-hack
+    - run: cargo install --target-dir ~/.cargo/target --locked --version 0.5.16 cargo-hack
     - if: "github.ref_protected"
       run: echo 'CARGO_HACK_ARGS=--feature-powerset' >> $GITHUB_ENV
     - if: "!github.ref_protected"
@@ -85,7 +85,7 @@ jobs:
     - uses: stellar/actions/rust-cache@main
     - run: rustup update
     - run: rustup target add wasm32-unknown-unknown
-    - run: cargo install --locked --version 0.2.35 cargo-workspaces
+    - run: cargo install --target-dir ~/.cargo/target --locked --version 0.2.35 cargo-workspaces
     - run: make publish
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
### What
Set the target-dir for cargo installs.

### Why
So that the builds of bins installed are cached.