### PR TITLE
Update xdrgen to get Rust 1.66 changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ export RUSTFLAGS=-Dwarnings -Dclippy::all -Dclippy::pedantic
 
 CARGO_HACK_ARGS=--feature-powerset --exclude-features default --group-features base64,serde,arbitrary,hex
 
-XDRGEN_VERSION=c4d72b59
+XDRGEN_VERSION=c6f8b7e8 # https://github.com/stellar/xdrgen/pull/149
 CARGO_DOC_ARGS?=--open
 
 all: build test

--- a/src/curr/generated.rs
+++ b/src/curr/generated.rs
@@ -137,11 +137,11 @@ impl fmt::Display for Error {
             Error::LengthExceedsMax => write!(f, "xdr value max length exceeded"),
             Error::LengthMismatch => write!(f, "xdr value length does not match"),
             Error::NonZeroPadding => write!(f, "xdr padding contains non-zero bytes"),
-            Error::Utf8Error(e) => write!(f, "{}", e),
+            Error::Utf8Error(e) => write!(f, "{e}"),
             #[cfg(feature = "alloc")]
             Error::InvalidHex => write!(f, "hex invalid"),
             #[cfg(feature = "std")]
-            Error::Io(e) => write!(f, "{}", e),
+            Error::Io(e) => write!(f, "{e}"),
         }
     }
 }
@@ -1468,7 +1468,7 @@ fn write_utf8_lossy(f: &mut impl core::fmt::Write, mut input: &[u8]) -> core::fm
     loop {
         match core::str::from_utf8(input) {
             Ok(valid) => {
-                write!(f, "{}", valid)?;
+                write!(f, "{valid}")?;
                 break;
             }
             Err(error) => {
@@ -1887,7 +1887,7 @@ mod tests {
         let res = VecM::<u8, 8>::read_xdr(&mut buf);
         match res {
             Err(Error::Io(_)) => (),
-            _ => panic!("expected IO error got {:?}", res),
+            _ => panic!("expected IO error got {res:?}"),
         }
     }
 
@@ -1897,7 +1897,7 @@ mod tests {
         let res = VecM::<u8, 8>::read_xdr(&mut buf);
         match res {
             Err(Error::NonZeroPadding) => (),
-            _ => panic!("expected NonZeroPadding got {:?}", res),
+            _ => panic!("expected NonZeroPadding got {res:?}"),
         }
     }
 
@@ -1937,7 +1937,7 @@ mod tests {
         let res = <[u8; 1]>::read_xdr(&mut buf);
         match res {
             Err(Error::Io(_)) => (),
-            _ => panic!("expected IO error got {:?}", res),
+            _ => panic!("expected IO error got {res:?}"),
         }
     }
 
@@ -1947,7 +1947,7 @@ mod tests {
         let res = <[u8; 1]>::read_xdr(&mut buf);
         match res {
             Err(Error::NonZeroPadding) => (),
-            _ => panic!("expected NonZeroPadding got {:?}", res),
+            _ => panic!("expected NonZeroPadding got {res:?}"),
         }
     }
 

--- a/src/next/generated.rs
+++ b/src/next/generated.rs
@@ -152,11 +152,11 @@ impl fmt::Display for Error {
             Error::LengthExceedsMax => write!(f, "xdr value max length exceeded"),
             Error::LengthMismatch => write!(f, "xdr value length does not match"),
             Error::NonZeroPadding => write!(f, "xdr padding contains non-zero bytes"),
-            Error::Utf8Error(e) => write!(f, "{}", e),
+            Error::Utf8Error(e) => write!(f, "{e}"),
             #[cfg(feature = "alloc")]
             Error::InvalidHex => write!(f, "hex invalid"),
             #[cfg(feature = "std")]
-            Error::Io(e) => write!(f, "{}", e),
+            Error::Io(e) => write!(f, "{e}"),
         }
     }
 }
@@ -1483,7 +1483,7 @@ fn write_utf8_lossy(f: &mut impl core::fmt::Write, mut input: &[u8]) -> core::fm
     loop {
         match core::str::from_utf8(input) {
             Ok(valid) => {
-                write!(f, "{}", valid)?;
+                write!(f, "{valid}")?;
                 break;
             }
             Err(error) => {
@@ -1902,7 +1902,7 @@ mod tests {
         let res = VecM::<u8, 8>::read_xdr(&mut buf);
         match res {
             Err(Error::Io(_)) => (),
-            _ => panic!("expected IO error got {:?}", res),
+            _ => panic!("expected IO error got {res:?}"),
         }
     }
 
@@ -1912,7 +1912,7 @@ mod tests {
         let res = VecM::<u8, 8>::read_xdr(&mut buf);
         match res {
             Err(Error::NonZeroPadding) => (),
-            _ => panic!("expected NonZeroPadding got {:?}", res),
+            _ => panic!("expected NonZeroPadding got {res:?}"),
         }
     }
 
@@ -1952,7 +1952,7 @@ mod tests {
         let res = <[u8; 1]>::read_xdr(&mut buf);
         match res {
             Err(Error::Io(_)) => (),
-            _ => panic!("expected IO error got {:?}", res),
+            _ => panic!("expected IO error got {res:?}"),
         }
     }
 
@@ -1962,7 +1962,7 @@ mod tests {
         let res = <[u8; 1]>::read_xdr(&mut buf);
         match res {
             Err(Error::NonZeroPadding) => (),
-            _ => panic!("expected NonZeroPadding got {:?}", res),
+            _ => panic!("expected NonZeroPadding got {res:?}"),
         }
     }
 


### PR DESCRIPTION
### What
Update xdrgen.

### Why
Get changes introduces to make it compile on Rust 1.66.