### PR TITLE
Bump version of specific_install gem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ src/curr/generated.rs: $(sort $(wildcard xdr/curr/*.x))
 	> $@
 ifeq ($(LOCAL_XDRGEN),)
 	docker run -i --rm -v $$PWD:/wd -w /wd docker.io/library/ruby:latest /bin/bash -c '\
-		gem install specific_install -v 0.3.7 && \
+		gem install specific_install -v 0.3.8 && \
 		gem specific_install https://github.com/stellar/xdrgen.git -b $(XDRGEN_VERSION) && \
 		xdrgen --language rust --namespace generated --output src/curr $^ \
 		'
@@ -52,7 +52,7 @@ src/next/generated.rs: $(sort $(wildcard xdr/next/*.x))
 	> $@
 ifeq ($(LOCAL_XDRGEN),)
 	docker run -i --rm -v $$PWD:/wd -w /wd docker.io/library/ruby:latest /bin/bash -c '\
-		gem install specific_install -v 0.3.7 && \
+		gem install specific_install -v 0.3.8 && \
 		gem specific_install https://github.com/stellar/xdrgen.git -b $(XDRGEN_VERSION) && \
 		xdrgen --language rust --namespace generated --output src/next $^ \
 		'


### PR DESCRIPTION
The `specific_install` gem version 0.3.7 is no longer compatible with `ruby:latest` from docker hub. 0.3.8 is.