### PR TITLE
Make apt-get installs more resilient

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,7 @@ jobs:
     - run: rustup update
     - run: rustup target add ${{ matrix.target }}
     - if: matrix.target == 'aarch64-unknown-linux-gnu'
-      run: sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+      run: sudo apt-get update && sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
     - name: Package
       run: cargo package --no-verify
     - name: Build


### PR DESCRIPTION
### What
Run apt-get update before apt-get install.

### Why
We're seeing failures which are likely to do with the apt-get repositories that are cached being out of date. It's common practice to run update before install.