### PR TITLE
Update crate-git-revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,9 +139,9 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "crate-git-revision"
-version = "0.0.4"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f998aef136a4e7833b0e4f0fc0939a59c40140b28e0ffbf524ad84fb2cc568c8"
+checksum = "c521bf1f43d31ed2f73441775ed31935d77901cb3451e44b38a1c1612fcbaf98"
 dependencies = [
  "serde",
  "serde_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ required-features = ["cli"]
 doctest = false
 
 [build_dependencies]
-crate-git-revision = "0.0.4"
+crate-git-revision = "0.0.6"
 
 [dependencies]
 base64 = { version = "0.13.0", optional = true }


### PR DESCRIPTION
### What
Update crate-git-revision

### Why
To use the latest version and get new warnings and fixes in newer versions.