### PR TITLE
Make git revision in version optional

### DIFF
--- a/src/bin/stellar-xdr/version.rs
+++ b/src/bin/stellar-xdr/version.rs
@@ -11,7 +11,10 @@ impl Cmd {
             "stellar-xdr {} ({})
 xdr (+curr): {}
 xdr (+next): {}",
-            v.pkg, v.rev, v.xdr_curr, v.xdr_next
+            v.pkg,
+            v.rev.unwrap_or("unknown git revision"),
+            v.xdr_curr,
+            v.xdr_next
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,14 +97,14 @@
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Version<'a> {
     pub pkg: &'a str,
-    pub rev: &'a str,
+    pub rev: Option<&'a str>,
     pub xdr: &'a str,
     pub xdr_curr: &'a str,
     pub xdr_next: &'a str,
 }
 pub const VERSION: Version = Version {
     pkg: env!("CARGO_PKG_VERSION"),
-    rev: env!("GIT_REVISION"),
+    rev: option_env!("GIT_REVISION"),
     xdr: if cfg!(all(feature = "curr", feature = "next")) {
         "curr,next"
     } else if cfg!(feature = "curr") {


### PR DESCRIPTION
### What
Make git revision in version optional.

### Why
In some situations folks install tools in enviroments from source, but without git installed. This seems to happen to Windows users from tim eto time.

While it isn't ideal that the version isn't present, the inconvenience of users getting errors installing tools seems unreasonable to me.

A version string in the compiled product, that isn't used frequently, shouldn't be a blocker for basic use.

Note that this does open up the possibility that we break out git revision collection and end up with no revision in a production build. That's the nice thing about failing otherwise. Again, the version missing wouldn't break functionality or stop a product from working and presumably we'd fix it when we noticed.