### PR TITLE
pub mod int128_helpers

### DIFF
--- a/src/scval_conversions.rs
+++ b/src/scval_conversions.rs
@@ -257,20 +257,14 @@ impl TryFrom<ScVal> for u64 {
 pub mod int128_helpers {
     #[must_use]
     #[inline(always)]
-    #[allow(
-        clippy::inline_always,
-        clippy::cast_possible_truncation
-    )]
+    #[allow(clippy::inline_always, clippy::cast_possible_truncation)]
     pub fn u128_lo(u: u128) -> u64 {
         u as u64
     }
 
     #[must_use]
     #[inline(always)]
-    #[allow(
-        clippy::inline_always,
-        clippy::cast_possible_truncation
-    )]
+    #[allow(clippy::inline_always, clippy::cast_possible_truncation)]
     pub fn u128_hi(u: u128) -> u64 {
         (u >> 64) as u64
     }
@@ -284,20 +278,14 @@ pub mod int128_helpers {
 
     #[must_use]
     #[inline(always)]
-    #[allow(
-        clippy::inline_always,
-        clippy::cast_sign_loss,
-    )]
+    #[allow(clippy::inline_always, clippy::cast_sign_loss)]
     pub fn u128_from_i128(i: i128) -> u128 {
         i as u128
     }
 
     #[must_use]
     #[inline(always)]
-    #[allow(
-        clippy::inline_always,
-        clippy::cast_possible_wrap,
-    )]
+    #[allow(clippy::inline_always, clippy::cast_possible_wrap)]
     pub fn i128_from_u128(u: u128) -> i128 {
         u as i128
     }

--- a/src/scval_conversions.rs
+++ b/src/scval_conversions.rs
@@ -254,35 +254,57 @@ impl TryFrom<ScVal> for u64 {
     }
 }
 
-#[inline(always)]
-#[allow(clippy::inline_always, clippy::cast_possible_truncation)]
-fn u128_lo(u: u128) -> u64 {
-    u as u64
+// Export int128_helpers for reuse in host.
+pub mod int128_helpers {
+    #[inline(always)]
+    #[allow(
+        clippy::inline_always,
+        clippy::must_use_candidate,
+        clippy::cast_possible_truncation
+    )]
+    pub fn u128_lo(u: u128) -> u64 {
+        u as u64
+    }
+
+    #[inline(always)]
+    #[allow(
+        clippy::inline_always,
+        clippy::must_use_candidate,
+        clippy::cast_possible_truncation
+    )]
+    pub fn u128_hi(u: u128) -> u64 {
+        (u >> 64) as u64
+    }
+
+    #[inline(always)]
+    #[allow(clippy::inline_always, clippy::must_use_candidate)]
+    pub fn u128_from_pieces(lo: u64, hi: u64) -> u128 {
+        u128::from(lo) | (u128::from(hi) << 64)
+    }
+
+    #[inline(always)]
+    #[allow(
+        clippy::inline_always,
+        clippy::cast_sign_loss,
+        clippy::must_use_candidate
+    )]
+    pub fn u128_from_i128(i: i128) -> u128 {
+        i as u128
+    }
+
+    #[inline(always)]
+    #[allow(
+        clippy::inline_always,
+        clippy::cast_possible_wrap,
+        clippy::must_use_candidate
+    )]
+    pub fn i128_from_u128(u: u128) -> i128 {
+        u as i128
+    }
 }
 
-#[inline(always)]
-#[allow(clippy::inline_always, clippy::cast_possible_truncation)]
-fn u128_hi(u: u128) -> u64 {
-    (u >> 64) as u64
-}
-
-#[inline(always)]
-#[allow(clippy::inline_always)]
-fn u128_from_pieces(lo: u64, hi: u64) -> u128 {
-    u128::from(lo) | (u128::from(hi) << 64)
-}
-
-#[inline(always)]
-#[allow(clippy::inline_always, clippy::cast_sign_loss)]
-fn u128_from_i128(i: i128) -> u128 {
-    i as u128
-}
-
-#[inline(always)]
-#[allow(clippy::inline_always, clippy::cast_possible_wrap)]
-fn i128_from_u128(u: u128) -> i128 {
-    u as i128
-}
+#[allow(clippy::wildcard_imports)]
+use int128_helpers::*;
 
 impl From<u128> for ScObject {
     fn from(v: u128) -> Self {

--- a/src/scval_conversions.rs
+++ b/src/scval_conversions.rs
@@ -254,49 +254,49 @@ impl TryFrom<ScVal> for u64 {
     }
 }
 
-// Export int128_helpers for reuse in host.
 pub mod int128_helpers {
+    #[must_use]
     #[inline(always)]
     #[allow(
         clippy::inline_always,
-        clippy::must_use_candidate,
         clippy::cast_possible_truncation
     )]
     pub fn u128_lo(u: u128) -> u64 {
         u as u64
     }
 
+    #[must_use]
     #[inline(always)]
     #[allow(
         clippy::inline_always,
-        clippy::must_use_candidate,
         clippy::cast_possible_truncation
     )]
     pub fn u128_hi(u: u128) -> u64 {
         (u >> 64) as u64
     }
 
+    #[must_use]
     #[inline(always)]
-    #[allow(clippy::inline_always, clippy::must_use_candidate)]
+    #[allow(clippy::inline_always)]
     pub fn u128_from_pieces(lo: u64, hi: u64) -> u128 {
         u128::from(lo) | (u128::from(hi) << 64)
     }
 
+    #[must_use]
     #[inline(always)]
     #[allow(
         clippy::inline_always,
         clippy::cast_sign_loss,
-        clippy::must_use_candidate
     )]
     pub fn u128_from_i128(i: i128) -> u128 {
         i as u128
     }
 
+    #[must_use]
     #[inline(always)]
     #[allow(
         clippy::inline_always,
         clippy::cast_possible_wrap,
-        clippy::must_use_candidate
     )]
     pub fn i128_from_u128(u: u128) -> i128 {
         u as i128


### PR DESCRIPTION
This just exposes some of the i128/u128 helper functions in the previous PR in a pub mod, so we can use them in the host.