### PR TITLE
Always group ancilliary features in tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -102,4 +102,4 @@ jobs:
     with:
       runs-on: ${{ matrix.sys.os }}
       target: ${{ matrix.sys.target }}
-      cargo-hack-feature-options: ${{ env.CARGO_HACK_ARGS }}
+      cargo-hack-feature-options: --feature-powerset --exclude-features default --group-features base64,serde,arbitrary,hex

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   RUSTFLAGS: -Dwarnings -Dclippy::all -Dclippy::pedantic
+  CARGO_HACK_ARGS: --feature-powerset --exclude-features default --group-features base64,serde,arbitrary,hex
 
 jobs:
 
@@ -62,10 +63,6 @@ jobs:
       with:
         name: cargo-hack
         version: 0.5.16
-    - if: "github.ref_protected"
-      run: echo 'CARGO_HACK_ARGS=--feature-powerset' >> $GITHUB_ENV
-    - if: "!github.ref_protected"
-      run: echo 'CARGO_HACK_ARGS=--feature-powerset --exclude-features default --group-features base64,serde,arbitrary' >> $GITHUB_ENV
     - run: cargo hack clippy $CARGO_HACK_ARGS --target ${{ matrix.sys.target }} --all-targets
 
   test:
@@ -90,10 +87,6 @@ jobs:
       with:
         name: cargo-hack
         version: 0.5.16
-    - if: "github.ref_protected"
-      run: echo 'CARGO_HACK_ARGS=--feature-powerset' >> $GITHUB_ENV
-    - if: "!github.ref_protected"
-      run: echo 'CARGO_HACK_ARGS=--feature-powerset --exclude-features default --group-features base64,serde,arbitrary' >> $GITHUB_ENV
     - run: cargo hack test $CARGO_HACK_ARGS
 
   publish-dry-run:
@@ -109,3 +102,4 @@ jobs:
     with:
       runs-on: ${{ matrix.sys.os }}
       target: ${{ matrix.sys.target }}
+      cargo-hack-feature-options: ${{ env.CARGO_HACK_ARGS }}


### PR DESCRIPTION
### What
Always group ancilliary features in tests.

### Why
Running tests on main individually is taking too long and consuming too much disk space causing builds to fail. Making this change isn't ideal but is necessary to get us workable builds while we figure out a better longer term solution. It's worth noting this might be the long term solution.

Grouping the ancilliary features together is low risk because they often get used together anyway.