### PR TITLE
Update crate-git-revision to 0.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,9 +101,9 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "crate-git-revision"
-version = "0.0.2"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bf26dd21fe3d2cfed5afaedba648f944ba425e39083d1b86b6993e0d71b430"
+checksum = "78cea8a8c6f40508aa6292231db40fe5b4968f6959fefcad608e528b50657564"
 dependencies = [
  "serde",
  "serde_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 rust-version = "1.65"
 
 [build_dependencies]
-crate-git-revision = "0.0.2"
+crate-git-revision = "0.0.3"
 
 [dependencies]
 base64 = { version = "0.13.0", optional = true }


### PR DESCRIPTION
### What
Update crate-git-revision to 0.0.3.

### Why
To get the fix in crate-git-revision that stops it from invalidating builds unnecessarily.