### PR TITLE
Add makefile rules for regenerating from a local xdrgen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,11 +31,18 @@ generate: src/curr/generated.rs xdr/curr-version src/next/generated.rs xdr/next-
 
 src/curr/generated.rs: $(sort $(wildcard xdr/curr/*.x))
 	> $@
+ifeq ($(LOCAL_XDRGEN),)
 	docker run -i --rm -v $$PWD:/wd -w /wd docker.io/library/ruby:latest /bin/bash -c '\
 		gem install specific_install -v 0.3.7 && \
 		gem specific_install https://github.com/stellar/xdrgen.git -b $(XDRGEN_VERSION) && \
 		xdrgen --language rust --namespace generated --output src/curr $^ \
 		'
+else
+	docker run -i --rm -v $$PWD/../xdrgen:/xdrgen -v $$PWD:/wd -w /wd docker.io/library/ruby:latest /bin/bash -c '\
+		pushd /xdrgen && bundle install && rake install && popd && \
+		xdrgen --language rust --namespace generated --output src/curr $^ \
+		'
+endif
 	rustfmt $@
 
 xdr/curr-version: $(wildcard .git/modules/xdr/curr/**/*) $(wildcard xdr/curr/*.x)
@@ -43,11 +50,18 @@ xdr/curr-version: $(wildcard .git/modules/xdr/curr/**/*) $(wildcard xdr/curr/*.x
 
 src/next/generated.rs: $(sort $(wildcard xdr/next/*.x))
 	> $@
+ifeq ($(LOCAL_XDRGEN),)
 	docker run -i --rm -v $$PWD:/wd -w /wd docker.io/library/ruby:latest /bin/bash -c '\
 		gem install specific_install -v 0.3.7 && \
 		gem specific_install https://github.com/stellar/xdrgen.git -b $(XDRGEN_VERSION) && \
 		xdrgen --language rust --namespace generated --output src/next $^ \
 		'
+else
+	docker run -i --rm -v $$PWD/../xdrgen:/xdrgen -v $$PWD:/wd -w /wd docker.io/library/ruby:latest /bin/bash -c '\
+		pushd /xdrgen && bundle install && rake install && popd && \
+		xdrgen --language rust --namespace generated --output src/next $^ \
+		'
+endif
 	rustfmt $@
 
 xdr/next-version: $(wildcard .git/modules/xdr/next/**/*) $(wildcard xdr/next/*.x)

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ ifeq ($(LOCAL_XDRGEN),)
 		'
 else
 	docker run -i --rm -v $$PWD/../xdrgen:/xdrgen -v $$PWD:/wd -w /wd docker.io/library/ruby:latest /bin/bash -c '\
-		pushd /xdrgen && bundle install && rake install && popd && \
+		pushd /xdrgen && bundle install --deployment && rake install && popd && \
 		xdrgen --language rust --namespace generated --output src/curr $^ \
 		'
 endif
@@ -58,7 +58,7 @@ ifeq ($(LOCAL_XDRGEN),)
 		'
 else
 	docker run -i --rm -v $$PWD/../xdrgen:/xdrgen -v $$PWD:/wd -w /wd docker.io/library/ruby:latest /bin/bash -c '\
-		pushd /xdrgen && bundle install && rake install && popd && \
+		pushd /xdrgen && bundle install --deployment && rake install && popd && \
 		xdrgen --language rust --namespace generated --output src/next $^ \
 		'
 endif


### PR DESCRIPTION
### What

When the LOCAL_XDRGEN env var is defined, `make generate` will run xdrgen from a local copy.

### Why

There isn't currently a good workflow for regenerating rs-stellar-xdr from a local copy of xdrgen.

### Known limitations

xdrgen has to be rebuilt each time it's run inside docker, so it's not fast, but good enough for limited hacking on xdrgen