### PR TITLE
Upgrade crate-git-revision to 0.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,9 +124,9 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "crate-git-revision"
-version = "0.0.3"
+version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cea8a8c6f40508aa6292231db40fe5b4968f6959fefcad608e528b50657564"
+checksum = "f998aef136a4e7833b0e4f0fc0939a59c40140b28e0ffbf524ad84fb2cc568c8"
 dependencies = [
  "serde",
  "serde_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ required-features = ["cli"]
 doctest = false
 
 [build_dependencies]
-crate-git-revision = "0.0.3"
+crate-git-revision = "0.0.4"
 
 [dependencies]
 base64 = { version = "0.13.0", optional = true }


### PR DESCRIPTION
### What

Upgrade crate-git-revision to 0.0.4

### Why

Upgrading to 0.0.4 will remove extra copies of the crate from the lockfile of other projects.

### Known limitations

[TODO or N/A]
