### PR TITLE
Fix apt-get install

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,7 @@ jobs:
     - run: rustup update
     - run: rustup target add ${{ matrix.target }}
     - if: matrix.target == 'aarch64-unknown-linux-gnu'
-      run: sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+      run: sudo apt-get update && sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
     - name: Package
       run: cargo package --no-verify
     - name: Build


### PR DESCRIPTION
### What
Run apt-get update before apt-get install.

### Why
We should have had this all along but the previous GitHub runners didn't require it for some reason. When GitHub upgraded this week to Ubuntu 22 we started to see failures with the update missing.