### PR TITLE
Add publish dry run to build on release branches

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
 
   complete:
     if: always()
-    needs: [generate, fmt, build, test]
+    needs: [generate, fmt, build, test, package-verify]
     runs-on: ubuntu-latest
     steps:
     - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
@@ -89,6 +89,34 @@ jobs:
     - if: "!github.ref_protected"
       run: echo 'CARGO_HACK_ARGS=--feature-powerset --exclude-features default --group-features base64,serde,num-bigint,arbitrary' >> $GITHUB_ENV
     - run: cargo hack test $CARGO_HACK_ARGS
+
+  package-verify:
+    if: startsWith(github.head_ref, 'release/')
+    strategy:
+      matrix:
+        sys:
+        - os: ubuntu-latest
+          target: wasm32-unknown-unknown
+        - os: ubuntu-latest
+          target: x86_64-unknown-linux-gnu
+        # TODO: Address GitHub Actions concurrency limits and re-enable.
+        # - os: macos-latest
+        #   target: x86_64-apple-darwin
+        # - os: macos-latest
+        #   target: aarch64-apple-darwin
+        # TODO: Address disk space usage problems and re-enable.
+        # - os: windows-latest
+        #   target: x86_64-pc-windows-msvc
+    runs-on: ${{ matrix.sys.os }}
+    steps:
+    - uses: actions/checkout@v3
+    - uses: stellar/actions/rust-cache@main
+    - run: rustup update
+    - run: rustup target add ${{ matrix.sys.target }}
+    - run: cargo install --target-dir ~/.cargo/target --locked --version 0.5.16 cargo-hack
+    - uses: stellar/actions/rust-workspace-publish-dry-run@main
+      with:
+        cargo-package-options: --target ${{ matrix.sys.target }}
 
   publish:
     if: github.event_name == 'release'


### PR DESCRIPTION
### What
Add publish dry run to build on release branches.

### Why
To ensure that release/ branches created by the bump version workflow are ready to go and will succeed when published.

Note that unlike our other Rust repos the package verification is done in a different workflow because of the length of time these workflows take for this specific package.