### PR TITLE
Update xdr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ XDR_FILES_CURR= \
 	Stellar-types.x
 XDR_FILES_LOCAL_CURR=$(addprefix xdr/curr/,$(XDR_FILES_CURR))
 
-XDR_BASE_URL_NEXT=https://github.com/stellar/stellar-xdr-next/raw/7bbc6a1b
+XDR_BASE_URL_NEXT=https://github.com/stellar/stellar-xdr-next/raw/main
 XDR_BASE_LOCAL_NEXT=xdr/next
 XDR_FILES_NEXT= \
 	Stellar-SCP.x \

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ XDR_FILES_CURR= \
 	Stellar-types.x
 XDR_FILES_LOCAL_CURR=$(addprefix xdr/curr/,$(XDR_FILES_CURR))
 
-XDR_BASE_URL_NEXT=https://github.com/stellar/stellar-xdr-next/raw/main
+XDR_BASE_URL_NEXT=https://github.com/stellar/stellar-xdr-next/raw/7bbc6a1b
 XDR_BASE_LOCAL_NEXT=xdr/next
 XDR_FILES_NEXT= \
 	Stellar-SCP.x \

--- a/src/next.rs
+++ b/src/next.rs
@@ -23,7 +23,7 @@ pub const XDR_FILES_SHA256: [(&str, &str); 9] = [
     ),
     (
         "xdr/next/Stellar-contract-spec.x",
-        "87a80c63cf6b757218ea07cb2a13e80c31fd0f08c81b872806455ea830d9fef6",
+        "11024aa780873312446d814d8bd37aeced7a8fa35ce2eeee2e24d59c4f13a29b",
     ),
     (
         "xdr/next/Stellar-contract.x",
@@ -32652,6 +32652,88 @@ impl WriteXdr for ScSpecUdtUnionV0 {
     }
 }
 
+// ScSpecUdtEnumCaseV0 is an XDR Struct defines as:
+//
+//   struct SCSpecUDTEnumCaseV0
+//    {
+//        string name<60>;
+//        uint32 value;
+//    };
+//
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[cfg_attr(
+    all(feature = "serde", feature = "alloc"),
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "camelCase")
+)]
+pub struct ScSpecUdtEnumCaseV0 {
+    pub name: VecM<u8, 60>,
+    pub value: u32,
+}
+
+impl ReadXdr for ScSpecUdtEnumCaseV0 {
+    #[cfg(feature = "std")]
+    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+        Ok(Self {
+            name: VecM::<u8, 60>::read_xdr(r)?,
+            value: u32::read_xdr(r)?,
+        })
+    }
+}
+
+impl WriteXdr for ScSpecUdtEnumCaseV0 {
+    #[cfg(feature = "std")]
+    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+        self.name.write_xdr(w)?;
+        self.value.write_xdr(w)?;
+        Ok(())
+    }
+}
+
+// ScSpecUdtEnumV0 is an XDR Struct defines as:
+//
+//   struct SCSpecUDTEnumV0
+//    {
+//        string lib<80>;
+//        string name<60>;
+//        SCSpecUDTEnumCaseV0 cases<50>;
+//    };
+//
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[cfg_attr(
+    all(feature = "serde", feature = "alloc"),
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "camelCase")
+)]
+pub struct ScSpecUdtEnumV0 {
+    pub lib: VecM<u8, 80>,
+    pub name: VecM<u8, 60>,
+    pub cases: VecM<ScSpecUdtEnumCaseV0, 50>,
+}
+
+impl ReadXdr for ScSpecUdtEnumV0 {
+    #[cfg(feature = "std")]
+    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+        Ok(Self {
+            lib: VecM::<u8, 80>::read_xdr(r)?,
+            name: VecM::<u8, 60>::read_xdr(r)?,
+            cases: VecM::<ScSpecUdtEnumCaseV0, 50>::read_xdr(r)?,
+        })
+    }
+}
+
+impl WriteXdr for ScSpecUdtEnumV0 {
+    #[cfg(feature = "std")]
+    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+        self.lib.write_xdr(w)?;
+        self.name.write_xdr(w)?;
+        self.cases.write_xdr(w)?;
+        Ok(())
+    }
+}
+
 // ScSpecFunctionInputV0 is an XDR Struct defines as:
 //
 //   struct SCSpecFunctionInputV0
@@ -32740,7 +32822,8 @@ impl WriteXdr for ScSpecFunctionV0 {
 //    {
 //        SC_SPEC_ENTRY_FUNCTION_V0 = 0,
 //        SC_SPEC_ENTRY_UDT_STRUCT_V0 = 1,
-//        SC_SPEC_ENTRY_UDT_UNION_V0 = 2
+//        SC_SPEC_ENTRY_UDT_UNION_V0 = 2,
+//        SC_SPEC_ENTRY_UDT_ENUM_V0 = 3
 //    };
 //
 // enum
@@ -32756,6 +32839,7 @@ pub enum ScSpecEntryKind {
     FunctionV0 = 0,
     UdtStructV0 = 1,
     UdtUnionV0 = 2,
+    UdtEnumV0 = 3,
 }
 
 impl ScSpecEntryKind {
@@ -32765,15 +32849,17 @@ impl ScSpecEntryKind {
             Self::FunctionV0 => "FunctionV0",
             Self::UdtStructV0 => "UdtStructV0",
             Self::UdtUnionV0 => "UdtUnionV0",
+            Self::UdtEnumV0 => "UdtEnumV0",
         }
     }
 
     #[must_use]
-    pub const fn variants() -> [ScSpecEntryKind; 3] {
-        const VARIANTS: [ScSpecEntryKind; 3] = [
+    pub const fn variants() -> [ScSpecEntryKind; 4] {
+        const VARIANTS: [ScSpecEntryKind; 4] = [
             ScSpecEntryKind::FunctionV0,
             ScSpecEntryKind::UdtStructV0,
             ScSpecEntryKind::UdtUnionV0,
+            ScSpecEntryKind::UdtEnumV0,
         ];
         VARIANTS
     }
@@ -32788,7 +32874,7 @@ impl Name for ScSpecEntryKind {
 
 impl Variants<ScSpecEntryKind> for ScSpecEntryKind {
     fn variants() -> slice::Iter<'static, ScSpecEntryKind> {
-        const VARIANTS: [ScSpecEntryKind; 3] = ScSpecEntryKind::variants();
+        const VARIANTS: [ScSpecEntryKind; 4] = ScSpecEntryKind::variants();
         VARIANTS.iter()
     }
 }
@@ -32809,6 +32895,7 @@ impl TryFrom<i32> for ScSpecEntryKind {
             0 => ScSpecEntryKind::FunctionV0,
             1 => ScSpecEntryKind::UdtStructV0,
             2 => ScSpecEntryKind::UdtUnionV0,
+            3 => ScSpecEntryKind::UdtEnumV0,
             #[allow(unreachable_patterns)]
             _ => return Err(Error::Invalid),
         };
@@ -32850,6 +32937,8 @@ impl WriteXdr for ScSpecEntryKind {
 //        SCSpecUDTStructV0 udtStructV0;
 //    case SC_SPEC_ENTRY_UDT_UNION_V0:
 //        SCSpecUDTUnionV0 udtUnionV0;
+//    case SC_SPEC_ENTRY_UDT_ENUM_V0:
+//        SCSpecUDTEnumV0 udtEnumV0;
 //    };
 //
 // union with discriminant ScSpecEntryKind
@@ -32865,6 +32954,7 @@ pub enum ScSpecEntry {
     FunctionV0(ScSpecFunctionV0),
     UdtStructV0(ScSpecUdtStructV0),
     UdtUnionV0(ScSpecUdtUnionV0),
+    UdtEnumV0(ScSpecUdtEnumV0),
 }
 
 impl ScSpecEntry {
@@ -32874,6 +32964,7 @@ impl ScSpecEntry {
             Self::FunctionV0(_) => "FunctionV0",
             Self::UdtStructV0(_) => "UdtStructV0",
             Self::UdtUnionV0(_) => "UdtUnionV0",
+            Self::UdtEnumV0(_) => "UdtEnumV0",
         }
     }
 
@@ -32884,15 +32975,17 @@ impl ScSpecEntry {
             Self::FunctionV0(_) => ScSpecEntryKind::FunctionV0,
             Self::UdtStructV0(_) => ScSpecEntryKind::UdtStructV0,
             Self::UdtUnionV0(_) => ScSpecEntryKind::UdtUnionV0,
+            Self::UdtEnumV0(_) => ScSpecEntryKind::UdtEnumV0,
         }
     }
 
     #[must_use]
-    pub const fn variants() -> [ScSpecEntryKind; 3] {
-        const VARIANTS: [ScSpecEntryKind; 3] = [
+    pub const fn variants() -> [ScSpecEntryKind; 4] {
+        const VARIANTS: [ScSpecEntryKind; 4] = [
             ScSpecEntryKind::FunctionV0,
             ScSpecEntryKind::UdtStructV0,
             ScSpecEntryKind::UdtUnionV0,
+            ScSpecEntryKind::UdtEnumV0,
         ];
         VARIANTS
     }
@@ -32914,7 +33007,7 @@ impl Discriminant<ScSpecEntryKind> for ScSpecEntry {
 
 impl Variants<ScSpecEntryKind> for ScSpecEntry {
     fn variants() -> slice::Iter<'static, ScSpecEntryKind> {
-        const VARIANTS: [ScSpecEntryKind; 3] = ScSpecEntry::variants();
+        const VARIANTS: [ScSpecEntryKind; 4] = ScSpecEntry::variants();
         VARIANTS.iter()
     }
 }
@@ -32930,6 +33023,7 @@ impl ReadXdr for ScSpecEntry {
             ScSpecEntryKind::FunctionV0 => Self::FunctionV0(ScSpecFunctionV0::read_xdr(r)?),
             ScSpecEntryKind::UdtStructV0 => Self::UdtStructV0(ScSpecUdtStructV0::read_xdr(r)?),
             ScSpecEntryKind::UdtUnionV0 => Self::UdtUnionV0(ScSpecUdtUnionV0::read_xdr(r)?),
+            ScSpecEntryKind::UdtEnumV0 => Self::UdtEnumV0(ScSpecUdtEnumV0::read_xdr(r)?),
             #[allow(unreachable_patterns)]
             _ => return Err(Error::Invalid),
         };
@@ -32946,6 +33040,7 @@ impl WriteXdr for ScSpecEntry {
             Self::FunctionV0(v) => v.write_xdr(w)?,
             Self::UdtStructV0(v) => v.write_xdr(w)?,
             Self::UdtUnionV0(v) => v.write_xdr(w)?,
+            Self::UdtEnumV0(v) => v.write_xdr(w)?,
         };
         Ok(())
     }

--- a/xdr/curr/Stellar-overlay.x
+++ b/xdr/curr/Stellar-overlay.x
@@ -47,11 +47,20 @@ struct Hello
     uint256 nonce;
 };
 
+
+// During the roll-out phrase, pull mode will be optional.
+// Therefore, we need a way to communicate with other nodes
+// that we want/don't want pull mode.
+// However, the goal is for everyone to enable it by default,
+// so we don't want to introduce a new member variable.
+// For now, we'll use the `flags` field (originally named
+// `unused`) in `Auth`.
+// 100 is just a number that is not 0.
+const AUTH_MSG_FLAG_PULL_MODE_REQUESTED = 100;
+
 struct Auth
 {
-    // Empty message, just to confirm
-    // establishment of MAC keys.
-    int unused;
+    int flags;
 };
 
 enum IPAddrType
@@ -102,7 +111,9 @@ enum MessageType
     SURVEY_REQUEST = 14,
     SURVEY_RESPONSE = 15,
 
-    SEND_MORE = 16
+    SEND_MORE = 16,
+    FLOOD_ADVERT = 18,
+    FLOOD_DEMAND = 19
 };
 
 struct DontHave
@@ -185,6 +196,22 @@ case SURVEY_TOPOLOGY:
     TopologyResponseBody topologyResponseBody;
 };
 
+const TX_ADVERT_VECTOR_MAX_SIZE = 1000;
+typedef Hash TxAdvertVector<TX_ADVERT_VECTOR_MAX_SIZE>;
+
+struct FloodAdvert
+{
+    TxAdvertVector txHashes;
+};
+
+const TX_DEMAND_VECTOR_MAX_SIZE = 1000;
+typedef Hash TxDemandVector<TX_DEMAND_VECTOR_MAX_SIZE>;
+
+struct FloodDemand
+{
+    TxDemandVector txHashes;
+};
+
 union StellarMessage switch (MessageType type)
 {
 case ERROR_MSG:
@@ -227,6 +254,12 @@ case GET_SCP_STATE:
     uint32 getSCPLedgerSeq; // ledger seq requested ; if 0, requests the latest
 case SEND_MORE:
     SendMore sendMoreMessage;
+
+// Pull mode
+case FLOOD_ADVERT:
+     FloodAdvert floodAdvert;
+case FLOOD_DEMAND:
+     FloodDemand floodDemand;
 };
 
 union AuthenticatedMessage switch (uint32 v)

--- a/xdr/next/Stellar-contract-spec.x
+++ b/xdr/next/Stellar-contract-spec.x
@@ -139,6 +139,19 @@ struct SCSpecUDTUnionV0
     SCSpecUDTUnionCaseV0 cases<50>;
 };
 
+struct SCSpecUDTEnumCaseV0
+{
+    string name<60>;
+    uint32 value;
+};
+
+struct SCSpecUDTEnumV0
+{
+    string lib<80>;
+    string name<60>;
+    SCSpecUDTEnumCaseV0 cases<50>;
+};
+
 struct SCSpecFunctionInputV0
 {
     string name<30>;
@@ -156,7 +169,8 @@ enum SCSpecEntryKind
 {
     SC_SPEC_ENTRY_FUNCTION_V0 = 0,
     SC_SPEC_ENTRY_UDT_STRUCT_V0 = 1,
-    SC_SPEC_ENTRY_UDT_UNION_V0 = 2
+    SC_SPEC_ENTRY_UDT_UNION_V0 = 2,
+    SC_SPEC_ENTRY_UDT_ENUM_V0 = 3
 };
 
 union SCSpecEntry switch (SCSpecEntryKind kind)
@@ -167,6 +181,8 @@ case SC_SPEC_ENTRY_UDT_STRUCT_V0:
     SCSpecUDTStructV0 udtStructV0;
 case SC_SPEC_ENTRY_UDT_UNION_V0:
     SCSpecUDTUnionV0 udtUnionV0;
+case SC_SPEC_ENTRY_UDT_ENUM_V0:
+    SCSpecUDTEnumV0 udtEnumV0;
 };
 
 }


### PR DESCRIPTION
### What
Update xdr.

### Why
To get the XDR for adding enum as a contract spec type.

Related to https://github.com/stellar/stellar-xdr-next/pull/34.