### PR TITLE
Parallelize feature builds and tests across instances

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -113,8 +113,7 @@ jobs:
         # TODO: Address disk space usage problems and re-enable.
         # - os: windows-latest
         #   target: x86_64-pc-windows-msvc
-        include:
-          commands: ${{ fromJSON(steps.build-commands.outputs.commands) }}
+        commands: ${{ fromJSON(needs.build-commands.outputs.commands) }}
     runs-on: ${{ matrix.sys.os }}
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -81,7 +81,7 @@ jobs:
       with:
         name: cargo-hack
         version: 0.5.16
-    - run: echo "${{ matrix.commands }}" | xargs -I{} '{} --target ${{ matrix.sys.target }}'
+    - run: echo "${{ matrix.commands }}" | xargs -I{} bash -c '{} --target ${{ matrix.sys.target }}'
 
   test-commands:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,8 +7,6 @@ on:
 
 env:
   RUSTFLAGS: -Dwarnings -Dclippy::all -Dclippy::pedantic
-  # CARGO_HACK_ARGS: --feature-powerset --exclude-features default --group-features base64,serde,arbitrary,hex
-  CARGO_HACK_ARGS: --feature-powerset
 
 jobs:
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -92,10 +92,10 @@ jobs:
     - uses: stellar/actions/rust-cache@main
     - run: rustup update
     - run: rustup target add ${{ matrix.sys.target }}
-    - uses: stellar/binaries@v12
+    - uses: stellar/binaries@v14
       with:
         name: cargo-hack
-        version: 0.5.16
+        version: 0.5.28
     - name: Build
       run: echo "${{ matrix.commands.build }}" | xargs -I{} bash -x -c '{} --target ${{ matrix.sys.target }}'
     - name: Test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,12 +47,12 @@ jobs:
       run: |
         build="$(cargo hack --print-command-list clippy --feature-powerset --all-targets \
           | sort \
-          | jq -R -s -c 'split("\n") | _nwise(20) | join("\n")' \
+          | jq -R -s -c 'split("\n") | _nwise(15) | join("\n")' \
           | jq -s -c \
         )"
         test="$(cargo hack --print-command-list test --feature-powerset --all-targets \
           | sort \
-          | jq -R -s -c 'split("\n") | _nwise(20) | join("\n")' \
+          | jq -R -s -c 'split("\n") | _nwise(15) | join("\n")' \
           | jq -s -c \
         )"
         zipped="$(echo {} | jq -c --argjson build "$build" --argjson test "$test" \

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -82,7 +82,7 @@ jobs:
       with:
         name: cargo-hack
         version: 0.5.16
-    - run: echo "${{ matrix.commands }}" | xargs -I{} {} --target ${{ matrix.sys.target }}
+    - run: echo "${{ matrix.commands }}" | xargs -I{} '{} --target ${{ matrix.sys.target }}'
 
   test-commands:
     runs-on: ubuntu-latest
@@ -126,7 +126,7 @@ jobs:
         name: cargo-hack
         version: 0.5.16
     - run: cargo hack test $CARGO_HACK_ARGS
-    - run: echo "${{ matrix.commands }}" | xargs -I{} {} --target ${{ matrix.sys.target }}
+    - run: echo "${{ matrix.commands }}" | xargs -I{} bash -c '{} --target ${{ matrix.sys.target }}'
 
   publish-dry-run:
     if: github.event_name == 'push' || startsWith(github.head_ref, 'release/')

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,7 +43,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: stellar/actions/rust-cache@main
     - run: rustup update
-    - run: cargo install --git https://github.com/taiki-e/cargo-hack --branch print-command-list cargo-hack
+    - run: cargo install --git https://github.com/taiki-e/cargo-hack --rev 042bb37456e7e024428854c405974a0ff2067622 cargo-hack
     - id: build-commands
       run: >-
         echo "::set-output name=commands::$(
@@ -90,7 +90,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: stellar/actions/rust-cache@main
     - run: rustup update
-    - run: cargo install --git https://github.com/taiki-e/cargo-hack --branch print-command-list cargo-hack
+    - run: cargo install --git https://github.com/taiki-e/cargo-hack --rev 042bb37456e7e024428854c405974a0ff2067622 cargo-hack
     - id: build-commands
       run: >-
         echo "::set-output name=commands::$(

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -87,6 +87,9 @@ jobs:
           test: true
         commands: ${{ fromJSON(needs.commands.outputs.commands) }}
     runs-on: ${{ matrix.sys.os }}
+    defaults:
+      run:
+        shell: bash
     steps:
     - uses: actions/checkout@v3
     - uses: stellar/actions/rust-cache@main

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -71,7 +71,7 @@ jobs:
         # TODO: Address disk space usage problems and re-enable.
         # - os: windows-latest
         #   target: x86_64-pc-windows-msvc
-        commands: ${{ fromJSON(steps.build-commands.outputs.commands) }}
+        commands: ${{ fromJSON(needs.build-commands.outputs.commands) }}
     runs-on: ${{ matrix.sys.os }}
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,12 +47,12 @@ jobs:
       run: |
         build="$(cargo hack --print-command-list clippy --feature-powerset --all-targets \
           | sort \
-          | jq -R -s -c 'split("\n") | _nwise(15) | join("\n")' \
+          | jq -R -s -c 'split("\n") | _nwise(10) | join("\n")' \
           | jq -s -c \
         )"
         test="$(cargo hack --print-command-list test --feature-powerset --all-targets \
           | sort \
-          | jq -R -s -c 'split("\n") | _nwise(15) | join("\n")' \
+          | jq -R -s -c 'split("\n") | _nwise(10) | join("\n")' \
           | jq -s -c \
         )"
         zipped="$(echo {} | jq -c --argjson build "$build" --argjson test "$test" \

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,7 @@ jobs:
 
   complete:
     if: always()
-    needs: [generate, fmt, build, test, publish-dry-run]
+    needs: [generate, fmt, build-and-test, publish-dry-run]
     runs-on: ubuntu-latest
     steps:
     - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -82,7 +82,7 @@ jobs:
       with:
         name: cargo-hack
         version: 0.5.16
-    - run: echo "${{ matrix.commands }}" | xargs -I {} {} --target ${{ matrix.sys.target }}
+    - run: echo "${{ matrix.commands }}" | xargs -I{} {} --target ${{ matrix.sys.target }}
 
   test-commands:
     runs-on: ubuntu-latest
@@ -126,7 +126,7 @@ jobs:
         name: cargo-hack
         version: 0.5.16
     - run: cargo hack test $CARGO_HACK_ARGS
-    - run: echo "${{ matrix.commands }}" | xargs -I {} {} --target ${{ matrix.sys.target }}
+    - run: echo "${{ matrix.commands }}" | xargs -I{} {} --target ${{ matrix.sys.target }}
 
   publish-dry-run:
     if: github.event_name == 'push' || startsWith(github.head_ref, 'release/')

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,7 +42,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: stellar/actions/rust-cache@main
     - run: rustup update
-    - uses: stellar/binaries@v12
+    - uses: stellar/binaries@v14
       with:
         name: cargo-hack
         version: 0.5.28

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,18 +45,22 @@ jobs:
     - run: cargo install --git https://github.com/taiki-e/cargo-hack --rev 042bb37456e7e024428854c405974a0ff2067622 cargo-hack
     - id: commands
       run: |
-        build="$(cargo hack --print-command-list clippy --feature-powerset --exclude-features default,cli --all-targets \
+        build="$({ \
+            cargo hack --print-command-list clippy --feature-powerset --exclude-features default,cli --all-targets \
+            & cargo hack --print-command-list clippy --features cli --all-targets; \
+          }\
           | sort \
           | jq -R -s -c 'split("\n") | _nwise(6) | join("\n")' \
           | jq -s -c \
-        )\n \
-        $(cargo hack --print-command-list clippy --features cli --all-targets)"
-        test="$(cargo hack --print-command-list test --feature-powerset --exclude-features default,cli --all-targets \
+        )"
+        test="$({ \
+            cargo hack --print-command-list test --feature-powerset --exclude-features default,cli --all-targets \
+            & cargo hack --print-command-list test --features cli --all-targets; \
+          }\
           | sort \
           | jq -R -s -c 'split("\n") | _nwise(6) | join("\n")' \
           | jq -s -c \
-        )\n \
-        $(cargo hack --print-command-list test --features cli --all-targets)"
+        )"
         zipped="$(echo {} | jq -c --argjson build "$build" --argjson test "$test" \
           '[$build,$test] | transpose | [.[] | {"build": .[0], "test": .[1]}]' \
         )"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   RUSTFLAGS: -Dwarnings -Dclippy::all -Dclippy::pedantic
+  CARGO_HACK_ARGS: --feature-powerset --exclude-features default --group-features base64,serde,arbitrary,hex
 
 jobs:
 
@@ -45,12 +46,12 @@ jobs:
     - run: cargo install --git https://github.com/taiki-e/cargo-hack --rev 042bb37456e7e024428854c405974a0ff2067622 cargo-hack
     - id: commands
       run: |
-        build="$(cargo hack --print-command-list clippy --feature-powerset --all-targets \
+        build="$(cargo hack --print-command-list clippy $CARGO_HACK_ARGS --all-targets \
           | sort \
           | jq -R -s -c 'split("\n") | _nwise(10) | join("\n")' \
           | jq -s -c \
         )"
-        test="$(cargo hack --print-command-list test --feature-powerset --all-targets \
+        test="$(cargo hack --print-command-list test $CARGO_HACK_ARGS --all-targets \
           | sort \
           | jq -R -s -c 'split("\n") | _nwise(10) | join("\n")' \
           | jq -s -c \

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,7 +56,7 @@ jobs:
           | jq -s -c \
         )"
         zipped="$(echo {} | jq -c --argjson build "$build" --argjson test "$test" \
-          '[$build,$test] | transpose | [.[] | {"build": .[0], "test": .[1]} + {"build": "cargo hack clippy --features cli --all-targets", "test": "cargo hack test --features cli --all-targets"}]' \
+          '[$build,$test] | transpose | [.[] | {"build": .[0], "test": .[1]}] + [{"build": "cargo hack clippy --features cli --all-targets", "test": "cargo hack test --features cli --all-targets"}]' \
         )"
         echo "commands=$zipped" >> $GITHUB_OUTPUT
     outputs:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,7 +7,8 @@ on:
 
 env:
   RUSTFLAGS: -Dwarnings -Dclippy::all -Dclippy::pedantic
-  CARGO_HACK_ARGS: --feature-powerset --exclude-features default --group-features base64,serde,arbitrary,hex
+  # CARGO_HACK_ARGS: --feature-powerset --exclude-features default --group-features base64,serde,arbitrary,hex
+  CARGO_HACK_ARGS: --feature-powerset
 
 jobs:
 
@@ -46,16 +47,18 @@ jobs:
     - run: cargo install --git https://github.com/taiki-e/cargo-hack --rev 042bb37456e7e024428854c405974a0ff2067622 cargo-hack
     - id: commands
       run: |
-        build="$(cargo hack --print-command-list clippy $CARGO_HACK_ARGS --all-targets \
+        build="$(cargo hack --print-command-list clippy --feature-powerset --exclude-features default,cli --all-targets \
           | sort \
           | jq -R -s -c 'split("\n") | _nwise(6) | join("\n")' \
           | jq -s -c \
-        )"
-        test="$(cargo hack --print-command-list test $CARGO_HACK_ARGS --all-targets \
+        )\n \
+        $(cargo hack --print-command-list clippy --features cli --all-targets)"
+        test="$(cargo hack --print-command-list test --feature-powerset --exclude-features default,cli --all-targets \
           | sort \
           | jq -R -s -c 'split("\n") | _nwise(6) | join("\n")' \
           | jq -s -c \
-        )"
+        )\n \
+        $(cargo hack --print-command-list test --features cli --all-targets)"
         zipped="$(echo {} | jq -c --argjson build "$build" --argjson test "$test" \
           '[$build,$test] | transpose | [.[] | {"build": .[0], "test": .[1]}]' \
         )"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,11 +45,11 @@ jobs:
     - run: rustup update
     - run: cargo install --git https://github.com/taiki-e/cargo-hack --rev 042bb37456e7e024428854c405974a0ff2067622 cargo-hack
     - id: build-commands
-      run: >-
-        echo "::set-output name=commands::$(
-          cargo hack --print-command-list clippy $CARGO_HACK_ARGS --all-targets
-          | jq -R -s -c 'split("\n") | _nwise(15) | join("\\\n")'
-          | jq -s
+      run: |
+        echo "::set-output name=commands::$( \
+          cargo hack --print-command-list clippy $CARGO_HACK_ARGS --all-targets \
+          | jq -R -s -c 'split("\n") | _nwise(15) | join("\\\n")' \
+          | jq -s \
         )"
     outputs:
       commands: ${{ steps.build-commands.outputs.commands }}
@@ -92,11 +92,11 @@ jobs:
     - run: rustup update
     - run: cargo install --git https://github.com/taiki-e/cargo-hack --rev 042bb37456e7e024428854c405974a0ff2067622 cargo-hack
     - id: build-commands
-      run: >-
-        echo "::set-output name=commands::$(
-          cargo hack --print-command-list test $CARGO_HACK_ARGS --all-targets
-          | jq -R -s -c 'split("\n") | _nwise(15) | join("\\\n")'
-          | jq -s
+      run: |
+        echo "::set-output name=commands::$( \
+          cargo hack --print-command-list test $CARGO_HACK_ARGS --all-targets \
+          | jq -R -s -c 'split("\n") | _nwise(15) | join("\n")' \
+          | jq -s \
         )"
     outputs:
       commands: ${{ steps.build-commands.outputs.commands }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,24 +45,25 @@ jobs:
     - run: cargo install --git https://github.com/taiki-e/cargo-hack --rev 042bb37456e7e024428854c405974a0ff2067622 cargo-hack
     - id: commands
       run: |
-        echo "build=$( \
-          cargo hack --print-command-list clippy --feature-powerset --all-targets \
+        build="$(cargo hack --print-command-list clippy --feature-powerset --all-targets \
           | sort \
           | jq -R -s -c 'split("\n") | _nwise(20) | join("\n")' \
           | jq -s -c \
-        )" >> $GITHUB_OUTPUT
-        echo "test=$( \
-          cargo hack --print-command-list test --feature-powerset --all-targets \
+        )"
+        test="$(cargo hack --print-command-list test --feature-powerset --all-targets \
           | sort \
           | jq -R -s -c 'split("\n") | _nwise(20) | join("\n")' \
           | jq -s -c \
-        )" >> $GITHUB_OUTPUT
+        )"
+        zipped="$(echo {} | jq --argjson build "$build" --argjson test "$test" \
+          '[$build,$test] | transpose | [.[] | {"build": .[0], "test": .[1]}]' \
+        )"
+        echo "commands=$zipped" >> $GITHUB_OUTPUT
     outputs:
-      build: ${{ steps.commands.outputs.build }}
-      test: ${{ steps.commands.outputs.test }}
+      commands: ${{ steps.commands.outputs.commands }}
 
   build-and-test:
-    needs: build-commands
+    needs: commands
     strategy:
       matrix:
         sys:
@@ -80,9 +81,7 @@ jobs:
         # TODO: Address disk space usage problems and re-enable.
         # - os: windows-latest
         #   target: x86_64-pc-windows-msvc
-        commands:
-          build: ${{ fromJSON(needs.build-commands.outputs.commands) }}
-          test: ${{ fromJSON(needs.build-commands.outputs.commands) }}
+        commands: ${{ fromJSON(needs.commands.outputs.commands) }}
     runs-on: ${{ matrix.sys.os }}
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,7 +37,24 @@ jobs:
     - run: rustup update
     - run: cargo fmt --all --check
 
+  build-commands:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: stellar/actions/rust-cache@main
+    - run: rustup update
+    - run: cargo install --git https://github.com/taiki-e/cargo-hack --branch print-command-list cargo-hack
+    - id: build-commands
+      run: >-
+        echo "::set-output name=commands::$(
+          cargo hack --print-command-list clippy $CARGO_HACK_ARGS --all-targets
+          | jq -R -s -c 'split("\n") | _nwise(15) | join("\n")'
+        )"
+    outputs:
+      commands: ${{ steps.build-commands.outputs.commands }}
+
   build:
+    needs: build-commands
     strategy:
       matrix:
         sys:
@@ -53,6 +70,8 @@ jobs:
         # TODO: Address disk space usage problems and re-enable.
         # - os: windows-latest
         #   target: x86_64-pc-windows-msvc
+        include:
+          commands: ${{ fromJSON(steps.build-commands.outputs.commands) }}
     runs-on: ${{ matrix.sys.os }}
     steps:
     - uses: actions/checkout@v3
@@ -63,9 +82,26 @@ jobs:
       with:
         name: cargo-hack
         version: 0.5.16
-    - run: cargo hack clippy $CARGO_HACK_ARGS --target ${{ matrix.sys.target }} --all-targets
+    - run: ${{ matrix.commands }} | xargs -I {} {} --target ${{ matrix.sys.target }}
+
+  test-commands:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: stellar/actions/rust-cache@main
+    - run: rustup update
+    - run: cargo install --git https://github.com/taiki-e/cargo-hack --branch print-command-list cargo-hack
+    - id: build-commands
+      run: >-
+        echo "::set-output name=commands::$(
+          cargo hack --print-command-list test $CARGO_HACK_ARGS --all-targets
+          | jq -R -s -c 'split("\n") | _nwise(15) | join("\n")'
+        )"
+    outputs:
+      commands: ${{ steps.build-commands.outputs.commands }}
 
   test:
+    needs: test-commands
     strategy:
       matrix:
         sys:
@@ -77,6 +113,8 @@ jobs:
         # TODO: Address disk space usage problems and re-enable.
         # - os: windows-latest
         #   target: x86_64-pc-windows-msvc
+        include:
+          commands: ${{ fromJSON(steps.build-commands.outputs.commands) }}
     runs-on: ${{ matrix.sys.os }}
     steps:
     - uses: actions/checkout@v3
@@ -88,6 +126,7 @@ jobs:
         name: cargo-hack
         version: 0.5.16
     - run: cargo hack test $CARGO_HACK_ARGS
+    - run: ${{ matrix.commands }} | xargs -I {} {} --target ${{ matrix.sys.target }}
 
   publish-dry-run:
     if: github.event_name == 'push' || startsWith(github.head_ref, 'release/')

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -82,7 +82,7 @@ jobs:
       with:
         name: cargo-hack
         version: 0.5.16
-    - run: ${{ matrix.commands }} | xargs -I {} {} --target ${{ matrix.sys.target }}
+    - run: echo "${{ matrix.commands }}" | xargs -I {} {} --target ${{ matrix.sys.target }}
 
   test-commands:
     runs-on: ubuntu-latest
@@ -126,7 +126,7 @@ jobs:
         name: cargo-hack
         version: 0.5.16
     - run: cargo hack test $CARGO_HACK_ARGS
-    - run: ${{ matrix.commands }} | xargs -I {} {} --target ${{ matrix.sys.target }}
+    - run: echo "${{ matrix.commands }}" | xargs -I {} {} --target ${{ matrix.sys.target }}
 
   publish-dry-run:
     if: github.event_name == 'push' || startsWith(github.head_ref, 'release/')

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,24 +45,18 @@ jobs:
     - run: cargo install --git https://github.com/taiki-e/cargo-hack --rev 042bb37456e7e024428854c405974a0ff2067622 cargo-hack
     - id: commands
       run: |
-        build="$({ \
-            cargo hack --print-command-list clippy --feature-powerset --exclude-features default,cli --all-targets \
-            & cargo hack --print-command-list clippy --features cli --all-targets; \
-          }\
+        build="$(cargo hack --print-command-list clippy --feature-powerset --exclude-features default,cli --all-targets \
           | sort \
           | jq -R -s -c 'split("\n") | _nwise(6) | join("\n")' \
           | jq -s -c \
         )"
-        test="$({ \
-            cargo hack --print-command-list test --feature-powerset --exclude-features default,cli --all-targets \
-            & cargo hack --print-command-list test --features cli --all-targets; \
-          }\
+        test="$(cargo hack --print-command-list test --feature-powerset --exclude-features default,cli --all-targets \
           | sort \
           | jq -R -s -c 'split("\n") | _nwise(6) | join("\n")' \
           | jq -s -c \
         )"
         zipped="$(echo {} | jq -c --argjson build "$build" --argjson test "$test" \
-          '[$build,$test] | transpose | [.[] | {"build": .[0], "test": .[1]}]' \
+          '[$build,$test] | transpose | [.[] | {"build": .[0], "test": .[1]} + {"build": "cargo hack clippy --features cli --all-targets", "test": "cargo hack test --features cli --all-targets"}]' \
         )"
         echo "commands=$zipped" >> $GITHUB_OUTPUT
     outputs:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -71,8 +71,7 @@ jobs:
         # TODO: Address disk space usage problems and re-enable.
         # - os: windows-latest
         #   target: x86_64-pc-windows-msvc
-        include:
-          commands: ${{ fromJSON(steps.build-commands.outputs.commands) }}
+        commands: ${{ fromJSON(steps.build-commands.outputs.commands) }}
     runs-on: ${{ matrix.sys.os }}
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,6 +49,7 @@ jobs:
         echo "::set-output name=commands::$(
           cargo hack --print-command-list clippy $CARGO_HACK_ARGS --all-targets
           | jq -R -s -c 'split("\n") | _nwise(15) | join("\n")'
+          | jq -s
         )"
     outputs:
       commands: ${{ steps.build-commands.outputs.commands }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,33 +36,42 @@ jobs:
     - run: rustup update
     - run: cargo fmt --all --check
 
-  build-commands:
+  commands:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - uses: stellar/actions/rust-cache@main
     - run: rustup update
     - run: cargo install --git https://github.com/taiki-e/cargo-hack --rev 042bb37456e7e024428854c405974a0ff2067622 cargo-hack
-    - id: build-commands
+    - id: commands
       run: |
-        echo "commands=$( \
+        echo "build=$( \
           cargo hack --print-command-list clippy --feature-powerset --all-targets \
           | sort \
-          | jq -R -s -c 'split("\n") | _nwise(15) | join("\n")' \
+          | jq -R -s -c 'split("\n") | _nwise(20) | join("\n")' \
+          | jq -s -c \
+        )" >> $GITHUB_OUTPUT
+        echo "test=$( \
+          cargo hack --print-command-list test --feature-powerset --all-targets \
+          | sort \
+          | jq -R -s -c 'split("\n") | _nwise(20) | join("\n")' \
           | jq -s -c \
         )" >> $GITHUB_OUTPUT
     outputs:
-      commands: ${{ steps.build-commands.outputs.commands }}
+      build: ${{ steps.commands.outputs.build }}
+      test: ${{ steps.commands.outputs.test }}
 
-  build:
+  build-and-test:
     needs: build-commands
     strategy:
       matrix:
         sys:
         - os: ubuntu-latest
           target: wasm32-unknown-unknown
+          test: false
         - os: ubuntu-latest
           target: x86_64-unknown-linux-gnu
+          test: true
         # TODO: Address GitHub Actions concurrency limits and re-enable.
         # - os: macos-latest
         #   target: x86_64-apple-darwin
@@ -71,7 +80,9 @@ jobs:
         # TODO: Address disk space usage problems and re-enable.
         # - os: windows-latest
         #   target: x86_64-pc-windows-msvc
-        commands: ${{ fromJSON(needs.build-commands.outputs.commands) }}
+        commands:
+          build: ${{ fromJSON(needs.build-commands.outputs.commands) }}
+          test: ${{ fromJSON(needs.build-commands.outputs.commands) }}
     runs-on: ${{ matrix.sys.os }}
     steps:
     - uses: actions/checkout@v3
@@ -82,51 +93,11 @@ jobs:
       with:
         name: cargo-hack
         version: 0.5.16
-    - run: echo "${{ matrix.commands }}" | xargs -I{} bash -c '{} --target ${{ matrix.sys.target }}'
-
-  test-commands:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - uses: stellar/actions/rust-cache@main
-    - run: rustup update
-    - run: cargo install --git https://github.com/taiki-e/cargo-hack --rev 042bb37456e7e024428854c405974a0ff2067622 cargo-hack
-    - id: test-commands
-      run: |
-        echo "commands=$( \
-          cargo hack --print-command-list test --feature-powerset --all-targets \
-          | sort \
-          | jq -R -s -c 'split("\n") | _nwise(15) | join("\n")' \
-          | jq -s -c \
-        )" >> $GITHUB_OUTPUT
-    outputs:
-      commands: ${{ steps.test-commands.outputs.commands }}
-
-  test:
-    needs: test-commands
-    strategy:
-      matrix:
-        sys:
-        - os: ubuntu-latest
-          target: x86_64-unknown-linux-gnu
-        # TODO: Address GitHub Actions concurrency limits and re-enable.
-        # - os: macos-latest
-        #   target: x86_64-apple-darwin
-        # TODO: Address disk space usage problems and re-enable.
-        # - os: windows-latest
-        #   target: x86_64-pc-windows-msvc
-        commands: ${{ fromJSON(needs.test-commands.outputs.commands) }}
-    runs-on: ${{ matrix.sys.os }}
-    steps:
-    - uses: actions/checkout@v3
-    - uses: stellar/actions/rust-cache@main
-    - run: rustup update
-    - run: rustup target add ${{ matrix.sys.target }}
-    - uses: stellar/binaries@v12
-      with:
-        name: cargo-hack
-        version: 0.5.16
-    - run: echo "${{ matrix.commands }}" | xargs -I{} bash -c '{} --target ${{ matrix.sys.target }}'
+    - name: Build
+      run: echo "${{ matrix.commands.build }}" | xargs -I{} bash -c '{} --target ${{ matrix.sys.target }}'
+    - name: Test
+      if: matrix.sys.test
+      run: echo "${{ matrix.commands.test }}" | xargs -I{} bash -c '{} --target ${{ matrix.sys.target }}'
 
   publish-dry-run:
     if: github.event_name == 'push' || startsWith(github.head_ref, 'release/')

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -96,6 +96,7 @@ jobs:
         echo "::set-output name=commands::$(
           cargo hack --print-command-list test $CARGO_HACK_ARGS --all-targets
           | jq -R -s -c 'split("\n") | _nwise(15) | join("\n")'
+          | jq -s
         )"
     outputs:
       commands: ${{ steps.build-commands.outputs.commands }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,7 +48,7 @@ jobs:
       run: >-
         echo "::set-output name=commands::$(
           cargo hack --print-command-list clippy $CARGO_HACK_ARGS --all-targets
-          | jq -R -s -c 'split("\n") | _nwise(15) | join("\n")'
+          | jq -R -s -c 'split("\n") | _nwise(15) | join("\\\n")'
           | jq -s
         )"
     outputs:
@@ -95,7 +95,7 @@ jobs:
       run: >-
         echo "::set-output name=commands::$(
           cargo hack --print-command-list test $CARGO_HACK_ARGS --all-targets
-          | jq -R -s -c 'split("\n") | _nwise(15) | join("\n")'
+          | jq -R -s -c 'split("\n") | _nwise(15) | join("\\\n")'
           | jq -s
         )"
     outputs:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -95,7 +95,7 @@ jobs:
       run: |
         echo "commands=$( \
           cargo hack --print-command-list test $CARGO_HACK_ARGS --all-targets \
-          | jq -R -s -c 'split("\n") | _nwise(15) | join("\n")' \
+          | jq -R -s -c 'split("\n") | _nwise(15) | join("\\\n")' \
           | jq -s -c \
         )" >> $GITHUB_OUTPUT
     outputs:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,7 +48,7 @@ jobs:
       run: |
         echo "commands=$( \
           cargo hack --print-command-list clippy $CARGO_HACK_ARGS --all-targets \
-          | jq -R -s -c 'split("\n") | _nwise(15) | join("\\\n")' \
+          | jq -R -s -c 'split("\n") | _nwise(15) | join("\n")' \
           | jq -s -c \
         )" >> $GITHUB_OUTPUT
     outputs:
@@ -91,15 +91,15 @@ jobs:
     - uses: stellar/actions/rust-cache@main
     - run: rustup update
     - run: cargo install --git https://github.com/taiki-e/cargo-hack --rev 042bb37456e7e024428854c405974a0ff2067622 cargo-hack
-    - id: build-commands
+    - id: test-commands
       run: |
         echo "commands=$( \
           cargo hack --print-command-list test $CARGO_HACK_ARGS --all-targets \
-          | jq -R -s -c 'split("\n") | _nwise(15) | join("\\\n")' \
+          | jq -R -s -c 'split("\n") | _nwise(15) | join("\n")' \
           | jq -s -c \
         )" >> $GITHUB_OUTPUT
     outputs:
-      commands: ${{ steps.build-commands.outputs.commands }}
+      commands: ${{ steps.test-commands.outputs.commands }}
 
   test:
     needs: test-commands
@@ -114,7 +114,7 @@ jobs:
         # TODO: Address disk space usage problems and re-enable.
         # - os: windows-latest
         #   target: x86_64-pc-windows-msvc
-        commands: ${{ fromJSON(needs.build-commands.outputs.commands) }}
+        commands: ${{ fromJSON(needs.test-commands.outputs.commands) }}
     runs-on: ${{ matrix.sys.os }}
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,12 +48,12 @@ jobs:
       run: |
         build="$(cargo hack --print-command-list clippy $CARGO_HACK_ARGS --all-targets \
           | sort \
-          | jq -R -s -c 'split("\n") | _nwise(10) | join("\n")' \
+          | jq -R -s -c 'split("\n") | _nwise(6) | join("\n")' \
           | jq -s -c \
         )"
         test="$(cargo hack --print-command-list test $CARGO_HACK_ARGS --all-targets \
           | sort \
-          | jq -R -s -c 'split("\n") | _nwise(10) | join("\n")' \
+          | jq -R -s -c 'split("\n") | _nwise(6) | join("\n")' \
           | jq -s -c \
         )"
         zipped="$(echo {} | jq -c --argjson build "$build" --argjson test "$test" \

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,6 +47,7 @@ jobs:
       run: |
         echo "commands=$( \
           cargo hack --print-command-list clippy --feature-powerset --all-targets \
+          | sort \
           | jq -R -s -c 'split("\n") | _nwise(15) | join("\n")' \
           | jq -s -c \
         )" >> $GITHUB_OUTPUT
@@ -94,6 +95,7 @@ jobs:
       run: |
         echo "commands=$( \
           cargo hack --print-command-list test --feature-powerset --all-targets \
+          | sort \
           | jq -R -s -c 'split("\n") | _nwise(15) | join("\n")' \
           | jq -s -c \
         )" >> $GITHUB_OUTPUT

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,7 +55,7 @@ jobs:
           | jq -R -s -c 'split("\n") | _nwise(20) | join("\n")' \
           | jq -s -c \
         )"
-        zipped="$(echo {} | jq --argjson build "$build" --argjson test "$test" \
+        zipped="$(echo {} | jq -c --argjson build "$build" --argjson test "$test" \
           '[$build,$test] | transpose | [.[] | {"build": .[0], "test": .[1]}]' \
         )"
         echo "commands=$zipped" >> $GITHUB_OUTPUT

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -94,10 +94,10 @@ jobs:
         name: cargo-hack
         version: 0.5.16
     - name: Build
-      run: echo "${{ matrix.commands.build }}" | xargs -I{} bash -c '{} --target ${{ matrix.sys.target }}'
+      run: echo "${{ matrix.commands.build }}" | xargs -I{} bash -x -c '{} --target ${{ matrix.sys.target }}'
     - name: Test
       if: matrix.sys.test
-      run: echo "${{ matrix.commands.test }}" | xargs -I{} bash -c '{} --target ${{ matrix.sys.target }}'
+      run: echo "${{ matrix.commands.test }}" | xargs -I{} bash -x -c '{} --target ${{ matrix.sys.target }}'
 
   publish-dry-run:
     if: github.event_name == 'push' || startsWith(github.head_ref, 'release/')

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,7 +42,10 @@ jobs:
     - uses: actions/checkout@v3
     - uses: stellar/actions/rust-cache@main
     - run: rustup update
-    - run: cargo install --git https://github.com/taiki-e/cargo-hack --rev 042bb37456e7e024428854c405974a0ff2067622 cargo-hack
+    - uses: stellar/binaries@v12
+      with:
+        name: cargo-hack
+        version: 0.5.28
     - id: commands
       run: |
         build="$(cargo hack --print-command-list clippy --feature-powerset --exclude-features default,cli --all-targets \

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,7 +7,6 @@ on:
 
 env:
   RUSTFLAGS: -Dwarnings -Dclippy::all -Dclippy::pedantic
-  CARGO_HACK_ARGS: --feature-powerset --exclude-features default --group-features base64,serde,arbitrary,hex
 
 jobs:
 
@@ -47,7 +46,7 @@ jobs:
     - id: build-commands
       run: |
         echo "commands=$( \
-          cargo hack --print-command-list clippy $CARGO_HACK_ARGS --all-targets \
+          cargo hack --print-command-list clippy --feature-powerset --all-targets \
           | jq -R -s -c 'split("\n") | _nwise(15) | join("\n")' \
           | jq -s -c \
         )" >> $GITHUB_OUTPUT
@@ -94,7 +93,7 @@ jobs:
     - id: test-commands
       run: |
         echo "commands=$( \
-          cargo hack --print-command-list test $CARGO_HACK_ARGS --all-targets \
+          cargo hack --print-command-list test --feature-powerset --all-targets \
           | jq -R -s -c 'split("\n") | _nwise(15) | join("\n")' \
           | jq -s -c \
         )" >> $GITHUB_OUTPUT
@@ -125,7 +124,6 @@ jobs:
       with:
         name: cargo-hack
         version: 0.5.16
-    - run: cargo hack test $CARGO_HACK_ARGS
     - run: echo "${{ matrix.commands }}" | xargs -I{} bash -c '{} --target ${{ matrix.sys.target }}'
 
   publish-dry-run:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,11 +46,11 @@ jobs:
     - run: cargo install --git https://github.com/taiki-e/cargo-hack --rev 042bb37456e7e024428854c405974a0ff2067622 cargo-hack
     - id: build-commands
       run: |
-        echo "::set-output name=commands::$( \
+        echo "commands=$( \
           cargo hack --print-command-list clippy $CARGO_HACK_ARGS --all-targets \
           | jq -R -s -c 'split("\n") | _nwise(15) | join("\\\n")' \
-          | jq -s \
-        )"
+          | jq -s -c \
+        )" >> $GITHUB_OUTPUT
     outputs:
       commands: ${{ steps.build-commands.outputs.commands }}
 
@@ -93,11 +93,11 @@ jobs:
     - run: cargo install --git https://github.com/taiki-e/cargo-hack --rev 042bb37456e7e024428854c405974a0ff2067622 cargo-hack
     - id: build-commands
       run: |
-        echo "::set-output name=commands::$( \
+        echo "commands=$( \
           cargo hack --print-command-list test $CARGO_HACK_ARGS --all-targets \
           | jq -R -s -c 'split("\n") | _nwise(15) | join("\n")' \
-          | jq -s \
-        )"
+          | jq -s -c \
+        )" >> $GITHUB_OUTPUT
     outputs:
       commands: ${{ steps.build-commands.outputs.commands }}
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -76,14 +76,15 @@ jobs:
         - os: ubuntu-latest
           target: x86_64-unknown-linux-gnu
           test: true
-        # TODO: Address GitHub Actions concurrency limits and re-enable.
-        # - os: macos-latest
-        #   target: x86_64-apple-darwin
-        # - os: macos-latest
-        #   target: aarch64-apple-darwin
-        # TODO: Address disk space usage problems and re-enable.
-        # - os: windows-latest
-        #   target: x86_64-pc-windows-msvc
+        - os: macos-latest
+          target: x86_64-apple-darwin
+          test: true
+        - os: macos-latest
+          target: aarch64-apple-darwin
+          test: false
+        - os: windows-latest
+          target: x86_64-pc-windows-msvc
+          test: true
         commands: ${{ fromJSON(needs.commands.outputs.commands) }}
     runs-on: ${{ matrix.sys.os }}
     steps:


### PR DESCRIPTION
### What
Break up the 148 build configurarations into groups of builds to run in parallel.

### Why
Running all the builds in serial is slow. 148 builds is a lot of compiles and linker runs.

Running all the builds in parallel is also slow. GitHub Actions can be slow to provision so many instances, although it can do it, this build will be slower than the first.

https://github.com/taiki-e/cargo-hack/pull/175 adds the ability to cargo-hack to get the commands it will run, and then we can group those commands and run them across multiple instances.