### PR TITLE
Run publish dry run on main

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -90,7 +90,7 @@ jobs:
     - run: cargo hack test $CARGO_HACK_ARGS
 
   publish-dry-run:
-    if: startsWith(github.head_ref, 'release/')
+    if: github.event_name == 'push' || startsWith(github.head_ref, 'release/')
     strategy:
       matrix:
         sys:


### PR DESCRIPTION
### What
Run publish dry run on main.

### Why
So that we know if main is ready to release.