### PR TITLE
Change version to be a struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,26 +74,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const_format"
-version = "0.2.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7309d9b4d3d2c0641e018d449232f2e28f1b22933c137f157d3dbc14228b8c0e"
-dependencies = [
- "const_format_proc_macros",
-]
-
-[[package]]
-name = "const_format_proc_macros"
-version = "0.2.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f47bf7270cf70d370f8f98c1abb6d2d4cf60a6845d30e05bfb90c6568650"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -430,7 +410,6 @@ version = "0.0.7"
 dependencies = [
  "arbitrary",
  "base64",
- "const_format",
  "crate-git-revision",
  "hex",
  "serde",
@@ -487,12 +466,6 @@ name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ serde = { version = "1.0.139", features = ["derive"], optional = true }
 serde_with = { version = "2.0.1", optional = true }
 hex = { version = "0.4.3", optional = true }
 arbitrary = {version = "1.1.3", features = ["derive"], optional = true}
-const_format = "0.2.30"
 
 [dev_dependencies]
 serde_json = "1.0.86"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,31 @@
 #![forbid(unsafe_code)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-const PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
-const GIT_REVISION: &str = env!("GIT_REVISION");
-#[cfg(not(feature = "next"))]
-const XDR_VERSION: &str = env!("XDR_CURR_VERSION");
-#[cfg(feature = "next")]
-const XDR_VERSION: &str = env!("XDR_NEXT_VERSION");
-pub const VERSION: &str = const_format::formatcp!("{PKG_VERSION} ({GIT_REVISION}) ({XDR_VERSION})");
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
+pub struct Version<'a> {
+    pub pkg: &'a str,
+    pub rev: &'a str,
+    pub xdr: &'a str,
+}
+
+pub const VERSION: Version = Version {
+    pkg: env!("CARGO_PKG_VERSION"),
+    rev: env!("GIT_REVISION"),
+    xdr: {
+        #[cfg(not(feature = "next"))]
+        {
+            env!("XDR_CURR_VERSION")
+        }
+        #[cfg(feature = "next")]
+        {
+            env!("XDR_NEXT_VERSION")
+        }
+    },
+};
 
 #[cfg(not(feature = "next"))]
 mod curr;
+
 #[cfg(not(feature = "next"))]
 pub use curr::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,6 @@ pub const VERSION: Version = Version {
 
 #[cfg(not(feature = "next"))]
 mod curr;
-
 #[cfg(not(feature = "next"))]
 pub use curr::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Version<'a> {
     pub pkg: &'a str,
     pub rev: &'a str,

--- a/tests/version.rs
+++ b/tests/version.rs
@@ -1,4 +1,4 @@
 #[test]
 fn version() {
-    std::println!("{}", stellar_xdr::VERSION);
+    std::println!("{:?}", stellar_xdr::VERSION);
 }


### PR DESCRIPTION
### What
Change version to be a struct.

### Why
So that applications can choose how to format it.