### PR TITLE
Make the default xdr decode stream base64

### DIFF
--- a/src/bin/stellar-xdr/decode.rs
+++ b/src/bin/stellar-xdr/decode.rs
@@ -55,7 +55,7 @@ pub enum InputFormat {
 
 impl Default for InputFormat {
     fn default() -> Self {
-        Self::SingleBase64
+        Self::StreamBase64
     }
 }
 


### PR DESCRIPTION
### What
Make the default xdr decode stream base64.

### Why
The current default is single base64, and stream base64 is a superset, so by making stream base64 the default we increase the inputs that the default will work for.