### PR TITLE
Rust-XDR for contract deployment changes specified in CAP-46-02

### DIFF
--- a/src/next.rs
+++ b/src/next.rs
@@ -15,39 +15,39 @@
 pub const XDR_FILES_SHA256: [(&str, &str); 9] = [
     (
         "xdr/next/Stellar-SCP.x",
-        "8f32b04d008f8bc33b8843d075e69837231a673691ee41d8b821ca229a6e802a",
+        "2b855c7f79b8e50cf15ca1e1aa89fb16bbb38117de0b1c969c80e675ae1ca4bb",
     ),
     (
         "xdr/next/Stellar-contract-env-meta.x",
-        "928a30de814ee589bc1d2aadd8dd81c39f71b7e6f430f56974505ccb1f49654b",
+        "8d30dbf039e41e149725b34f2c809fc034c0879adac9d85fc49b8371f9a0444f",
     ),
     (
         "xdr/next/Stellar-contract-spec.x",
-        "8819c9b462fcc74199f051989ad14621b833036e8fed0fa3a1b83abda84a8bfc",
+        "93314675c50e026df2c0505c89efd917a1a4327896644c8d6efb3b72630d59e4",
     ),
     (
         "xdr/next/Stellar-contract.x",
-        "1cbf58f3a8e3f7d2f700ae48551782344c095ec38d2a36618d33ad1af18a39d1",
+        "4c9a04dae392675deb8c51f397b614bcb6b963b987beb32372038af0605e4462",
     ),
     (
         "xdr/next/Stellar-ledger-entries.x",
-        "b06993820d3488cf05d69755de7fef2f1b1ad9c185d2f55ce78b9fb556c17dcf",
+        "76ed66cb96eb29db8ccfc03434d00679e7ea35668ff8469d5cc8fdd9a743465a",
     ),
     (
         "xdr/next/Stellar-ledger.x",
-        "c1b43f57346f5ca124c79a1c05a33043bcb9a8185432efec848b7001afd3bb25",
+        "9949aa422c521116d5bc1e4fa508f07d6670a54fd421ff93ca1dbc2742979e1c",
     ),
     (
         "xdr/next/Stellar-overlay.x",
-        "5b45fe3bd74abb25d91db4c729f3fb57a438d0a2a012f7a1c1118f1bb4d23637",
+        "56d0a34446e90f047e7d9d862c881d710abac37ac6ccabc37de7b2d23b77056f",
     ),
     (
         "xdr/next/Stellar-transaction.x",
-        "dc270655d2c26d656c7b035bc3003477dfab1097d3c46ff1cee6d68602af114c",
+        "728244001903fe06ec6d5a23b81256adbccf1b0c0817ec084aa2703980889a75",
     ),
     (
         "xdr/next/Stellar-types.x",
-        "7b3e5470c4bcf7c19f9cc8f8bf81a494b540fc2157476329cf19863afab2343b",
+        "92991a74191509be836e0507081b8624f38bde51994d5c4554b0347c0c68ac6c",
     ),
 ];
 
@@ -564,7 +564,7 @@ impl ReadXdr for bool {
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
     fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let i: u32 = if *self { 1 } else { 0 };
+        let i = u32::from(*self); // true = 1, false = 0
         i.write_xdr(w)?;
         Ok(())
     }
@@ -3971,7 +3971,8 @@ impl WriteXdr for ThresholdIndexes {
 //        CLAIMABLE_BALANCE = 4,
 //        LIQUIDITY_POOL = 5,
 //        CONTRACT_DATA = 6,
-//        CONFIG_SETTING = 7
+//        CONTRACT_CODE = 7,
+//        CONFIG_SETTING = 8
 //    };
 //
 // enum
@@ -3991,11 +3992,12 @@ pub enum LedgerEntryType {
     ClaimableBalance = 4,
     LiquidityPool = 5,
     ContractData = 6,
-    ConfigSetting = 7,
+    ContractCode = 7,
+    ConfigSetting = 8,
 }
 
 impl LedgerEntryType {
-    pub const VARIANTS: [LedgerEntryType; 8] = [
+    pub const VARIANTS: [LedgerEntryType; 9] = [
         LedgerEntryType::Account,
         LedgerEntryType::Trustline,
         LedgerEntryType::Offer,
@@ -4003,9 +4005,10 @@ impl LedgerEntryType {
         LedgerEntryType::ClaimableBalance,
         LedgerEntryType::LiquidityPool,
         LedgerEntryType::ContractData,
+        LedgerEntryType::ContractCode,
         LedgerEntryType::ConfigSetting,
     ];
-    pub const VARIANTS_STR: [&'static str; 8] = [
+    pub const VARIANTS_STR: [&'static str; 9] = [
         "Account",
         "Trustline",
         "Offer",
@@ -4013,6 +4016,7 @@ impl LedgerEntryType {
         "ClaimableBalance",
         "LiquidityPool",
         "ContractData",
+        "ContractCode",
         "ConfigSetting",
     ];
 
@@ -4026,12 +4030,13 @@ impl LedgerEntryType {
             Self::ClaimableBalance => "ClaimableBalance",
             Self::LiquidityPool => "LiquidityPool",
             Self::ContractData => "ContractData",
+            Self::ContractCode => "ContractCode",
             Self::ConfigSetting => "ConfigSetting",
         }
     }
 
     #[must_use]
-    pub const fn variants() -> [LedgerEntryType; 8] {
+    pub const fn variants() -> [LedgerEntryType; 9] {
         Self::VARIANTS
     }
 }
@@ -4069,7 +4074,8 @@ impl TryFrom<i32> for LedgerEntryType {
             4 => LedgerEntryType::ClaimableBalance,
             5 => LedgerEntryType::LiquidityPool,
             6 => LedgerEntryType::ContractData,
-            7 => LedgerEntryType::ConfigSetting,
+            7 => LedgerEntryType::ContractCode,
+            8 => LedgerEntryType::ConfigSetting,
             #[allow(unreachable_patterns)]
             _ => return Err(Error::Invalid),
         };
@@ -7538,6 +7544,49 @@ impl WriteXdr for ContractDataEntry {
     }
 }
 
+// ContractCodeEntry is an XDR Struct defines as:
+//
+//   struct ContractCodeEntry {
+//        ExtensionPoint ext;
+//
+//        Hash hash;
+//        opaque code<SCVAL_LIMIT>;
+//    };
+//
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[cfg_attr(
+    all(feature = "serde", feature = "alloc"),
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "camelCase")
+)]
+pub struct ContractCodeEntry {
+    pub ext: ExtensionPoint,
+    pub hash: Hash,
+    pub code: BytesM<256000>,
+}
+
+impl ReadXdr for ContractCodeEntry {
+    #[cfg(feature = "std")]
+    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+        Ok(Self {
+            ext: ExtensionPoint::read_xdr(r)?,
+            hash: Hash::read_xdr(r)?,
+            code: BytesM::<256000>::read_xdr(r)?,
+        })
+    }
+}
+
+impl WriteXdr for ContractCodeEntry {
+    #[cfg(feature = "std")]
+    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+        self.ext.write_xdr(w)?;
+        self.hash.write_xdr(w)?;
+        self.code.write_xdr(w)?;
+        Ok(())
+    }
+}
+
 // ConfigSettingType is an XDR Enum defines as:
 //
 //   enum ConfigSettingType
@@ -8124,6 +8173,8 @@ impl WriteXdr for LedgerEntryExtensionV1 {
 //            LiquidityPoolEntry liquidityPool;
 //        case CONTRACT_DATA:
 //            ContractDataEntry contractData;
+//        case CONTRACT_CODE:
+//            ContractCodeEntry contractCode;
 //        case CONFIG_SETTING:
 //            ConfigSettingEntry configSetting;
 //        }
@@ -8145,11 +8196,12 @@ pub enum LedgerEntryData {
     ClaimableBalance(ClaimableBalanceEntry),
     LiquidityPool(LiquidityPoolEntry),
     ContractData(ContractDataEntry),
+    ContractCode(ContractCodeEntry),
     ConfigSetting(ConfigSettingEntry),
 }
 
 impl LedgerEntryData {
-    pub const VARIANTS: [LedgerEntryType; 8] = [
+    pub const VARIANTS: [LedgerEntryType; 9] = [
         LedgerEntryType::Account,
         LedgerEntryType::Trustline,
         LedgerEntryType::Offer,
@@ -8157,9 +8209,10 @@ impl LedgerEntryData {
         LedgerEntryType::ClaimableBalance,
         LedgerEntryType::LiquidityPool,
         LedgerEntryType::ContractData,
+        LedgerEntryType::ContractCode,
         LedgerEntryType::ConfigSetting,
     ];
-    pub const VARIANTS_STR: [&'static str; 8] = [
+    pub const VARIANTS_STR: [&'static str; 9] = [
         "Account",
         "Trustline",
         "Offer",
@@ -8167,6 +8220,7 @@ impl LedgerEntryData {
         "ClaimableBalance",
         "LiquidityPool",
         "ContractData",
+        "ContractCode",
         "ConfigSetting",
     ];
 
@@ -8180,6 +8234,7 @@ impl LedgerEntryData {
             Self::ClaimableBalance(_) => "ClaimableBalance",
             Self::LiquidityPool(_) => "LiquidityPool",
             Self::ContractData(_) => "ContractData",
+            Self::ContractCode(_) => "ContractCode",
             Self::ConfigSetting(_) => "ConfigSetting",
         }
     }
@@ -8195,12 +8250,13 @@ impl LedgerEntryData {
             Self::ClaimableBalance(_) => LedgerEntryType::ClaimableBalance,
             Self::LiquidityPool(_) => LedgerEntryType::LiquidityPool,
             Self::ContractData(_) => LedgerEntryType::ContractData,
+            Self::ContractCode(_) => LedgerEntryType::ContractCode,
             Self::ConfigSetting(_) => LedgerEntryType::ConfigSetting,
         }
     }
 
     #[must_use]
-    pub const fn variants() -> [LedgerEntryType; 8] {
+    pub const fn variants() -> [LedgerEntryType; 9] {
         Self::VARIANTS
     }
 }
@@ -8242,6 +8298,7 @@ impl ReadXdr for LedgerEntryData {
             }
             LedgerEntryType::LiquidityPool => Self::LiquidityPool(LiquidityPoolEntry::read_xdr(r)?),
             LedgerEntryType::ContractData => Self::ContractData(ContractDataEntry::read_xdr(r)?),
+            LedgerEntryType::ContractCode => Self::ContractCode(ContractCodeEntry::read_xdr(r)?),
             LedgerEntryType::ConfigSetting => Self::ConfigSetting(ConfigSettingEntry::read_xdr(r)?),
             #[allow(unreachable_patterns)]
             _ => return Err(Error::Invalid),
@@ -8263,6 +8320,7 @@ impl WriteXdr for LedgerEntryData {
             Self::ClaimableBalance(v) => v.write_xdr(w)?,
             Self::LiquidityPool(v) => v.write_xdr(w)?,
             Self::ContractData(v) => v.write_xdr(w)?,
+            Self::ContractCode(v) => v.write_xdr(w)?,
             Self::ConfigSetting(v) => v.write_xdr(w)?,
         };
         Ok(())
@@ -8392,6 +8450,8 @@ impl WriteXdr for LedgerEntryExt {
 //            LiquidityPoolEntry liquidityPool;
 //        case CONTRACT_DATA:
 //            ContractDataEntry contractData;
+//        case CONTRACT_CODE:
+//            ContractCodeEntry contractCode;
 //        case CONFIG_SETTING:
 //            ConfigSettingEntry configSetting;
 //        }
@@ -8703,6 +8763,41 @@ impl WriteXdr for LedgerKeyContractData {
     }
 }
 
+// LedgerKeyContractCode is an XDR NestedStruct defines as:
+//
+//   struct
+//        {
+//            Hash hash;
+//        }
+//
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[cfg_attr(
+    all(feature = "serde", feature = "alloc"),
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "camelCase")
+)]
+pub struct LedgerKeyContractCode {
+    pub hash: Hash,
+}
+
+impl ReadXdr for LedgerKeyContractCode {
+    #[cfg(feature = "std")]
+    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+        Ok(Self {
+            hash: Hash::read_xdr(r)?,
+        })
+    }
+}
+
+impl WriteXdr for LedgerKeyContractCode {
+    #[cfg(feature = "std")]
+    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+        self.hash.write_xdr(w)?;
+        Ok(())
+    }
+}
+
 // LedgerKeyConfigSetting is an XDR NestedStruct defines as:
 //
 //   struct
@@ -8786,6 +8881,11 @@ impl WriteXdr for LedgerKeyConfigSetting {
 //            Hash contractID;
 //            SCVal key;
 //        } contractData;
+//    case CONTRACT_CODE:
+//        struct
+//        {
+//            Hash hash;
+//        } contractCode;
 //    case CONFIG_SETTING:
 //        struct
 //        {
@@ -8810,11 +8910,12 @@ pub enum LedgerKey {
     ClaimableBalance(LedgerKeyClaimableBalance),
     LiquidityPool(LedgerKeyLiquidityPool),
     ContractData(LedgerKeyContractData),
+    ContractCode(LedgerKeyContractCode),
     ConfigSetting(LedgerKeyConfigSetting),
 }
 
 impl LedgerKey {
-    pub const VARIANTS: [LedgerEntryType; 8] = [
+    pub const VARIANTS: [LedgerEntryType; 9] = [
         LedgerEntryType::Account,
         LedgerEntryType::Trustline,
         LedgerEntryType::Offer,
@@ -8822,9 +8923,10 @@ impl LedgerKey {
         LedgerEntryType::ClaimableBalance,
         LedgerEntryType::LiquidityPool,
         LedgerEntryType::ContractData,
+        LedgerEntryType::ContractCode,
         LedgerEntryType::ConfigSetting,
     ];
-    pub const VARIANTS_STR: [&'static str; 8] = [
+    pub const VARIANTS_STR: [&'static str; 9] = [
         "Account",
         "Trustline",
         "Offer",
@@ -8832,6 +8934,7 @@ impl LedgerKey {
         "ClaimableBalance",
         "LiquidityPool",
         "ContractData",
+        "ContractCode",
         "ConfigSetting",
     ];
 
@@ -8845,6 +8948,7 @@ impl LedgerKey {
             Self::ClaimableBalance(_) => "ClaimableBalance",
             Self::LiquidityPool(_) => "LiquidityPool",
             Self::ContractData(_) => "ContractData",
+            Self::ContractCode(_) => "ContractCode",
             Self::ConfigSetting(_) => "ConfigSetting",
         }
     }
@@ -8860,12 +8964,13 @@ impl LedgerKey {
             Self::ClaimableBalance(_) => LedgerEntryType::ClaimableBalance,
             Self::LiquidityPool(_) => LedgerEntryType::LiquidityPool,
             Self::ContractData(_) => LedgerEntryType::ContractData,
+            Self::ContractCode(_) => LedgerEntryType::ContractCode,
             Self::ConfigSetting(_) => LedgerEntryType::ConfigSetting,
         }
     }
 
     #[must_use]
-    pub const fn variants() -> [LedgerEntryType; 8] {
+    pub const fn variants() -> [LedgerEntryType; 9] {
         Self::VARIANTS
     }
 }
@@ -8911,6 +9016,9 @@ impl ReadXdr for LedgerKey {
             LedgerEntryType::ContractData => {
                 Self::ContractData(LedgerKeyContractData::read_xdr(r)?)
             }
+            LedgerEntryType::ContractCode => {
+                Self::ContractCode(LedgerKeyContractCode::read_xdr(r)?)
+            }
             LedgerEntryType::ConfigSetting => {
                 Self::ConfigSetting(LedgerKeyConfigSetting::read_xdr(r)?)
             }
@@ -8934,6 +9042,7 @@ impl WriteXdr for LedgerKey {
             Self::ClaimableBalance(v) => v.write_xdr(w)?,
             Self::LiquidityPool(v) => v.write_xdr(w)?,
             Self::ContractData(v) => v.write_xdr(w)?,
+            Self::ContractCode(v) => v.write_xdr(w)?,
             Self::ConfigSetting(v) => v.write_xdr(w)?,
         };
         Ok(())
@@ -8955,7 +9064,8 @@ impl WriteXdr for LedgerKey {
 //        ENVELOPE_TYPE_CONTRACT_ID_FROM_ED25519 = 8,
 //        ENVELOPE_TYPE_CONTRACT_ID_FROM_CONTRACT = 9,
 //        ENVELOPE_TYPE_CONTRACT_ID_FROM_ASSET = 10,
-//        ENVELOPE_TYPE_CONTRACT_ID_FROM_SOURCE_ACCOUNT = 11
+//        ENVELOPE_TYPE_CONTRACT_ID_FROM_SOURCE_ACCOUNT = 11,
+//        ENVELOPE_TYPE_CREATE_CONTRACT_ARGS = 12
 //    };
 //
 // enum
@@ -8980,10 +9090,11 @@ pub enum EnvelopeType {
     ContractIdFromContract = 9,
     ContractIdFromAsset = 10,
     ContractIdFromSourceAccount = 11,
+    CreateContractArgs = 12,
 }
 
 impl EnvelopeType {
-    pub const VARIANTS: [EnvelopeType; 12] = [
+    pub const VARIANTS: [EnvelopeType; 13] = [
         EnvelopeType::TxV0,
         EnvelopeType::Scp,
         EnvelopeType::Tx,
@@ -8996,8 +9107,9 @@ impl EnvelopeType {
         EnvelopeType::ContractIdFromContract,
         EnvelopeType::ContractIdFromAsset,
         EnvelopeType::ContractIdFromSourceAccount,
+        EnvelopeType::CreateContractArgs,
     ];
-    pub const VARIANTS_STR: [&'static str; 12] = [
+    pub const VARIANTS_STR: [&'static str; 13] = [
         "TxV0",
         "Scp",
         "Tx",
@@ -9010,6 +9122,7 @@ impl EnvelopeType {
         "ContractIdFromContract",
         "ContractIdFromAsset",
         "ContractIdFromSourceAccount",
+        "CreateContractArgs",
     ];
 
     #[must_use]
@@ -9027,11 +9140,12 @@ impl EnvelopeType {
             Self::ContractIdFromContract => "ContractIdFromContract",
             Self::ContractIdFromAsset => "ContractIdFromAsset",
             Self::ContractIdFromSourceAccount => "ContractIdFromSourceAccount",
+            Self::CreateContractArgs => "CreateContractArgs",
         }
     }
 
     #[must_use]
-    pub const fn variants() -> [EnvelopeType; 12] {
+    pub const fn variants() -> [EnvelopeType; 13] {
         Self::VARIANTS
     }
 }
@@ -9074,6 +9188,7 @@ impl TryFrom<i32> for EnvelopeType {
             9 => EnvelopeType::ContractIdFromContract,
             10 => EnvelopeType::ContractIdFromAsset,
             11 => EnvelopeType::ContractIdFromSourceAccount,
+            12 => EnvelopeType::CreateContractArgs,
             #[allow(unreachable_patterns)]
             _ => return Err(Error::Invalid),
         };
@@ -14905,6 +15020,102 @@ impl WriteXdr for TopologyResponseBody {
     }
 }
 
+// SurveyResponseBody is an XDR Union defines as:
+//
+//   union SurveyResponseBody switch (SurveyMessageCommandType type)
+//    {
+//    case SURVEY_TOPOLOGY:
+//        TopologyResponseBody topologyResponseBody;
+//    };
+//
+// union with discriminant SurveyMessageCommandType
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[cfg_attr(
+    all(feature = "serde", feature = "alloc"),
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "camelCase")
+)]
+#[allow(clippy::large_enum_variant)]
+pub enum SurveyResponseBody {
+    SurveyTopology(TopologyResponseBody),
+}
+
+impl SurveyResponseBody {
+    pub const VARIANTS: [SurveyMessageCommandType; 1] = [SurveyMessageCommandType::SurveyTopology];
+    pub const VARIANTS_STR: [&'static str; 1] = ["SurveyTopology"];
+
+    #[must_use]
+    pub const fn name(&self) -> &'static str {
+        match self {
+            Self::SurveyTopology(_) => "SurveyTopology",
+        }
+    }
+
+    #[must_use]
+    pub const fn discriminant(&self) -> SurveyMessageCommandType {
+        #[allow(clippy::match_same_arms)]
+        match self {
+            Self::SurveyTopology(_) => SurveyMessageCommandType::SurveyTopology,
+        }
+    }
+
+    #[must_use]
+    pub const fn variants() -> [SurveyMessageCommandType; 1] {
+        Self::VARIANTS
+    }
+}
+
+impl Name for SurveyResponseBody {
+    #[must_use]
+    fn name(&self) -> &'static str {
+        Self::name(self)
+    }
+}
+
+impl Discriminant<SurveyMessageCommandType> for SurveyResponseBody {
+    #[must_use]
+    fn discriminant(&self) -> SurveyMessageCommandType {
+        Self::discriminant(self)
+    }
+}
+
+impl Variants<SurveyMessageCommandType> for SurveyResponseBody {
+    fn variants() -> slice::Iter<'static, SurveyMessageCommandType> {
+        Self::VARIANTS.iter()
+    }
+}
+
+impl Union<SurveyMessageCommandType> for SurveyResponseBody {}
+
+impl ReadXdr for SurveyResponseBody {
+    #[cfg(feature = "std")]
+    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+        let dv: SurveyMessageCommandType = <SurveyMessageCommandType as ReadXdr>::read_xdr(r)?;
+        #[allow(clippy::match_same_arms, clippy::match_wildcard_for_single_variants)]
+        let v = match dv {
+            SurveyMessageCommandType::SurveyTopology => {
+                Self::SurveyTopology(TopologyResponseBody::read_xdr(r)?)
+            }
+            #[allow(unreachable_patterns)]
+            _ => return Err(Error::Invalid),
+        };
+        Ok(v)
+    }
+}
+
+impl WriteXdr for SurveyResponseBody {
+    #[cfg(feature = "std")]
+    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+        self.discriminant().write_xdr(w)?;
+        #[allow(clippy::match_same_arms)]
+        match self {
+            Self::SurveyTopology(v) => v.write_xdr(w)?,
+        };
+        Ok(())
+    }
+}
+
 // TxAdvertVectorMaxSize is an XDR Const defines as:
 //
 //   const TX_ADVERT_VECTOR_MAX_SIZE = 1000;
@@ -15187,102 +15398,6 @@ impl WriteXdr for FloodDemand {
     }
 }
 
-// SurveyResponseBody is an XDR Union defines as:
-//
-//   union SurveyResponseBody switch (SurveyMessageCommandType type)
-//    {
-//    case SURVEY_TOPOLOGY:
-//        TopologyResponseBody topologyResponseBody;
-//    };
-//
-// union with discriminant SurveyMessageCommandType
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(
-    all(feature = "serde", feature = "alloc"),
-    derive(serde::Serialize, serde::Deserialize),
-    serde(rename_all = "camelCase")
-)]
-#[allow(clippy::large_enum_variant)]
-pub enum SurveyResponseBody {
-    SurveyTopology(TopologyResponseBody),
-}
-
-impl SurveyResponseBody {
-    pub const VARIANTS: [SurveyMessageCommandType; 1] = [SurveyMessageCommandType::SurveyTopology];
-    pub const VARIANTS_STR: [&'static str; 1] = ["SurveyTopology"];
-
-    #[must_use]
-    pub const fn name(&self) -> &'static str {
-        match self {
-            Self::SurveyTopology(_) => "SurveyTopology",
-        }
-    }
-
-    #[must_use]
-    pub const fn discriminant(&self) -> SurveyMessageCommandType {
-        #[allow(clippy::match_same_arms)]
-        match self {
-            Self::SurveyTopology(_) => SurveyMessageCommandType::SurveyTopology,
-        }
-    }
-
-    #[must_use]
-    pub const fn variants() -> [SurveyMessageCommandType; 1] {
-        Self::VARIANTS
-    }
-}
-
-impl Name for SurveyResponseBody {
-    #[must_use]
-    fn name(&self) -> &'static str {
-        Self::name(self)
-    }
-}
-
-impl Discriminant<SurveyMessageCommandType> for SurveyResponseBody {
-    #[must_use]
-    fn discriminant(&self) -> SurveyMessageCommandType {
-        Self::discriminant(self)
-    }
-}
-
-impl Variants<SurveyMessageCommandType> for SurveyResponseBody {
-    fn variants() -> slice::Iter<'static, SurveyMessageCommandType> {
-        Self::VARIANTS.iter()
-    }
-}
-
-impl Union<SurveyMessageCommandType> for SurveyResponseBody {}
-
-impl ReadXdr for SurveyResponseBody {
-    #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let dv: SurveyMessageCommandType = <SurveyMessageCommandType as ReadXdr>::read_xdr(r)?;
-        #[allow(clippy::match_same_arms, clippy::match_wildcard_for_single_variants)]
-        let v = match dv {
-            SurveyMessageCommandType::SurveyTopology => {
-                Self::SurveyTopology(TopologyResponseBody::read_xdr(r)?)
-            }
-            #[allow(unreachable_patterns)]
-            _ => return Err(Error::Invalid),
-        };
-        Ok(v)
-    }
-}
-
-impl WriteXdr for SurveyResponseBody {
-    #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        self.discriminant().write_xdr(w)?;
-        #[allow(clippy::match_same_arms)]
-        match self {
-            Self::SurveyTopology(v) => v.write_xdr(w)?,
-        };
-        Ok(())
-    }
-}
-
 // StellarMessage is an XDR Union defines as:
 //
 //   union StellarMessage switch (MessageType type)
@@ -15330,9 +15445,9 @@ impl WriteXdr for SurveyResponseBody {
 //
 //    // Pull mode
 //    case FLOOD_ADVERT:
-//        FloodAdvert floodAdvert;
+//         FloodAdvert floodAdvert;
 //    case FLOOD_DEMAND:
-//        FloodDemand floodDemand;
+//         FloodDemand floodDemand;
 //    };
 //
 // union with discriminant MessageType
@@ -17568,15 +17683,13 @@ impl WriteXdr for LiquidityPoolWithdrawOp {
     }
 }
 
-// HostFunction is an XDR Enum defines as:
+// HostFunctionType is an XDR Enum defines as:
 //
-//   enum HostFunction
+//   enum HostFunctionType
 //    {
-//        HOST_FN_INVOKE_CONTRACT = 0,
-//        HOST_FN_CREATE_CONTRACT_WITH_ED25519 = 1,
-//        HOST_FN_CREATE_CONTRACT_WITH_SOURCE_ACCOUNT = 2,
-//        HOST_FN_CREATE_TOKEN_CONTRACT_WITH_SOURCE_ACCOUNT = 3,
-//        HOST_FN_CREATE_TOKEN_CONTRACT_WITH_ASSET = 4
+//        HOST_FUNCTION_TYPE_INVOKE_CONTRACT = 0,
+//        HOST_FUNCTION_TYPE_CREATE_CONTRACT = 1,
+//        HOST_FUNCTION_TYPE_INSTALL_CONTRACT_CODE = 2
 //    };
 //
 // enum
@@ -17588,43 +17701,598 @@ impl WriteXdr for LiquidityPoolWithdrawOp {
     serde(rename_all = "camelCase")
 )]
 #[repr(i32)]
-pub enum HostFunction {
+pub enum HostFunctionType {
     InvokeContract = 0,
-    CreateContractWithEd25519 = 1,
-    CreateContractWithSourceAccount = 2,
-    CreateTokenContractWithSourceAccount = 3,
-    CreateTokenContractWithAsset = 4,
+    CreateContract = 1,
+    InstallContractCode = 2,
 }
 
-impl HostFunction {
-    pub const VARIANTS: [HostFunction; 5] = [
-        HostFunction::InvokeContract,
-        HostFunction::CreateContractWithEd25519,
-        HostFunction::CreateContractWithSourceAccount,
-        HostFunction::CreateTokenContractWithSourceAccount,
-        HostFunction::CreateTokenContractWithAsset,
+impl HostFunctionType {
+    pub const VARIANTS: [HostFunctionType; 3] = [
+        HostFunctionType::InvokeContract,
+        HostFunctionType::CreateContract,
+        HostFunctionType::InstallContractCode,
     ];
-    pub const VARIANTS_STR: [&'static str; 5] = [
-        "InvokeContract",
-        "CreateContractWithEd25519",
-        "CreateContractWithSourceAccount",
-        "CreateTokenContractWithSourceAccount",
-        "CreateTokenContractWithAsset",
-    ];
+    pub const VARIANTS_STR: [&'static str; 3] =
+        ["InvokeContract", "CreateContract", "InstallContractCode"];
 
     #[must_use]
     pub const fn name(&self) -> &'static str {
         match self {
             Self::InvokeContract => "InvokeContract",
-            Self::CreateContractWithEd25519 => "CreateContractWithEd25519",
-            Self::CreateContractWithSourceAccount => "CreateContractWithSourceAccount",
-            Self::CreateTokenContractWithSourceAccount => "CreateTokenContractWithSourceAccount",
-            Self::CreateTokenContractWithAsset => "CreateTokenContractWithAsset",
+            Self::CreateContract => "CreateContract",
+            Self::InstallContractCode => "InstallContractCode",
         }
     }
 
     #[must_use]
-    pub const fn variants() -> [HostFunction; 5] {
+    pub const fn variants() -> [HostFunctionType; 3] {
+        Self::VARIANTS
+    }
+}
+
+impl Name for HostFunctionType {
+    #[must_use]
+    fn name(&self) -> &'static str {
+        Self::name(self)
+    }
+}
+
+impl Variants<HostFunctionType> for HostFunctionType {
+    fn variants() -> slice::Iter<'static, HostFunctionType> {
+        Self::VARIANTS.iter()
+    }
+}
+
+impl Enum for HostFunctionType {}
+
+impl fmt::Display for HostFunctionType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.name())
+    }
+}
+
+impl TryFrom<i32> for HostFunctionType {
+    type Error = Error;
+
+    fn try_from(i: i32) -> Result<Self> {
+        let e = match i {
+            0 => HostFunctionType::InvokeContract,
+            1 => HostFunctionType::CreateContract,
+            2 => HostFunctionType::InstallContractCode,
+            #[allow(unreachable_patterns)]
+            _ => return Err(Error::Invalid),
+        };
+        Ok(e)
+    }
+}
+
+impl From<HostFunctionType> for i32 {
+    #[must_use]
+    fn from(e: HostFunctionType) -> Self {
+        e as Self
+    }
+}
+
+impl ReadXdr for HostFunctionType {
+    #[cfg(feature = "std")]
+    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+        let e = i32::read_xdr(r)?;
+        let v: Self = e.try_into()?;
+        Ok(v)
+    }
+}
+
+impl WriteXdr for HostFunctionType {
+    #[cfg(feature = "std")]
+    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+        let i: i32 = (*self).into();
+        i.write_xdr(w)
+    }
+}
+
+// ContractIdType is an XDR Enum defines as:
+//
+//   enum ContractIDType
+//    {
+//        CONTRACT_ID_FROM_SOURCE_ACCOUNT = 0,
+//        CONTRACT_ID_FROM_ED25519_PUBLIC_KEY = 1,
+//        CONTRACT_ID_FROM_ASSET = 2
+//    };
+//
+// enum
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[cfg_attr(
+    all(feature = "serde", feature = "alloc"),
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "camelCase")
+)]
+#[repr(i32)]
+pub enum ContractIdType {
+    SourceAccount = 0,
+    Ed25519PublicKey = 1,
+    Asset = 2,
+}
+
+impl ContractIdType {
+    pub const VARIANTS: [ContractIdType; 3] = [
+        ContractIdType::SourceAccount,
+        ContractIdType::Ed25519PublicKey,
+        ContractIdType::Asset,
+    ];
+    pub const VARIANTS_STR: [&'static str; 3] = ["SourceAccount", "Ed25519PublicKey", "Asset"];
+
+    #[must_use]
+    pub const fn name(&self) -> &'static str {
+        match self {
+            Self::SourceAccount => "SourceAccount",
+            Self::Ed25519PublicKey => "Ed25519PublicKey",
+            Self::Asset => "Asset",
+        }
+    }
+
+    #[must_use]
+    pub const fn variants() -> [ContractIdType; 3] {
+        Self::VARIANTS
+    }
+}
+
+impl Name for ContractIdType {
+    #[must_use]
+    fn name(&self) -> &'static str {
+        Self::name(self)
+    }
+}
+
+impl Variants<ContractIdType> for ContractIdType {
+    fn variants() -> slice::Iter<'static, ContractIdType> {
+        Self::VARIANTS.iter()
+    }
+}
+
+impl Enum for ContractIdType {}
+
+impl fmt::Display for ContractIdType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.name())
+    }
+}
+
+impl TryFrom<i32> for ContractIdType {
+    type Error = Error;
+
+    fn try_from(i: i32) -> Result<Self> {
+        let e = match i {
+            0 => ContractIdType::SourceAccount,
+            1 => ContractIdType::Ed25519PublicKey,
+            2 => ContractIdType::Asset,
+            #[allow(unreachable_patterns)]
+            _ => return Err(Error::Invalid),
+        };
+        Ok(e)
+    }
+}
+
+impl From<ContractIdType> for i32 {
+    #[must_use]
+    fn from(e: ContractIdType) -> Self {
+        e as Self
+    }
+}
+
+impl ReadXdr for ContractIdType {
+    #[cfg(feature = "std")]
+    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+        let e = i32::read_xdr(r)?;
+        let v: Self = e.try_into()?;
+        Ok(v)
+    }
+}
+
+impl WriteXdr for ContractIdType {
+    #[cfg(feature = "std")]
+    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+        let i: i32 = (*self).into();
+        i.write_xdr(w)
+    }
+}
+
+// ContractIdPublicKeyType is an XDR Enum defines as:
+//
+//   enum ContractIDPublicKeyType
+//    {
+//        CONTRACT_ID_PUBLIC_KEY_SOURCE_ACCOUNT = 0,
+//        CONTRACT_ID_PUBLIC_KEY_ED25519 = 1
+//    };
+//
+// enum
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[cfg_attr(
+    all(feature = "serde", feature = "alloc"),
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "camelCase")
+)]
+#[repr(i32)]
+pub enum ContractIdPublicKeyType {
+    SourceAccount = 0,
+    Ed25519 = 1,
+}
+
+impl ContractIdPublicKeyType {
+    pub const VARIANTS: [ContractIdPublicKeyType; 2] = [
+        ContractIdPublicKeyType::SourceAccount,
+        ContractIdPublicKeyType::Ed25519,
+    ];
+    pub const VARIANTS_STR: [&'static str; 2] = ["SourceAccount", "Ed25519"];
+
+    #[must_use]
+    pub const fn name(&self) -> &'static str {
+        match self {
+            Self::SourceAccount => "SourceAccount",
+            Self::Ed25519 => "Ed25519",
+        }
+    }
+
+    #[must_use]
+    pub const fn variants() -> [ContractIdPublicKeyType; 2] {
+        Self::VARIANTS
+    }
+}
+
+impl Name for ContractIdPublicKeyType {
+    #[must_use]
+    fn name(&self) -> &'static str {
+        Self::name(self)
+    }
+}
+
+impl Variants<ContractIdPublicKeyType> for ContractIdPublicKeyType {
+    fn variants() -> slice::Iter<'static, ContractIdPublicKeyType> {
+        Self::VARIANTS.iter()
+    }
+}
+
+impl Enum for ContractIdPublicKeyType {}
+
+impl fmt::Display for ContractIdPublicKeyType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.name())
+    }
+}
+
+impl TryFrom<i32> for ContractIdPublicKeyType {
+    type Error = Error;
+
+    fn try_from(i: i32) -> Result<Self> {
+        let e = match i {
+            0 => ContractIdPublicKeyType::SourceAccount,
+            1 => ContractIdPublicKeyType::Ed25519,
+            #[allow(unreachable_patterns)]
+            _ => return Err(Error::Invalid),
+        };
+        Ok(e)
+    }
+}
+
+impl From<ContractIdPublicKeyType> for i32 {
+    #[must_use]
+    fn from(e: ContractIdPublicKeyType) -> Self {
+        e as Self
+    }
+}
+
+impl ReadXdr for ContractIdPublicKeyType {
+    #[cfg(feature = "std")]
+    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+        let e = i32::read_xdr(r)?;
+        let v: Self = e.try_into()?;
+        Ok(v)
+    }
+}
+
+impl WriteXdr for ContractIdPublicKeyType {
+    #[cfg(feature = "std")]
+    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+        let i: i32 = (*self).into();
+        i.write_xdr(w)
+    }
+}
+
+// InstallContractCodeArgs is an XDR Struct defines as:
+//
+//   struct InstallContractCodeArgs
+//    {
+//        opaque code<SCVAL_LIMIT>;
+//    };
+//
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[cfg_attr(
+    all(feature = "serde", feature = "alloc"),
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "camelCase")
+)]
+pub struct InstallContractCodeArgs {
+    pub code: BytesM<256000>,
+}
+
+impl ReadXdr for InstallContractCodeArgs {
+    #[cfg(feature = "std")]
+    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+        Ok(Self {
+            code: BytesM::<256000>::read_xdr(r)?,
+        })
+    }
+}
+
+impl WriteXdr for InstallContractCodeArgs {
+    #[cfg(feature = "std")]
+    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+        self.code.write_xdr(w)?;
+        Ok(())
+    }
+}
+
+// ContractIdFromEd25519PublicKey is an XDR NestedStruct defines as:
+//
+//   struct
+//        {
+//            uint256 key;
+//            Signature signature;
+//            uint256 salt;
+//        }
+//
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[cfg_attr(
+    all(feature = "serde", feature = "alloc"),
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "camelCase")
+)]
+pub struct ContractIdFromEd25519PublicKey {
+    pub key: Uint256,
+    pub signature: Signature,
+    pub salt: Uint256,
+}
+
+impl ReadXdr for ContractIdFromEd25519PublicKey {
+    #[cfg(feature = "std")]
+    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+        Ok(Self {
+            key: Uint256::read_xdr(r)?,
+            signature: Signature::read_xdr(r)?,
+            salt: Uint256::read_xdr(r)?,
+        })
+    }
+}
+
+impl WriteXdr for ContractIdFromEd25519PublicKey {
+    #[cfg(feature = "std")]
+    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+        self.key.write_xdr(w)?;
+        self.signature.write_xdr(w)?;
+        self.salt.write_xdr(w)?;
+        Ok(())
+    }
+}
+
+// ContractId is an XDR Union defines as:
+//
+//   union ContractID switch (ContractIDType type)
+//    {
+//    case CONTRACT_ID_FROM_SOURCE_ACCOUNT:
+//        uint256 salt;
+//    case CONTRACT_ID_FROM_ED25519_PUBLIC_KEY:
+//        struct
+//        {
+//            uint256 key;
+//            Signature signature;
+//            uint256 salt;
+//        } fromEd25519PublicKey;
+//    case CONTRACT_ID_FROM_ASSET:
+//        Asset asset;
+//    };
+//
+// union with discriminant ContractIdType
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[cfg_attr(
+    all(feature = "serde", feature = "alloc"),
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "camelCase")
+)]
+#[allow(clippy::large_enum_variant)]
+pub enum ContractId {
+    SourceAccount(Uint256),
+    Ed25519PublicKey(ContractIdFromEd25519PublicKey),
+    Asset(Asset),
+}
+
+impl ContractId {
+    pub const VARIANTS: [ContractIdType; 3] = [
+        ContractIdType::SourceAccount,
+        ContractIdType::Ed25519PublicKey,
+        ContractIdType::Asset,
+    ];
+    pub const VARIANTS_STR: [&'static str; 3] = ["SourceAccount", "Ed25519PublicKey", "Asset"];
+
+    #[must_use]
+    pub const fn name(&self) -> &'static str {
+        match self {
+            Self::SourceAccount(_) => "SourceAccount",
+            Self::Ed25519PublicKey(_) => "Ed25519PublicKey",
+            Self::Asset(_) => "Asset",
+        }
+    }
+
+    #[must_use]
+    pub const fn discriminant(&self) -> ContractIdType {
+        #[allow(clippy::match_same_arms)]
+        match self {
+            Self::SourceAccount(_) => ContractIdType::SourceAccount,
+            Self::Ed25519PublicKey(_) => ContractIdType::Ed25519PublicKey,
+            Self::Asset(_) => ContractIdType::Asset,
+        }
+    }
+
+    #[must_use]
+    pub const fn variants() -> [ContractIdType; 3] {
+        Self::VARIANTS
+    }
+}
+
+impl Name for ContractId {
+    #[must_use]
+    fn name(&self) -> &'static str {
+        Self::name(self)
+    }
+}
+
+impl Discriminant<ContractIdType> for ContractId {
+    #[must_use]
+    fn discriminant(&self) -> ContractIdType {
+        Self::discriminant(self)
+    }
+}
+
+impl Variants<ContractIdType> for ContractId {
+    fn variants() -> slice::Iter<'static, ContractIdType> {
+        Self::VARIANTS.iter()
+    }
+}
+
+impl Union<ContractIdType> for ContractId {}
+
+impl ReadXdr for ContractId {
+    #[cfg(feature = "std")]
+    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+        let dv: ContractIdType = <ContractIdType as ReadXdr>::read_xdr(r)?;
+        #[allow(clippy::match_same_arms, clippy::match_wildcard_for_single_variants)]
+        let v = match dv {
+            ContractIdType::SourceAccount => Self::SourceAccount(Uint256::read_xdr(r)?),
+            ContractIdType::Ed25519PublicKey => {
+                Self::Ed25519PublicKey(ContractIdFromEd25519PublicKey::read_xdr(r)?)
+            }
+            ContractIdType::Asset => Self::Asset(Asset::read_xdr(r)?),
+            #[allow(unreachable_patterns)]
+            _ => return Err(Error::Invalid),
+        };
+        Ok(v)
+    }
+}
+
+impl WriteXdr for ContractId {
+    #[cfg(feature = "std")]
+    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+        self.discriminant().write_xdr(w)?;
+        #[allow(clippy::match_same_arms)]
+        match self {
+            Self::SourceAccount(v) => v.write_xdr(w)?,
+            Self::Ed25519PublicKey(v) => v.write_xdr(w)?,
+            Self::Asset(v) => v.write_xdr(w)?,
+        };
+        Ok(())
+    }
+}
+
+// CreateContractArgs is an XDR Struct defines as:
+//
+//   struct CreateContractArgs
+//    {
+//        ContractID contractID;
+//        SCContractCode source;
+//    };
+//
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[cfg_attr(
+    all(feature = "serde", feature = "alloc"),
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "camelCase")
+)]
+pub struct CreateContractArgs {
+    pub contract_id: ContractId,
+    pub source: ScContractCode,
+}
+
+impl ReadXdr for CreateContractArgs {
+    #[cfg(feature = "std")]
+    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+        Ok(Self {
+            contract_id: ContractId::read_xdr(r)?,
+            source: ScContractCode::read_xdr(r)?,
+        })
+    }
+}
+
+impl WriteXdr for CreateContractArgs {
+    #[cfg(feature = "std")]
+    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+        self.contract_id.write_xdr(w)?;
+        self.source.write_xdr(w)?;
+        Ok(())
+    }
+}
+
+// HostFunction is an XDR Union defines as:
+//
+//   union HostFunction switch (HostFunctionType type)
+//    {
+//    case HOST_FUNCTION_TYPE_INVOKE_CONTRACT:
+//        SCVec invokeArgs;
+//    case HOST_FUNCTION_TYPE_CREATE_CONTRACT:
+//        CreateContractArgs createContractArgs;
+//    case HOST_FUNCTION_TYPE_INSTALL_CONTRACT_CODE:
+//        InstallContractCodeArgs installContractCodeArgs;
+//    };
+//
+// union with discriminant HostFunctionType
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[cfg_attr(
+    all(feature = "serde", feature = "alloc"),
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "camelCase")
+)]
+#[allow(clippy::large_enum_variant)]
+pub enum HostFunction {
+    InvokeContract(ScVec),
+    CreateContract(CreateContractArgs),
+    InstallContractCode(InstallContractCodeArgs),
+}
+
+impl HostFunction {
+    pub const VARIANTS: [HostFunctionType; 3] = [
+        HostFunctionType::InvokeContract,
+        HostFunctionType::CreateContract,
+        HostFunctionType::InstallContractCode,
+    ];
+    pub const VARIANTS_STR: [&'static str; 3] =
+        ["InvokeContract", "CreateContract", "InstallContractCode"];
+
+    #[must_use]
+    pub const fn name(&self) -> &'static str {
+        match self {
+            Self::InvokeContract(_) => "InvokeContract",
+            Self::CreateContract(_) => "CreateContract",
+            Self::InstallContractCode(_) => "InstallContractCode",
+        }
+    }
+
+    #[must_use]
+    pub const fn discriminant(&self) -> HostFunctionType {
+        #[allow(clippy::match_same_arms)]
+        match self {
+            Self::InvokeContract(_) => HostFunctionType::InvokeContract,
+            Self::CreateContract(_) => HostFunctionType::CreateContract,
+            Self::InstallContractCode(_) => HostFunctionType::InstallContractCode,
+        }
+    }
+
+    #[must_use]
+    pub const fn variants() -> [HostFunctionType; 3] {
         Self::VARIANTS
     }
 }
@@ -17636,49 +18304,37 @@ impl Name for HostFunction {
     }
 }
 
-impl Variants<HostFunction> for HostFunction {
-    fn variants() -> slice::Iter<'static, HostFunction> {
+impl Discriminant<HostFunctionType> for HostFunction {
+    #[must_use]
+    fn discriminant(&self) -> HostFunctionType {
+        Self::discriminant(self)
+    }
+}
+
+impl Variants<HostFunctionType> for HostFunction {
+    fn variants() -> slice::Iter<'static, HostFunctionType> {
         Self::VARIANTS.iter()
     }
 }
 
-impl Enum for HostFunction {}
-
-impl fmt::Display for HostFunction {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.name())
-    }
-}
-
-impl TryFrom<i32> for HostFunction {
-    type Error = Error;
-
-    fn try_from(i: i32) -> Result<Self> {
-        let e = match i {
-            0 => HostFunction::InvokeContract,
-            1 => HostFunction::CreateContractWithEd25519,
-            2 => HostFunction::CreateContractWithSourceAccount,
-            3 => HostFunction::CreateTokenContractWithSourceAccount,
-            4 => HostFunction::CreateTokenContractWithAsset,
-            #[allow(unreachable_patterns)]
-            _ => return Err(Error::Invalid),
-        };
-        Ok(e)
-    }
-}
-
-impl From<HostFunction> for i32 {
-    #[must_use]
-    fn from(e: HostFunction) -> Self {
-        e as Self
-    }
-}
+impl Union<HostFunctionType> for HostFunction {}
 
 impl ReadXdr for HostFunction {
     #[cfg(feature = "std")]
     fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let e = i32::read_xdr(r)?;
-        let v: Self = e.try_into()?;
+        let dv: HostFunctionType = <HostFunctionType as ReadXdr>::read_xdr(r)?;
+        #[allow(clippy::match_same_arms, clippy::match_wildcard_for_single_variants)]
+        let v = match dv {
+            HostFunctionType::InvokeContract => Self::InvokeContract(ScVec::read_xdr(r)?),
+            HostFunctionType::CreateContract => {
+                Self::CreateContract(CreateContractArgs::read_xdr(r)?)
+            }
+            HostFunctionType::InstallContractCode => {
+                Self::InstallContractCode(InstallContractCodeArgs::read_xdr(r)?)
+            }
+            #[allow(unreachable_patterns)]
+            _ => return Err(Error::Invalid),
+        };
         Ok(v)
     }
 }
@@ -17686,8 +18342,14 @@ impl ReadXdr for HostFunction {
 impl WriteXdr for HostFunction {
     #[cfg(feature = "std")]
     fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let i: i32 = (*self).into();
-        i.write_xdr(w)
+        self.discriminant().write_xdr(w)?;
+        #[allow(clippy::match_same_arms)]
+        match self {
+            Self::InvokeContract(v) => v.write_xdr(w)?,
+            Self::CreateContract(v) => v.write_xdr(w)?,
+            Self::InstallContractCode(v) => v.write_xdr(w)?,
+        };
+        Ok(())
     }
 }
 
@@ -17697,10 +18359,6 @@ impl WriteXdr for HostFunction {
 //    {
 //        // The host function to invoke
 //        HostFunction function;
-//
-//        // Parameters to the host function
-//        SCVec parameters;
-//
 //        // The footprint for this invocation
 //        LedgerFootprint footprint;
 //    };
@@ -17714,7 +18372,6 @@ impl WriteXdr for HostFunction {
 )]
 pub struct InvokeHostFunctionOp {
     pub function: HostFunction,
-    pub parameters: ScVec,
     pub footprint: LedgerFootprint,
 }
 
@@ -17723,7 +18380,6 @@ impl ReadXdr for InvokeHostFunctionOp {
     fn read_xdr(r: &mut impl Read) -> Result<Self> {
         Ok(Self {
             function: HostFunction::read_xdr(r)?,
-            parameters: ScVec::read_xdr(r)?,
             footprint: LedgerFootprint::read_xdr(r)?,
         })
     }
@@ -17733,7 +18389,6 @@ impl WriteXdr for InvokeHostFunctionOp {
     #[cfg(feature = "std")]
     fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
         self.function.write_xdr(w)?;
-        self.parameters.write_xdr(w)?;
         self.footprint.write_xdr(w)?;
         Ok(())
     }
@@ -18273,6 +18928,7 @@ impl WriteXdr for HashIdPreimageRevokeId {
 //
 //   struct
 //        {
+//            Hash networkID;
 //            uint256 ed25519;
 //            uint256 salt;
 //        }
@@ -18285,6 +18941,7 @@ impl WriteXdr for HashIdPreimageRevokeId {
     serde(rename_all = "camelCase")
 )]
 pub struct HashIdPreimageEd25519ContractId {
+    pub network_id: Hash,
     pub ed25519: Uint256,
     pub salt: Uint256,
 }
@@ -18293,6 +18950,7 @@ impl ReadXdr for HashIdPreimageEd25519ContractId {
     #[cfg(feature = "std")]
     fn read_xdr(r: &mut impl Read) -> Result<Self> {
         Ok(Self {
+            network_id: Hash::read_xdr(r)?,
             ed25519: Uint256::read_xdr(r)?,
             salt: Uint256::read_xdr(r)?,
         })
@@ -18302,6 +18960,7 @@ impl ReadXdr for HashIdPreimageEd25519ContractId {
 impl WriteXdr for HashIdPreimageEd25519ContractId {
     #[cfg(feature = "std")]
     fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+        self.network_id.write_xdr(w)?;
         self.ed25519.write_xdr(w)?;
         self.salt.write_xdr(w)?;
         Ok(())
@@ -18312,6 +18971,7 @@ impl WriteXdr for HashIdPreimageEd25519ContractId {
 //
 //   struct
 //        {
+//            Hash networkID;
 //            Hash contractID;
 //            uint256 salt;
 //        }
@@ -18324,6 +18984,7 @@ impl WriteXdr for HashIdPreimageEd25519ContractId {
     serde(rename_all = "camelCase")
 )]
 pub struct HashIdPreimageContractId {
+    pub network_id: Hash,
     pub contract_id: Hash,
     pub salt: Uint256,
 }
@@ -18332,6 +18993,7 @@ impl ReadXdr for HashIdPreimageContractId {
     #[cfg(feature = "std")]
     fn read_xdr(r: &mut impl Read) -> Result<Self> {
         Ok(Self {
+            network_id: Hash::read_xdr(r)?,
             contract_id: Hash::read_xdr(r)?,
             salt: Uint256::read_xdr(r)?,
         })
@@ -18341,8 +19003,48 @@ impl ReadXdr for HashIdPreimageContractId {
 impl WriteXdr for HashIdPreimageContractId {
     #[cfg(feature = "std")]
     fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+        self.network_id.write_xdr(w)?;
         self.contract_id.write_xdr(w)?;
         self.salt.write_xdr(w)?;
+        Ok(())
+    }
+}
+
+// HashIdPreimageFromAsset is an XDR NestedStruct defines as:
+//
+//   struct
+//        {
+//            Hash networkID;
+//            Asset asset;
+//        }
+//
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[cfg_attr(
+    all(feature = "serde", feature = "alloc"),
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "camelCase")
+)]
+pub struct HashIdPreimageFromAsset {
+    pub network_id: Hash,
+    pub asset: Asset,
+}
+
+impl ReadXdr for HashIdPreimageFromAsset {
+    #[cfg(feature = "std")]
+    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+        Ok(Self {
+            network_id: Hash::read_xdr(r)?,
+            asset: Asset::read_xdr(r)?,
+        })
+    }
+}
+
+impl WriteXdr for HashIdPreimageFromAsset {
+    #[cfg(feature = "std")]
+    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+        self.network_id.write_xdr(w)?;
+        self.asset.write_xdr(w)?;
         Ok(())
     }
 }
@@ -18351,6 +19053,7 @@ impl WriteXdr for HashIdPreimageContractId {
 //
 //   struct
 //        {
+//            Hash networkID;
 //            AccountID sourceAccount;
 //            uint256 salt;
 //        }
@@ -18363,6 +19066,7 @@ impl WriteXdr for HashIdPreimageContractId {
     serde(rename_all = "camelCase")
 )]
 pub struct HashIdPreimageSourceAccountContractId {
+    pub network_id: Hash,
     pub source_account: AccountId,
     pub salt: Uint256,
 }
@@ -18371,6 +19075,7 @@ impl ReadXdr for HashIdPreimageSourceAccountContractId {
     #[cfg(feature = "std")]
     fn read_xdr(r: &mut impl Read) -> Result<Self> {
         Ok(Self {
+            network_id: Hash::read_xdr(r)?,
             source_account: AccountId::read_xdr(r)?,
             salt: Uint256::read_xdr(r)?,
         })
@@ -18380,7 +19085,51 @@ impl ReadXdr for HashIdPreimageSourceAccountContractId {
 impl WriteXdr for HashIdPreimageSourceAccountContractId {
     #[cfg(feature = "std")]
     fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+        self.network_id.write_xdr(w)?;
         self.source_account.write_xdr(w)?;
+        self.salt.write_xdr(w)?;
+        Ok(())
+    }
+}
+
+// HashIdPreimageCreateContractArgs is an XDR NestedStruct defines as:
+//
+//   struct
+//        {
+//            Hash networkID;
+//            SCContractCode source;
+//            uint256 salt;
+//        }
+//
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[cfg_attr(
+    all(feature = "serde", feature = "alloc"),
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "camelCase")
+)]
+pub struct HashIdPreimageCreateContractArgs {
+    pub network_id: Hash,
+    pub source: ScContractCode,
+    pub salt: Uint256,
+}
+
+impl ReadXdr for HashIdPreimageCreateContractArgs {
+    #[cfg(feature = "std")]
+    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+        Ok(Self {
+            network_id: Hash::read_xdr(r)?,
+            source: ScContractCode::read_xdr(r)?,
+            salt: Uint256::read_xdr(r)?,
+        })
+    }
+}
+
+impl WriteXdr for HashIdPreimageCreateContractArgs {
+    #[cfg(feature = "std")]
+    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+        self.network_id.write_xdr(w)?;
+        self.source.write_xdr(w)?;
         self.salt.write_xdr(w)?;
         Ok(())
     }
@@ -18409,23 +19158,37 @@ impl WriteXdr for HashIdPreimageSourceAccountContractId {
 //    case ENVELOPE_TYPE_CONTRACT_ID_FROM_ED25519:
 //        struct
 //        {
+//            Hash networkID;
 //            uint256 ed25519;
 //            uint256 salt;
 //        } ed25519ContractID;
 //    case ENVELOPE_TYPE_CONTRACT_ID_FROM_CONTRACT:
 //        struct
 //        {
+//            Hash networkID;
 //            Hash contractID;
 //            uint256 salt;
 //        } contractID;
 //    case ENVELOPE_TYPE_CONTRACT_ID_FROM_ASSET:
-//        Asset fromAsset;
+//        struct
+//        {
+//            Hash networkID;
+//            Asset asset;
+//        } fromAsset;
 //    case ENVELOPE_TYPE_CONTRACT_ID_FROM_SOURCE_ACCOUNT:
 //        struct
 //        {
+//            Hash networkID;
 //            AccountID sourceAccount;
 //            uint256 salt;
 //        } sourceAccountContractID;
+//    case ENVELOPE_TYPE_CREATE_CONTRACT_ARGS:
+//        struct
+//        {
+//            Hash networkID;
+//            SCContractCode source;
+//            uint256 salt;
+//        } createContractArgs;
 //    };
 //
 // union with discriminant EnvelopeType
@@ -18442,26 +19205,29 @@ pub enum HashIdPreimage {
     PoolRevokeOpId(HashIdPreimageRevokeId),
     ContractIdFromEd25519(HashIdPreimageEd25519ContractId),
     ContractIdFromContract(HashIdPreimageContractId),
-    ContractIdFromAsset(Asset),
+    ContractIdFromAsset(HashIdPreimageFromAsset),
     ContractIdFromSourceAccount(HashIdPreimageSourceAccountContractId),
+    CreateContractArgs(HashIdPreimageCreateContractArgs),
 }
 
 impl HashIdPreimage {
-    pub const VARIANTS: [EnvelopeType; 6] = [
+    pub const VARIANTS: [EnvelopeType; 7] = [
         EnvelopeType::OpId,
         EnvelopeType::PoolRevokeOpId,
         EnvelopeType::ContractIdFromEd25519,
         EnvelopeType::ContractIdFromContract,
         EnvelopeType::ContractIdFromAsset,
         EnvelopeType::ContractIdFromSourceAccount,
+        EnvelopeType::CreateContractArgs,
     ];
-    pub const VARIANTS_STR: [&'static str; 6] = [
+    pub const VARIANTS_STR: [&'static str; 7] = [
         "OpId",
         "PoolRevokeOpId",
         "ContractIdFromEd25519",
         "ContractIdFromContract",
         "ContractIdFromAsset",
         "ContractIdFromSourceAccount",
+        "CreateContractArgs",
     ];
 
     #[must_use]
@@ -18473,6 +19239,7 @@ impl HashIdPreimage {
             Self::ContractIdFromContract(_) => "ContractIdFromContract",
             Self::ContractIdFromAsset(_) => "ContractIdFromAsset",
             Self::ContractIdFromSourceAccount(_) => "ContractIdFromSourceAccount",
+            Self::CreateContractArgs(_) => "CreateContractArgs",
         }
     }
 
@@ -18486,11 +19253,12 @@ impl HashIdPreimage {
             Self::ContractIdFromContract(_) => EnvelopeType::ContractIdFromContract,
             Self::ContractIdFromAsset(_) => EnvelopeType::ContractIdFromAsset,
             Self::ContractIdFromSourceAccount(_) => EnvelopeType::ContractIdFromSourceAccount,
+            Self::CreateContractArgs(_) => EnvelopeType::CreateContractArgs,
         }
     }
 
     #[must_use]
-    pub const fn variants() -> [EnvelopeType; 6] {
+    pub const fn variants() -> [EnvelopeType; 7] {
         Self::VARIANTS
     }
 }
@@ -18533,10 +19301,15 @@ impl ReadXdr for HashIdPreimage {
             EnvelopeType::ContractIdFromContract => {
                 Self::ContractIdFromContract(HashIdPreimageContractId::read_xdr(r)?)
             }
-            EnvelopeType::ContractIdFromAsset => Self::ContractIdFromAsset(Asset::read_xdr(r)?),
+            EnvelopeType::ContractIdFromAsset => {
+                Self::ContractIdFromAsset(HashIdPreimageFromAsset::read_xdr(r)?)
+            }
             EnvelopeType::ContractIdFromSourceAccount => Self::ContractIdFromSourceAccount(
                 HashIdPreimageSourceAccountContractId::read_xdr(r)?,
             ),
+            EnvelopeType::CreateContractArgs => {
+                Self::CreateContractArgs(HashIdPreimageCreateContractArgs::read_xdr(r)?)
+            }
             #[allow(unreachable_patterns)]
             _ => return Err(Error::Invalid),
         };
@@ -18556,6 +19329,7 @@ impl WriteXdr for HashIdPreimage {
             Self::ContractIdFromContract(v) => v.write_xdr(w)?,
             Self::ContractIdFromAsset(v) => v.write_xdr(w)?,
             Self::ContractIdFromSourceAccount(v) => v.write_xdr(w)?,
+            Self::CreateContractArgs(v) => v.write_xdr(w)?,
         };
         Ok(())
     }
@@ -33256,7 +34030,7 @@ impl WriteXdr for ScBigInt {
 //
 //   enum SCContractCodeType
 //    {
-//        SCCONTRACT_CODE_WASM = 0,
+//        SCCONTRACT_CODE_WASM_REF = 0,
 //        SCCONTRACT_CODE_TOKEN = 1
 //    };
 //
@@ -33270,19 +34044,19 @@ impl WriteXdr for ScBigInt {
 )]
 #[repr(i32)]
 pub enum ScContractCodeType {
-    Wasm = 0,
+    WasmRef = 0,
     Token = 1,
 }
 
 impl ScContractCodeType {
     pub const VARIANTS: [ScContractCodeType; 2] =
-        [ScContractCodeType::Wasm, ScContractCodeType::Token];
-    pub const VARIANTS_STR: [&'static str; 2] = ["Wasm", "Token"];
+        [ScContractCodeType::WasmRef, ScContractCodeType::Token];
+    pub const VARIANTS_STR: [&'static str; 2] = ["WasmRef", "Token"];
 
     #[must_use]
     pub const fn name(&self) -> &'static str {
         match self {
-            Self::Wasm => "Wasm",
+            Self::WasmRef => "WasmRef",
             Self::Token => "Token",
         }
     }
@@ -33319,7 +34093,7 @@ impl TryFrom<i32> for ScContractCodeType {
 
     fn try_from(i: i32) -> Result<Self> {
         let e = match i {
-            0 => ScContractCodeType::Wasm,
+            0 => ScContractCodeType::WasmRef,
             1 => ScContractCodeType::Token,
             #[allow(unreachable_patterns)]
             _ => return Err(Error::Invalid),
@@ -33356,8 +34130,8 @@ impl WriteXdr for ScContractCodeType {
 //
 //   union SCContractCode switch (SCContractCodeType type)
 //    {
-//    case SCCONTRACT_CODE_WASM:
-//        opaque wasm<SCVAL_LIMIT>;
+//    case SCCONTRACT_CODE_WASM_REF:
+//        Hash wasm_id;
 //    case SCCONTRACT_CODE_TOKEN:
 //        void;
 //    };
@@ -33372,19 +34146,19 @@ impl WriteXdr for ScContractCodeType {
 )]
 #[allow(clippy::large_enum_variant)]
 pub enum ScContractCode {
-    Wasm(BytesM<256000>),
+    WasmRef(Hash),
     Token,
 }
 
 impl ScContractCode {
     pub const VARIANTS: [ScContractCodeType; 2] =
-        [ScContractCodeType::Wasm, ScContractCodeType::Token];
-    pub const VARIANTS_STR: [&'static str; 2] = ["Wasm", "Token"];
+        [ScContractCodeType::WasmRef, ScContractCodeType::Token];
+    pub const VARIANTS_STR: [&'static str; 2] = ["WasmRef", "Token"];
 
     #[must_use]
     pub const fn name(&self) -> &'static str {
         match self {
-            Self::Wasm(_) => "Wasm",
+            Self::WasmRef(_) => "WasmRef",
             Self::Token => "Token",
         }
     }
@@ -33393,7 +34167,7 @@ impl ScContractCode {
     pub const fn discriminant(&self) -> ScContractCodeType {
         #[allow(clippy::match_same_arms)]
         match self {
-            Self::Wasm(_) => ScContractCodeType::Wasm,
+            Self::WasmRef(_) => ScContractCodeType::WasmRef,
             Self::Token => ScContractCodeType::Token,
         }
     }
@@ -33432,7 +34206,7 @@ impl ReadXdr for ScContractCode {
         let dv: ScContractCodeType = <ScContractCodeType as ReadXdr>::read_xdr(r)?;
         #[allow(clippy::match_same_arms, clippy::match_wildcard_for_single_variants)]
         let v = match dv {
-            ScContractCodeType::Wasm => Self::Wasm(BytesM::<256000>::read_xdr(r)?),
+            ScContractCodeType::WasmRef => Self::WasmRef(Hash::read_xdr(r)?),
             ScContractCodeType::Token => Self::Token,
             #[allow(unreachable_patterns)]
             _ => return Err(Error::Invalid),
@@ -33447,7 +34221,7 @@ impl WriteXdr for ScContractCode {
         self.discriminant().write_xdr(w)?;
         #[allow(clippy::match_same_arms)]
         match self {
-            Self::Wasm(v) => v.write_xdr(w)?,
+            Self::WasmRef(v) => v.write_xdr(w)?,
             Self::Token => ().write_xdr(w)?,
         };
         Ok(())
@@ -35332,6 +36106,7 @@ pub enum TypeVariant {
     LiquidityPoolEntryBody,
     LiquidityPoolEntryConstantProduct,
     ContractDataEntry,
+    ContractCodeEntry,
     ConfigSettingType,
     ConfigSetting,
     ConfigSettingId,
@@ -35350,6 +36125,7 @@ pub enum TypeVariant {
     LedgerKeyClaimableBalance,
     LedgerKeyLiquidityPool,
     LedgerKeyContractData,
+    LedgerKeyContractCode,
     LedgerKeyConfigSetting,
     EnvelopeType,
     UpgradeType,
@@ -35430,11 +36206,11 @@ pub enum TypeVariant {
     PeerStats,
     PeerStatList,
     TopologyResponseBody,
+    SurveyResponseBody,
     TxAdvertVector,
     FloodAdvert,
     TxDemandVector,
     FloodDemand,
-    SurveyResponseBody,
     StellarMessage,
     AuthenticatedMessage,
     AuthenticatedMessageV0,
@@ -35468,6 +36244,13 @@ pub enum TypeVariant {
     SetTrustLineFlagsOp,
     LiquidityPoolDepositOp,
     LiquidityPoolWithdrawOp,
+    HostFunctionType,
+    ContractIdType,
+    ContractIdPublicKeyType,
+    InstallContractCodeArgs,
+    ContractId,
+    ContractIdFromEd25519PublicKey,
+    CreateContractArgs,
     HostFunction,
     InvokeHostFunctionOp,
     Operation,
@@ -35477,7 +36260,9 @@ pub enum TypeVariant {
     HashIdPreimageRevokeId,
     HashIdPreimageEd25519ContractId,
     HashIdPreimageContractId,
+    HashIdPreimageFromAsset,
     HashIdPreimageSourceAccountContractId,
+    HashIdPreimageCreateContractArgs,
     MemoType,
     Memo,
     TimeBounds,
@@ -35639,7 +36424,7 @@ pub enum TypeVariant {
 }
 
 impl TypeVariant {
-    pub const VARIANTS: [TypeVariant; 375] = [
+    pub const VARIANTS: [TypeVariant; 386] = [
         TypeVariant::Value,
         TypeVariant::ScpBallot,
         TypeVariant::ScpStatementType,
@@ -35711,6 +36496,7 @@ impl TypeVariant {
         TypeVariant::LiquidityPoolEntryBody,
         TypeVariant::LiquidityPoolEntryConstantProduct,
         TypeVariant::ContractDataEntry,
+        TypeVariant::ContractCodeEntry,
         TypeVariant::ConfigSettingType,
         TypeVariant::ConfigSetting,
         TypeVariant::ConfigSettingId,
@@ -35729,6 +36515,7 @@ impl TypeVariant {
         TypeVariant::LedgerKeyClaimableBalance,
         TypeVariant::LedgerKeyLiquidityPool,
         TypeVariant::LedgerKeyContractData,
+        TypeVariant::LedgerKeyContractCode,
         TypeVariant::LedgerKeyConfigSetting,
         TypeVariant::EnvelopeType,
         TypeVariant::UpgradeType,
@@ -35809,11 +36596,11 @@ impl TypeVariant {
         TypeVariant::PeerStats,
         TypeVariant::PeerStatList,
         TypeVariant::TopologyResponseBody,
+        TypeVariant::SurveyResponseBody,
         TypeVariant::TxAdvertVector,
         TypeVariant::FloodAdvert,
         TypeVariant::TxDemandVector,
         TypeVariant::FloodDemand,
-        TypeVariant::SurveyResponseBody,
         TypeVariant::StellarMessage,
         TypeVariant::AuthenticatedMessage,
         TypeVariant::AuthenticatedMessageV0,
@@ -35847,6 +36634,13 @@ impl TypeVariant {
         TypeVariant::SetTrustLineFlagsOp,
         TypeVariant::LiquidityPoolDepositOp,
         TypeVariant::LiquidityPoolWithdrawOp,
+        TypeVariant::HostFunctionType,
+        TypeVariant::ContractIdType,
+        TypeVariant::ContractIdPublicKeyType,
+        TypeVariant::InstallContractCodeArgs,
+        TypeVariant::ContractId,
+        TypeVariant::ContractIdFromEd25519PublicKey,
+        TypeVariant::CreateContractArgs,
         TypeVariant::HostFunction,
         TypeVariant::InvokeHostFunctionOp,
         TypeVariant::Operation,
@@ -35856,7 +36650,9 @@ impl TypeVariant {
         TypeVariant::HashIdPreimageRevokeId,
         TypeVariant::HashIdPreimageEd25519ContractId,
         TypeVariant::HashIdPreimageContractId,
+        TypeVariant::HashIdPreimageFromAsset,
         TypeVariant::HashIdPreimageSourceAccountContractId,
+        TypeVariant::HashIdPreimageCreateContractArgs,
         TypeVariant::MemoType,
         TypeVariant::Memo,
         TypeVariant::TimeBounds,
@@ -36016,7 +36812,7 @@ impl TypeVariant {
         TypeVariant::ScSpecEntryKind,
         TypeVariant::ScSpecEntry,
     ];
-    pub const VARIANTS_STR: [&'static str; 375] = [
+    pub const VARIANTS_STR: [&'static str; 386] = [
         "Value",
         "ScpBallot",
         "ScpStatementType",
@@ -36088,6 +36884,7 @@ impl TypeVariant {
         "LiquidityPoolEntryBody",
         "LiquidityPoolEntryConstantProduct",
         "ContractDataEntry",
+        "ContractCodeEntry",
         "ConfigSettingType",
         "ConfigSetting",
         "ConfigSettingId",
@@ -36106,6 +36903,7 @@ impl TypeVariant {
         "LedgerKeyClaimableBalance",
         "LedgerKeyLiquidityPool",
         "LedgerKeyContractData",
+        "LedgerKeyContractCode",
         "LedgerKeyConfigSetting",
         "EnvelopeType",
         "UpgradeType",
@@ -36186,11 +36984,11 @@ impl TypeVariant {
         "PeerStats",
         "PeerStatList",
         "TopologyResponseBody",
+        "SurveyResponseBody",
         "TxAdvertVector",
         "FloodAdvert",
         "TxDemandVector",
         "FloodDemand",
-        "SurveyResponseBody",
         "StellarMessage",
         "AuthenticatedMessage",
         "AuthenticatedMessageV0",
@@ -36224,6 +37022,13 @@ impl TypeVariant {
         "SetTrustLineFlagsOp",
         "LiquidityPoolDepositOp",
         "LiquidityPoolWithdrawOp",
+        "HostFunctionType",
+        "ContractIdType",
+        "ContractIdPublicKeyType",
+        "InstallContractCodeArgs",
+        "ContractId",
+        "ContractIdFromEd25519PublicKey",
+        "CreateContractArgs",
         "HostFunction",
         "InvokeHostFunctionOp",
         "Operation",
@@ -36233,7 +37038,9 @@ impl TypeVariant {
         "HashIdPreimageRevokeId",
         "HashIdPreimageEd25519ContractId",
         "HashIdPreimageContractId",
+        "HashIdPreimageFromAsset",
         "HashIdPreimageSourceAccountContractId",
+        "HashIdPreimageCreateContractArgs",
         "MemoType",
         "Memo",
         "TimeBounds",
@@ -36471,6 +37278,7 @@ impl TypeVariant {
             Self::LiquidityPoolEntryBody => "LiquidityPoolEntryBody",
             Self::LiquidityPoolEntryConstantProduct => "LiquidityPoolEntryConstantProduct",
             Self::ContractDataEntry => "ContractDataEntry",
+            Self::ContractCodeEntry => "ContractCodeEntry",
             Self::ConfigSettingType => "ConfigSettingType",
             Self::ConfigSetting => "ConfigSetting",
             Self::ConfigSettingId => "ConfigSettingId",
@@ -36489,6 +37297,7 @@ impl TypeVariant {
             Self::LedgerKeyClaimableBalance => "LedgerKeyClaimableBalance",
             Self::LedgerKeyLiquidityPool => "LedgerKeyLiquidityPool",
             Self::LedgerKeyContractData => "LedgerKeyContractData",
+            Self::LedgerKeyContractCode => "LedgerKeyContractCode",
             Self::LedgerKeyConfigSetting => "LedgerKeyConfigSetting",
             Self::EnvelopeType => "EnvelopeType",
             Self::UpgradeType => "UpgradeType",
@@ -36569,11 +37378,11 @@ impl TypeVariant {
             Self::PeerStats => "PeerStats",
             Self::PeerStatList => "PeerStatList",
             Self::TopologyResponseBody => "TopologyResponseBody",
+            Self::SurveyResponseBody => "SurveyResponseBody",
             Self::TxAdvertVector => "TxAdvertVector",
             Self::FloodAdvert => "FloodAdvert",
             Self::TxDemandVector => "TxDemandVector",
             Self::FloodDemand => "FloodDemand",
-            Self::SurveyResponseBody => "SurveyResponseBody",
             Self::StellarMessage => "StellarMessage",
             Self::AuthenticatedMessage => "AuthenticatedMessage",
             Self::AuthenticatedMessageV0 => "AuthenticatedMessageV0",
@@ -36607,6 +37416,13 @@ impl TypeVariant {
             Self::SetTrustLineFlagsOp => "SetTrustLineFlagsOp",
             Self::LiquidityPoolDepositOp => "LiquidityPoolDepositOp",
             Self::LiquidityPoolWithdrawOp => "LiquidityPoolWithdrawOp",
+            Self::HostFunctionType => "HostFunctionType",
+            Self::ContractIdType => "ContractIdType",
+            Self::ContractIdPublicKeyType => "ContractIdPublicKeyType",
+            Self::InstallContractCodeArgs => "InstallContractCodeArgs",
+            Self::ContractId => "ContractId",
+            Self::ContractIdFromEd25519PublicKey => "ContractIdFromEd25519PublicKey",
+            Self::CreateContractArgs => "CreateContractArgs",
             Self::HostFunction => "HostFunction",
             Self::InvokeHostFunctionOp => "InvokeHostFunctionOp",
             Self::Operation => "Operation",
@@ -36616,7 +37432,9 @@ impl TypeVariant {
             Self::HashIdPreimageRevokeId => "HashIdPreimageRevokeId",
             Self::HashIdPreimageEd25519ContractId => "HashIdPreimageEd25519ContractId",
             Self::HashIdPreimageContractId => "HashIdPreimageContractId",
+            Self::HashIdPreimageFromAsset => "HashIdPreimageFromAsset",
             Self::HashIdPreimageSourceAccountContractId => "HashIdPreimageSourceAccountContractId",
+            Self::HashIdPreimageCreateContractArgs => "HashIdPreimageCreateContractArgs",
             Self::MemoType => "MemoType",
             Self::Memo => "Memo",
             Self::TimeBounds => "TimeBounds",
@@ -36784,7 +37602,7 @@ impl TypeVariant {
 
     #[must_use]
     #[allow(clippy::too_many_lines)]
-    pub const fn variants() -> [TypeVariant; 375] {
+    pub const fn variants() -> [TypeVariant; 386] {
         Self::VARIANTS
     }
 }
@@ -36880,6 +37698,7 @@ impl core::str::FromStr for TypeVariant {
             "LiquidityPoolEntryBody" => Ok(Self::LiquidityPoolEntryBody),
             "LiquidityPoolEntryConstantProduct" => Ok(Self::LiquidityPoolEntryConstantProduct),
             "ContractDataEntry" => Ok(Self::ContractDataEntry),
+            "ContractCodeEntry" => Ok(Self::ContractCodeEntry),
             "ConfigSettingType" => Ok(Self::ConfigSettingType),
             "ConfigSetting" => Ok(Self::ConfigSetting),
             "ConfigSettingId" => Ok(Self::ConfigSettingId),
@@ -36898,6 +37717,7 @@ impl core::str::FromStr for TypeVariant {
             "LedgerKeyClaimableBalance" => Ok(Self::LedgerKeyClaimableBalance),
             "LedgerKeyLiquidityPool" => Ok(Self::LedgerKeyLiquidityPool),
             "LedgerKeyContractData" => Ok(Self::LedgerKeyContractData),
+            "LedgerKeyContractCode" => Ok(Self::LedgerKeyContractCode),
             "LedgerKeyConfigSetting" => Ok(Self::LedgerKeyConfigSetting),
             "EnvelopeType" => Ok(Self::EnvelopeType),
             "UpgradeType" => Ok(Self::UpgradeType),
@@ -36978,11 +37798,11 @@ impl core::str::FromStr for TypeVariant {
             "PeerStats" => Ok(Self::PeerStats),
             "PeerStatList" => Ok(Self::PeerStatList),
             "TopologyResponseBody" => Ok(Self::TopologyResponseBody),
+            "SurveyResponseBody" => Ok(Self::SurveyResponseBody),
             "TxAdvertVector" => Ok(Self::TxAdvertVector),
             "FloodAdvert" => Ok(Self::FloodAdvert),
             "TxDemandVector" => Ok(Self::TxDemandVector),
             "FloodDemand" => Ok(Self::FloodDemand),
-            "SurveyResponseBody" => Ok(Self::SurveyResponseBody),
             "StellarMessage" => Ok(Self::StellarMessage),
             "AuthenticatedMessage" => Ok(Self::AuthenticatedMessage),
             "AuthenticatedMessageV0" => Ok(Self::AuthenticatedMessageV0),
@@ -37016,6 +37836,13 @@ impl core::str::FromStr for TypeVariant {
             "SetTrustLineFlagsOp" => Ok(Self::SetTrustLineFlagsOp),
             "LiquidityPoolDepositOp" => Ok(Self::LiquidityPoolDepositOp),
             "LiquidityPoolWithdrawOp" => Ok(Self::LiquidityPoolWithdrawOp),
+            "HostFunctionType" => Ok(Self::HostFunctionType),
+            "ContractIdType" => Ok(Self::ContractIdType),
+            "ContractIdPublicKeyType" => Ok(Self::ContractIdPublicKeyType),
+            "InstallContractCodeArgs" => Ok(Self::InstallContractCodeArgs),
+            "ContractId" => Ok(Self::ContractId),
+            "ContractIdFromEd25519PublicKey" => Ok(Self::ContractIdFromEd25519PublicKey),
+            "CreateContractArgs" => Ok(Self::CreateContractArgs),
             "HostFunction" => Ok(Self::HostFunction),
             "InvokeHostFunctionOp" => Ok(Self::InvokeHostFunctionOp),
             "Operation" => Ok(Self::Operation),
@@ -37025,9 +37852,11 @@ impl core::str::FromStr for TypeVariant {
             "HashIdPreimageRevokeId" => Ok(Self::HashIdPreimageRevokeId),
             "HashIdPreimageEd25519ContractId" => Ok(Self::HashIdPreimageEd25519ContractId),
             "HashIdPreimageContractId" => Ok(Self::HashIdPreimageContractId),
+            "HashIdPreimageFromAsset" => Ok(Self::HashIdPreimageFromAsset),
             "HashIdPreimageSourceAccountContractId" => {
                 Ok(Self::HashIdPreimageSourceAccountContractId)
             }
+            "HashIdPreimageCreateContractArgs" => Ok(Self::HashIdPreimageCreateContractArgs),
             "MemoType" => Ok(Self::MemoType),
             "Memo" => Ok(Self::Memo),
             "TimeBounds" => Ok(Self::TimeBounds),
@@ -37277,6 +38106,7 @@ pub enum Type {
     LiquidityPoolEntryBody(Box<LiquidityPoolEntryBody>),
     LiquidityPoolEntryConstantProduct(Box<LiquidityPoolEntryConstantProduct>),
     ContractDataEntry(Box<ContractDataEntry>),
+    ContractCodeEntry(Box<ContractCodeEntry>),
     ConfigSettingType(Box<ConfigSettingType>),
     ConfigSetting(Box<ConfigSetting>),
     ConfigSettingId(Box<ConfigSettingId>),
@@ -37295,6 +38125,7 @@ pub enum Type {
     LedgerKeyClaimableBalance(Box<LedgerKeyClaimableBalance>),
     LedgerKeyLiquidityPool(Box<LedgerKeyLiquidityPool>),
     LedgerKeyContractData(Box<LedgerKeyContractData>),
+    LedgerKeyContractCode(Box<LedgerKeyContractCode>),
     LedgerKeyConfigSetting(Box<LedgerKeyConfigSetting>),
     EnvelopeType(Box<EnvelopeType>),
     UpgradeType(Box<UpgradeType>),
@@ -37375,11 +38206,11 @@ pub enum Type {
     PeerStats(Box<PeerStats>),
     PeerStatList(Box<PeerStatList>),
     TopologyResponseBody(Box<TopologyResponseBody>),
+    SurveyResponseBody(Box<SurveyResponseBody>),
     TxAdvertVector(Box<TxAdvertVector>),
     FloodAdvert(Box<FloodAdvert>),
     TxDemandVector(Box<TxDemandVector>),
     FloodDemand(Box<FloodDemand>),
-    SurveyResponseBody(Box<SurveyResponseBody>),
     StellarMessage(Box<StellarMessage>),
     AuthenticatedMessage(Box<AuthenticatedMessage>),
     AuthenticatedMessageV0(Box<AuthenticatedMessageV0>),
@@ -37413,6 +38244,13 @@ pub enum Type {
     SetTrustLineFlagsOp(Box<SetTrustLineFlagsOp>),
     LiquidityPoolDepositOp(Box<LiquidityPoolDepositOp>),
     LiquidityPoolWithdrawOp(Box<LiquidityPoolWithdrawOp>),
+    HostFunctionType(Box<HostFunctionType>),
+    ContractIdType(Box<ContractIdType>),
+    ContractIdPublicKeyType(Box<ContractIdPublicKeyType>),
+    InstallContractCodeArgs(Box<InstallContractCodeArgs>),
+    ContractId(Box<ContractId>),
+    ContractIdFromEd25519PublicKey(Box<ContractIdFromEd25519PublicKey>),
+    CreateContractArgs(Box<CreateContractArgs>),
     HostFunction(Box<HostFunction>),
     InvokeHostFunctionOp(Box<InvokeHostFunctionOp>),
     Operation(Box<Operation>),
@@ -37422,7 +38260,9 @@ pub enum Type {
     HashIdPreimageRevokeId(Box<HashIdPreimageRevokeId>),
     HashIdPreimageEd25519ContractId(Box<HashIdPreimageEd25519ContractId>),
     HashIdPreimageContractId(Box<HashIdPreimageContractId>),
+    HashIdPreimageFromAsset(Box<HashIdPreimageFromAsset>),
     HashIdPreimageSourceAccountContractId(Box<HashIdPreimageSourceAccountContractId>),
+    HashIdPreimageCreateContractArgs(Box<HashIdPreimageCreateContractArgs>),
     MemoType(Box<MemoType>),
     Memo(Box<Memo>),
     TimeBounds(Box<TimeBounds>),
@@ -37584,7 +38424,7 @@ pub enum Type {
 }
 
 impl Type {
-    pub const VARIANTS: [TypeVariant; 375] = [
+    pub const VARIANTS: [TypeVariant; 386] = [
         TypeVariant::Value,
         TypeVariant::ScpBallot,
         TypeVariant::ScpStatementType,
@@ -37656,6 +38496,7 @@ impl Type {
         TypeVariant::LiquidityPoolEntryBody,
         TypeVariant::LiquidityPoolEntryConstantProduct,
         TypeVariant::ContractDataEntry,
+        TypeVariant::ContractCodeEntry,
         TypeVariant::ConfigSettingType,
         TypeVariant::ConfigSetting,
         TypeVariant::ConfigSettingId,
@@ -37674,6 +38515,7 @@ impl Type {
         TypeVariant::LedgerKeyClaimableBalance,
         TypeVariant::LedgerKeyLiquidityPool,
         TypeVariant::LedgerKeyContractData,
+        TypeVariant::LedgerKeyContractCode,
         TypeVariant::LedgerKeyConfigSetting,
         TypeVariant::EnvelopeType,
         TypeVariant::UpgradeType,
@@ -37754,11 +38596,11 @@ impl Type {
         TypeVariant::PeerStats,
         TypeVariant::PeerStatList,
         TypeVariant::TopologyResponseBody,
+        TypeVariant::SurveyResponseBody,
         TypeVariant::TxAdvertVector,
         TypeVariant::FloodAdvert,
         TypeVariant::TxDemandVector,
         TypeVariant::FloodDemand,
-        TypeVariant::SurveyResponseBody,
         TypeVariant::StellarMessage,
         TypeVariant::AuthenticatedMessage,
         TypeVariant::AuthenticatedMessageV0,
@@ -37792,6 +38634,13 @@ impl Type {
         TypeVariant::SetTrustLineFlagsOp,
         TypeVariant::LiquidityPoolDepositOp,
         TypeVariant::LiquidityPoolWithdrawOp,
+        TypeVariant::HostFunctionType,
+        TypeVariant::ContractIdType,
+        TypeVariant::ContractIdPublicKeyType,
+        TypeVariant::InstallContractCodeArgs,
+        TypeVariant::ContractId,
+        TypeVariant::ContractIdFromEd25519PublicKey,
+        TypeVariant::CreateContractArgs,
         TypeVariant::HostFunction,
         TypeVariant::InvokeHostFunctionOp,
         TypeVariant::Operation,
@@ -37801,7 +38650,9 @@ impl Type {
         TypeVariant::HashIdPreimageRevokeId,
         TypeVariant::HashIdPreimageEd25519ContractId,
         TypeVariant::HashIdPreimageContractId,
+        TypeVariant::HashIdPreimageFromAsset,
         TypeVariant::HashIdPreimageSourceAccountContractId,
+        TypeVariant::HashIdPreimageCreateContractArgs,
         TypeVariant::MemoType,
         TypeVariant::Memo,
         TypeVariant::TimeBounds,
@@ -37961,7 +38812,7 @@ impl Type {
         TypeVariant::ScSpecEntryKind,
         TypeVariant::ScSpecEntry,
     ];
-    pub const VARIANTS_STR: [&'static str; 375] = [
+    pub const VARIANTS_STR: [&'static str; 386] = [
         "Value",
         "ScpBallot",
         "ScpStatementType",
@@ -38033,6 +38884,7 @@ impl Type {
         "LiquidityPoolEntryBody",
         "LiquidityPoolEntryConstantProduct",
         "ContractDataEntry",
+        "ContractCodeEntry",
         "ConfigSettingType",
         "ConfigSetting",
         "ConfigSettingId",
@@ -38051,6 +38903,7 @@ impl Type {
         "LedgerKeyClaimableBalance",
         "LedgerKeyLiquidityPool",
         "LedgerKeyContractData",
+        "LedgerKeyContractCode",
         "LedgerKeyConfigSetting",
         "EnvelopeType",
         "UpgradeType",
@@ -38131,11 +38984,11 @@ impl Type {
         "PeerStats",
         "PeerStatList",
         "TopologyResponseBody",
+        "SurveyResponseBody",
         "TxAdvertVector",
         "FloodAdvert",
         "TxDemandVector",
         "FloodDemand",
-        "SurveyResponseBody",
         "StellarMessage",
         "AuthenticatedMessage",
         "AuthenticatedMessageV0",
@@ -38169,6 +39022,13 @@ impl Type {
         "SetTrustLineFlagsOp",
         "LiquidityPoolDepositOp",
         "LiquidityPoolWithdrawOp",
+        "HostFunctionType",
+        "ContractIdType",
+        "ContractIdPublicKeyType",
+        "InstallContractCodeArgs",
+        "ContractId",
+        "ContractIdFromEd25519PublicKey",
+        "CreateContractArgs",
         "HostFunction",
         "InvokeHostFunctionOp",
         "Operation",
@@ -38178,7 +39038,9 @@ impl Type {
         "HashIdPreimageRevokeId",
         "HashIdPreimageEd25519ContractId",
         "HashIdPreimageContractId",
+        "HashIdPreimageFromAsset",
         "HashIdPreimageSourceAccountContractId",
+        "HashIdPreimageCreateContractArgs",
         "MemoType",
         "Memo",
         "TimeBounds",
@@ -38516,6 +39378,9 @@ impl Type {
             TypeVariant::ContractDataEntry => Ok(Self::ContractDataEntry(Box::new(
                 ContractDataEntry::read_xdr(r)?,
             ))),
+            TypeVariant::ContractCodeEntry => Ok(Self::ContractCodeEntry(Box::new(
+                ContractCodeEntry::read_xdr(r)?,
+            ))),
             TypeVariant::ConfigSettingType => Ok(Self::ConfigSettingType(Box::new(
                 ConfigSettingType::read_xdr(r)?,
             ))),
@@ -38565,6 +39430,9 @@ impl Type {
             ))),
             TypeVariant::LedgerKeyContractData => Ok(Self::LedgerKeyContractData(Box::new(
                 LedgerKeyContractData::read_xdr(r)?,
+            ))),
+            TypeVariant::LedgerKeyContractCode => Ok(Self::LedgerKeyContractCode(Box::new(
+                LedgerKeyContractCode::read_xdr(r)?,
             ))),
             TypeVariant::LedgerKeyConfigSetting => Ok(Self::LedgerKeyConfigSetting(Box::new(
                 LedgerKeyConfigSetting::read_xdr(r)?,
@@ -38788,6 +39656,9 @@ impl Type {
             TypeVariant::TopologyResponseBody => Ok(Self::TopologyResponseBody(Box::new(
                 TopologyResponseBody::read_xdr(r)?,
             ))),
+            TypeVariant::SurveyResponseBody => Ok(Self::SurveyResponseBody(Box::new(
+                SurveyResponseBody::read_xdr(r)?,
+            ))),
             TypeVariant::TxAdvertVector => {
                 Ok(Self::TxAdvertVector(Box::new(TxAdvertVector::read_xdr(r)?)))
             }
@@ -38796,9 +39667,6 @@ impl Type {
                 Ok(Self::TxDemandVector(Box::new(TxDemandVector::read_xdr(r)?)))
             }
             TypeVariant::FloodDemand => Ok(Self::FloodDemand(Box::new(FloodDemand::read_xdr(r)?))),
-            TypeVariant::SurveyResponseBody => Ok(Self::SurveyResponseBody(Box::new(
-                SurveyResponseBody::read_xdr(r)?,
-            ))),
             TypeVariant::StellarMessage => {
                 Ok(Self::StellarMessage(Box::new(StellarMessage::read_xdr(r)?)))
             }
@@ -38896,6 +39764,27 @@ impl Type {
             TypeVariant::LiquidityPoolWithdrawOp => Ok(Self::LiquidityPoolWithdrawOp(Box::new(
                 LiquidityPoolWithdrawOp::read_xdr(r)?,
             ))),
+            TypeVariant::HostFunctionType => Ok(Self::HostFunctionType(Box::new(
+                HostFunctionType::read_xdr(r)?,
+            ))),
+            TypeVariant::ContractIdType => {
+                Ok(Self::ContractIdType(Box::new(ContractIdType::read_xdr(r)?)))
+            }
+            TypeVariant::ContractIdPublicKeyType => Ok(Self::ContractIdPublicKeyType(Box::new(
+                ContractIdPublicKeyType::read_xdr(r)?,
+            ))),
+            TypeVariant::InstallContractCodeArgs => Ok(Self::InstallContractCodeArgs(Box::new(
+                InstallContractCodeArgs::read_xdr(r)?,
+            ))),
+            TypeVariant::ContractId => Ok(Self::ContractId(Box::new(ContractId::read_xdr(r)?))),
+            TypeVariant::ContractIdFromEd25519PublicKey => {
+                Ok(Self::ContractIdFromEd25519PublicKey(Box::new(
+                    ContractIdFromEd25519PublicKey::read_xdr(r)?,
+                )))
+            }
+            TypeVariant::CreateContractArgs => Ok(Self::CreateContractArgs(Box::new(
+                CreateContractArgs::read_xdr(r)?,
+            ))),
             TypeVariant::HostFunction => {
                 Ok(Self::HostFunction(Box::new(HostFunction::read_xdr(r)?)))
             }
@@ -38923,9 +39812,17 @@ impl Type {
             TypeVariant::HashIdPreimageContractId => Ok(Self::HashIdPreimageContractId(Box::new(
                 HashIdPreimageContractId::read_xdr(r)?,
             ))),
+            TypeVariant::HashIdPreimageFromAsset => Ok(Self::HashIdPreimageFromAsset(Box::new(
+                HashIdPreimageFromAsset::read_xdr(r)?,
+            ))),
             TypeVariant::HashIdPreimageSourceAccountContractId => {
                 Ok(Self::HashIdPreimageSourceAccountContractId(Box::new(
                     HashIdPreimageSourceAccountContractId::read_xdr(r)?,
+                )))
+            }
+            TypeVariant::HashIdPreimageCreateContractArgs => {
+                Ok(Self::HashIdPreimageCreateContractArgs(Box::new(
+                    HashIdPreimageCreateContractArgs::read_xdr(r)?,
                 )))
             }
             TypeVariant::MemoType => Ok(Self::MemoType(Box::new(MemoType::read_xdr(r)?))),
@@ -39470,6 +40367,7 @@ impl Type {
             Self::LiquidityPoolEntryBody(ref v) => v.as_ref(),
             Self::LiquidityPoolEntryConstantProduct(ref v) => v.as_ref(),
             Self::ContractDataEntry(ref v) => v.as_ref(),
+            Self::ContractCodeEntry(ref v) => v.as_ref(),
             Self::ConfigSettingType(ref v) => v.as_ref(),
             Self::ConfigSetting(ref v) => v.as_ref(),
             Self::ConfigSettingId(ref v) => v.as_ref(),
@@ -39488,6 +40386,7 @@ impl Type {
             Self::LedgerKeyClaimableBalance(ref v) => v.as_ref(),
             Self::LedgerKeyLiquidityPool(ref v) => v.as_ref(),
             Self::LedgerKeyContractData(ref v) => v.as_ref(),
+            Self::LedgerKeyContractCode(ref v) => v.as_ref(),
             Self::LedgerKeyConfigSetting(ref v) => v.as_ref(),
             Self::EnvelopeType(ref v) => v.as_ref(),
             Self::UpgradeType(ref v) => v.as_ref(),
@@ -39568,11 +40467,11 @@ impl Type {
             Self::PeerStats(ref v) => v.as_ref(),
             Self::PeerStatList(ref v) => v.as_ref(),
             Self::TopologyResponseBody(ref v) => v.as_ref(),
+            Self::SurveyResponseBody(ref v) => v.as_ref(),
             Self::TxAdvertVector(ref v) => v.as_ref(),
             Self::FloodAdvert(ref v) => v.as_ref(),
             Self::TxDemandVector(ref v) => v.as_ref(),
             Self::FloodDemand(ref v) => v.as_ref(),
-            Self::SurveyResponseBody(ref v) => v.as_ref(),
             Self::StellarMessage(ref v) => v.as_ref(),
             Self::AuthenticatedMessage(ref v) => v.as_ref(),
             Self::AuthenticatedMessageV0(ref v) => v.as_ref(),
@@ -39606,6 +40505,13 @@ impl Type {
             Self::SetTrustLineFlagsOp(ref v) => v.as_ref(),
             Self::LiquidityPoolDepositOp(ref v) => v.as_ref(),
             Self::LiquidityPoolWithdrawOp(ref v) => v.as_ref(),
+            Self::HostFunctionType(ref v) => v.as_ref(),
+            Self::ContractIdType(ref v) => v.as_ref(),
+            Self::ContractIdPublicKeyType(ref v) => v.as_ref(),
+            Self::InstallContractCodeArgs(ref v) => v.as_ref(),
+            Self::ContractId(ref v) => v.as_ref(),
+            Self::ContractIdFromEd25519PublicKey(ref v) => v.as_ref(),
+            Self::CreateContractArgs(ref v) => v.as_ref(),
             Self::HostFunction(ref v) => v.as_ref(),
             Self::InvokeHostFunctionOp(ref v) => v.as_ref(),
             Self::Operation(ref v) => v.as_ref(),
@@ -39615,7 +40521,9 @@ impl Type {
             Self::HashIdPreimageRevokeId(ref v) => v.as_ref(),
             Self::HashIdPreimageEd25519ContractId(ref v) => v.as_ref(),
             Self::HashIdPreimageContractId(ref v) => v.as_ref(),
+            Self::HashIdPreimageFromAsset(ref v) => v.as_ref(),
             Self::HashIdPreimageSourceAccountContractId(ref v) => v.as_ref(),
+            Self::HashIdPreimageCreateContractArgs(ref v) => v.as_ref(),
             Self::MemoType(ref v) => v.as_ref(),
             Self::Memo(ref v) => v.as_ref(),
             Self::TimeBounds(ref v) => v.as_ref(),
@@ -39854,6 +40762,7 @@ impl Type {
             Self::LiquidityPoolEntryBody(_) => "LiquidityPoolEntryBody",
             Self::LiquidityPoolEntryConstantProduct(_) => "LiquidityPoolEntryConstantProduct",
             Self::ContractDataEntry(_) => "ContractDataEntry",
+            Self::ContractCodeEntry(_) => "ContractCodeEntry",
             Self::ConfigSettingType(_) => "ConfigSettingType",
             Self::ConfigSetting(_) => "ConfigSetting",
             Self::ConfigSettingId(_) => "ConfigSettingId",
@@ -39872,6 +40781,7 @@ impl Type {
             Self::LedgerKeyClaimableBalance(_) => "LedgerKeyClaimableBalance",
             Self::LedgerKeyLiquidityPool(_) => "LedgerKeyLiquidityPool",
             Self::LedgerKeyContractData(_) => "LedgerKeyContractData",
+            Self::LedgerKeyContractCode(_) => "LedgerKeyContractCode",
             Self::LedgerKeyConfigSetting(_) => "LedgerKeyConfigSetting",
             Self::EnvelopeType(_) => "EnvelopeType",
             Self::UpgradeType(_) => "UpgradeType",
@@ -39952,11 +40862,11 @@ impl Type {
             Self::PeerStats(_) => "PeerStats",
             Self::PeerStatList(_) => "PeerStatList",
             Self::TopologyResponseBody(_) => "TopologyResponseBody",
+            Self::SurveyResponseBody(_) => "SurveyResponseBody",
             Self::TxAdvertVector(_) => "TxAdvertVector",
             Self::FloodAdvert(_) => "FloodAdvert",
             Self::TxDemandVector(_) => "TxDemandVector",
             Self::FloodDemand(_) => "FloodDemand",
-            Self::SurveyResponseBody(_) => "SurveyResponseBody",
             Self::StellarMessage(_) => "StellarMessage",
             Self::AuthenticatedMessage(_) => "AuthenticatedMessage",
             Self::AuthenticatedMessageV0(_) => "AuthenticatedMessageV0",
@@ -39990,6 +40900,13 @@ impl Type {
             Self::SetTrustLineFlagsOp(_) => "SetTrustLineFlagsOp",
             Self::LiquidityPoolDepositOp(_) => "LiquidityPoolDepositOp",
             Self::LiquidityPoolWithdrawOp(_) => "LiquidityPoolWithdrawOp",
+            Self::HostFunctionType(_) => "HostFunctionType",
+            Self::ContractIdType(_) => "ContractIdType",
+            Self::ContractIdPublicKeyType(_) => "ContractIdPublicKeyType",
+            Self::InstallContractCodeArgs(_) => "InstallContractCodeArgs",
+            Self::ContractId(_) => "ContractId",
+            Self::ContractIdFromEd25519PublicKey(_) => "ContractIdFromEd25519PublicKey",
+            Self::CreateContractArgs(_) => "CreateContractArgs",
             Self::HostFunction(_) => "HostFunction",
             Self::InvokeHostFunctionOp(_) => "InvokeHostFunctionOp",
             Self::Operation(_) => "Operation",
@@ -39999,9 +40916,11 @@ impl Type {
             Self::HashIdPreimageRevokeId(_) => "HashIdPreimageRevokeId",
             Self::HashIdPreimageEd25519ContractId(_) => "HashIdPreimageEd25519ContractId",
             Self::HashIdPreimageContractId(_) => "HashIdPreimageContractId",
+            Self::HashIdPreimageFromAsset(_) => "HashIdPreimageFromAsset",
             Self::HashIdPreimageSourceAccountContractId(_) => {
                 "HashIdPreimageSourceAccountContractId"
             }
+            Self::HashIdPreimageCreateContractArgs(_) => "HashIdPreimageCreateContractArgs",
             Self::MemoType(_) => "MemoType",
             Self::Memo(_) => "Memo",
             Self::TimeBounds(_) => "TimeBounds",
@@ -40173,7 +41092,7 @@ impl Type {
 
     #[must_use]
     #[allow(clippy::too_many_lines)]
-    pub const fn variants() -> [TypeVariant; 375] {
+    pub const fn variants() -> [TypeVariant; 386] {
         Self::VARIANTS
     }
 
@@ -40260,6 +41179,7 @@ impl Type {
                 TypeVariant::LiquidityPoolEntryConstantProduct
             }
             Self::ContractDataEntry(_) => TypeVariant::ContractDataEntry,
+            Self::ContractCodeEntry(_) => TypeVariant::ContractCodeEntry,
             Self::ConfigSettingType(_) => TypeVariant::ConfigSettingType,
             Self::ConfigSetting(_) => TypeVariant::ConfigSetting,
             Self::ConfigSettingId(_) => TypeVariant::ConfigSettingId,
@@ -40278,6 +41198,7 @@ impl Type {
             Self::LedgerKeyClaimableBalance(_) => TypeVariant::LedgerKeyClaimableBalance,
             Self::LedgerKeyLiquidityPool(_) => TypeVariant::LedgerKeyLiquidityPool,
             Self::LedgerKeyContractData(_) => TypeVariant::LedgerKeyContractData,
+            Self::LedgerKeyContractCode(_) => TypeVariant::LedgerKeyContractCode,
             Self::LedgerKeyConfigSetting(_) => TypeVariant::LedgerKeyConfigSetting,
             Self::EnvelopeType(_) => TypeVariant::EnvelopeType,
             Self::UpgradeType(_) => TypeVariant::UpgradeType,
@@ -40366,11 +41287,11 @@ impl Type {
             Self::PeerStats(_) => TypeVariant::PeerStats,
             Self::PeerStatList(_) => TypeVariant::PeerStatList,
             Self::TopologyResponseBody(_) => TypeVariant::TopologyResponseBody,
+            Self::SurveyResponseBody(_) => TypeVariant::SurveyResponseBody,
             Self::TxAdvertVector(_) => TypeVariant::TxAdvertVector,
             Self::FloodAdvert(_) => TypeVariant::FloodAdvert,
             Self::TxDemandVector(_) => TypeVariant::TxDemandVector,
             Self::FloodDemand(_) => TypeVariant::FloodDemand,
-            Self::SurveyResponseBody(_) => TypeVariant::SurveyResponseBody,
             Self::StellarMessage(_) => TypeVariant::StellarMessage,
             Self::AuthenticatedMessage(_) => TypeVariant::AuthenticatedMessage,
             Self::AuthenticatedMessageV0(_) => TypeVariant::AuthenticatedMessageV0,
@@ -40406,6 +41327,13 @@ impl Type {
             Self::SetTrustLineFlagsOp(_) => TypeVariant::SetTrustLineFlagsOp,
             Self::LiquidityPoolDepositOp(_) => TypeVariant::LiquidityPoolDepositOp,
             Self::LiquidityPoolWithdrawOp(_) => TypeVariant::LiquidityPoolWithdrawOp,
+            Self::HostFunctionType(_) => TypeVariant::HostFunctionType,
+            Self::ContractIdType(_) => TypeVariant::ContractIdType,
+            Self::ContractIdPublicKeyType(_) => TypeVariant::ContractIdPublicKeyType,
+            Self::InstallContractCodeArgs(_) => TypeVariant::InstallContractCodeArgs,
+            Self::ContractId(_) => TypeVariant::ContractId,
+            Self::ContractIdFromEd25519PublicKey(_) => TypeVariant::ContractIdFromEd25519PublicKey,
+            Self::CreateContractArgs(_) => TypeVariant::CreateContractArgs,
             Self::HostFunction(_) => TypeVariant::HostFunction,
             Self::InvokeHostFunctionOp(_) => TypeVariant::InvokeHostFunctionOp,
             Self::Operation(_) => TypeVariant::Operation,
@@ -40417,8 +41345,12 @@ impl Type {
                 TypeVariant::HashIdPreimageEd25519ContractId
             }
             Self::HashIdPreimageContractId(_) => TypeVariant::HashIdPreimageContractId,
+            Self::HashIdPreimageFromAsset(_) => TypeVariant::HashIdPreimageFromAsset,
             Self::HashIdPreimageSourceAccountContractId(_) => {
                 TypeVariant::HashIdPreimageSourceAccountContractId
+            }
+            Self::HashIdPreimageCreateContractArgs(_) => {
+                TypeVariant::HashIdPreimageCreateContractArgs
             }
             Self::MemoType(_) => TypeVariant::MemoType,
             Self::Memo(_) => TypeVariant::Memo,

--- a/src/next.rs
+++ b/src/next.rs
@@ -15,39 +15,39 @@
 pub const XDR_FILES_SHA256: [(&str, &str); 9] = [
     (
         "xdr/next/Stellar-SCP.x",
-        "2b855c7f79b8e50cf15ca1e1aa89fb16bbb38117de0b1c969c80e675ae1ca4bb",
+        "8f32b04d008f8bc33b8843d075e69837231a673691ee41d8b821ca229a6e802a",
     ),
     (
         "xdr/next/Stellar-contract-env-meta.x",
-        "8d30dbf039e41e149725b34f2c809fc034c0879adac9d85fc49b8371f9a0444f",
+        "928a30de814ee589bc1d2aadd8dd81c39f71b7e6f430f56974505ccb1f49654b",
     ),
     (
         "xdr/next/Stellar-contract-spec.x",
-        "93314675c50e026df2c0505c89efd917a1a4327896644c8d6efb3b72630d59e4",
+        "8819c9b462fcc74199f051989ad14621b833036e8fed0fa3a1b83abda84a8bfc",
     ),
     (
         "xdr/next/Stellar-contract.x",
-        "4c9a04dae392675deb8c51f397b614bcb6b963b987beb32372038af0605e4462",
+        "f0cd24f498a0b9c99586fe1a7759bf4d00dfa834ed164f3eed4e56bc5f781014",
     ),
     (
         "xdr/next/Stellar-ledger-entries.x",
-        "76ed66cb96eb29db8ccfc03434d00679e7ea35668ff8469d5cc8fdd9a743465a",
+        "bc3ef59ed74e6f990ce14dd051a000a6dd793fc6a5deb4a83c7fef1035ff1bc6",
     ),
     (
         "xdr/next/Stellar-ledger.x",
-        "9949aa422c521116d5bc1e4fa508f07d6670a54fd421ff93ca1dbc2742979e1c",
+        "c1b43f57346f5ca124c79a1c05a33043bcb9a8185432efec848b7001afd3bb25",
     ),
     (
         "xdr/next/Stellar-overlay.x",
-        "56d0a34446e90f047e7d9d862c881d710abac37ac6ccabc37de7b2d23b77056f",
+        "3093b425866f34b32702d80d5298f9f2dc00736b0fdaac7efa653490a39fb231",
     ),
     (
         "xdr/next/Stellar-transaction.x",
-        "728244001903fe06ec6d5a23b81256adbccf1b0c0817ec084aa2703980889a75",
+        "bdac432e08265df6a13dc4c6135090ca6dcaa8eeedd61a0533ba52b4c9baf201",
     ),
     (
         "xdr/next/Stellar-types.x",
-        "92991a74191509be836e0507081b8624f38bde51994d5c4554b0347c0c68ac6c",
+        "7b3e5470c4bcf7c19f9cc8f8bf81a494b540fc2157476329cf19863afab2343b",
     ),
 ];
 

--- a/xdr/next/Stellar-contract.x
+++ b/xdr/next/Stellar-contract.x
@@ -250,14 +250,14 @@ case NEGATIVE:
 
 enum SCContractCodeType
 {
-    SCCONTRACT_CODE_WASM = 0,
+    SCCONTRACT_CODE_WASM_REF = 0,
     SCCONTRACT_CODE_TOKEN = 1
 };
 
 union SCContractCode switch (SCContractCodeType type)
 {
-case SCCONTRACT_CODE_WASM:
-    opaque wasm<SCVAL_LIMIT>;
+case SCCONTRACT_CODE_WASM_REF:
+    Hash wasm_id;
 case SCCONTRACT_CODE_TOKEN:
     void;
 };

--- a/xdr/next/Stellar-ledger-entries.x
+++ b/xdr/next/Stellar-ledger-entries.x
@@ -100,7 +100,8 @@ enum LedgerEntryType
     CLAIMABLE_BALANCE = 4,
     LIQUIDITY_POOL = 5,
     CONTRACT_DATA = 6,
-    CONFIG_SETTING = 7
+    CONTRACT_CODE = 7,
+    CONFIG_SETTING = 8
 };
 
 struct Signer
@@ -499,6 +500,13 @@ struct ContractDataEntry {
     SCVal val;
 };
 
+struct ContractCodeEntry {
+    ExtensionPoint ext;
+
+    Hash hash;
+    opaque code<SCVAL_LIMIT>;
+};
+
 enum ConfigSettingType
 {
     CONFIG_SETTING_TYPE_UINT32 = 0
@@ -560,6 +568,8 @@ struct LedgerEntry
         LiquidityPoolEntry liquidityPool;
     case CONTRACT_DATA:
         ContractDataEntry contractData;
+    case CONTRACT_CODE:
+        ContractCodeEntry contractCode;
     case CONFIG_SETTING:
         ConfigSettingEntry configSetting;
     }
@@ -622,6 +632,11 @@ case CONTRACT_DATA:
         Hash contractID;
         SCVal key;
     } contractData;
+case CONTRACT_CODE:
+    struct
+    {
+        Hash hash;
+    } contractCode;
 case CONFIG_SETTING:
     struct
     {
@@ -645,6 +660,7 @@ enum EnvelopeType
     ENVELOPE_TYPE_CONTRACT_ID_FROM_ED25519 = 8,
     ENVELOPE_TYPE_CONTRACT_ID_FROM_CONTRACT = 9,
     ENVELOPE_TYPE_CONTRACT_ID_FROM_ASSET = 10,
-    ENVELOPE_TYPE_CONTRACT_ID_FROM_SOURCE_ACCOUNT = 11
+    ENVELOPE_TYPE_CONTRACT_ID_FROM_SOURCE_ACCOUNT = 11,
+    ENVELOPE_TYPE_CREATE_CONTRACT_ARGS = 12
 };
 }

--- a/xdr/next/Stellar-overlay.x
+++ b/xdr/next/Stellar-overlay.x
@@ -47,6 +47,7 @@ struct Hello
     uint256 nonce;
 };
 
+
 // During the roll-out phrase, pull mode will be optional.
 // Therefore, we need a way to communicate with other nodes
 // that we want/don't want pull mode.
@@ -189,6 +190,12 @@ struct TopologyResponseBody
     uint32 totalOutboundPeerCount;
 };
 
+union SurveyResponseBody switch (SurveyMessageCommandType type)
+{
+case SURVEY_TOPOLOGY:
+    TopologyResponseBody topologyResponseBody;
+};
+
 const TX_ADVERT_VECTOR_MAX_SIZE = 1000;
 typedef Hash TxAdvertVector<TX_ADVERT_VECTOR_MAX_SIZE>;
 
@@ -203,12 +210,6 @@ typedef Hash TxDemandVector<TX_DEMAND_VECTOR_MAX_SIZE>;
 struct FloodDemand
 {
     TxDemandVector txHashes;
-};
-
-union SurveyResponseBody switch (SurveyMessageCommandType type)
-{
-case SURVEY_TOPOLOGY:
-    TopologyResponseBody topologyResponseBody;
 };
 
 union StellarMessage switch (MessageType type)
@@ -256,9 +257,9 @@ case SEND_MORE:
 
 // Pull mode
 case FLOOD_ADVERT:
-    FloodAdvert floodAdvert;
+     FloodAdvert floodAdvert;
 case FLOOD_DEMAND:
-    FloodDemand floodDemand;
+     FloodDemand floodDemand;
 };
 
 union AuthenticatedMessage switch (uint32 v)

--- a/xdr/next/Stellar-transaction.x
+++ b/xdr/next/Stellar-transaction.x
@@ -474,23 +474,66 @@ struct LiquidityPoolWithdrawOp
     int64 minAmountB; // minimum amount of second asset to withdraw
 };
 
-enum HostFunction
+enum HostFunctionType
 {
-    HOST_FN_INVOKE_CONTRACT = 0,
-    HOST_FN_CREATE_CONTRACT_WITH_ED25519 = 1,
-    HOST_FN_CREATE_CONTRACT_WITH_SOURCE_ACCOUNT = 2,
-    HOST_FN_CREATE_TOKEN_CONTRACT_WITH_SOURCE_ACCOUNT = 3,
-    HOST_FN_CREATE_TOKEN_CONTRACT_WITH_ASSET = 4
+    HOST_FUNCTION_TYPE_INVOKE_CONTRACT = 0,
+    HOST_FUNCTION_TYPE_CREATE_CONTRACT = 1,
+    HOST_FUNCTION_TYPE_INSTALL_CONTRACT_CODE = 2
+};
+
+enum ContractIDType
+{
+    CONTRACT_ID_FROM_SOURCE_ACCOUNT = 0,
+    CONTRACT_ID_FROM_ED25519_PUBLIC_KEY = 1,
+    CONTRACT_ID_FROM_ASSET = 2
+};
+ 
+enum ContractIDPublicKeyType
+{
+    CONTRACT_ID_PUBLIC_KEY_SOURCE_ACCOUNT = 0,
+    CONTRACT_ID_PUBLIC_KEY_ED25519 = 1
+};
+
+struct InstallContractCodeArgs
+{
+    opaque code<SCVAL_LIMIT>;
+};
+
+union ContractID switch (ContractIDType type)
+{
+case CONTRACT_ID_FROM_SOURCE_ACCOUNT:
+    uint256 salt;
+case CONTRACT_ID_FROM_ED25519_PUBLIC_KEY:
+    struct 
+    {
+        uint256 key;
+        Signature signature;
+        uint256 salt;
+    } fromEd25519PublicKey;
+case CONTRACT_ID_FROM_ASSET:
+    Asset asset;
+};
+
+struct CreateContractArgs
+{
+    ContractID contractID;
+    SCContractCode source;
+};
+
+union HostFunction switch (HostFunctionType type)
+{
+case HOST_FUNCTION_TYPE_INVOKE_CONTRACT:
+    SCVec invokeArgs;
+case HOST_FUNCTION_TYPE_CREATE_CONTRACT:
+    CreateContractArgs createContractArgs;
+case HOST_FUNCTION_TYPE_INSTALL_CONTRACT_CODE:
+    InstallContractCodeArgs installContractCodeArgs;
 };
 
 struct InvokeHostFunctionOp
 {
     // The host function to invoke
     HostFunction function;
-
-    // Parameters to the host function
-    SCVec parameters;
-
     // The footprint for this invocation
     LedgerFootprint footprint;
 };
@@ -580,23 +623,37 @@ case ENVELOPE_TYPE_POOL_REVOKE_OP_ID:
 case ENVELOPE_TYPE_CONTRACT_ID_FROM_ED25519:
     struct
     {
+        Hash networkID;
         uint256 ed25519;
         uint256 salt;
     } ed25519ContractID;
 case ENVELOPE_TYPE_CONTRACT_ID_FROM_CONTRACT:
     struct
     {
+        Hash networkID;
         Hash contractID;
         uint256 salt;
     } contractID;
 case ENVELOPE_TYPE_CONTRACT_ID_FROM_ASSET:
-    Asset fromAsset;
+    struct
+    {
+        Hash networkID;
+        Asset asset;
+    } fromAsset;
 case ENVELOPE_TYPE_CONTRACT_ID_FROM_SOURCE_ACCOUNT:
     struct
     {
+        Hash networkID;
         AccountID sourceAccount;
         uint256 salt;
     } sourceAccountContractID;
+case ENVELOPE_TYPE_CREATE_CONTRACT_ARGS:
+    struct
+    {
+        Hash networkID;
+        SCContractCode source;
+        uint256 salt;
+    } createContractArgs;        
 };
 
 enum MemoType


### PR DESCRIPTION
### What

This introduces the ledger entries to store the wasm code and also changes the host functions to support creating/installing the contracts.

### Why

The change mirrors the merged XDR changes in https://github.com/stellar/stellar-xdr-next/pull/51

### Known limitations

N/A
