### PR TITLE
Add test to check how errors are rendered

### DIFF
--- a/tests/error.rs
+++ b/tests/error.rs
@@ -4,13 +4,17 @@
 ))]
 #![cfg(all(feature = "std", feature = "serde"))]
 
-use stellar_xdr::{ScError, ScVal};
+use stellar_xdr::{ScError, ScVal, VecM};
 
 #[test]
 fn test_serde_ser() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(
         serde_json::to_string(&ScVal::Error(ScError::Contract(4)))?,
         "{\"error\":{\"contract\":4}}"
+    );
+    assert_eq!(
+        serde_json::to_string(&VecM::<ScVal, 1>::try_from([ScVal::Error(ScError::Contract(4))])?)?,
+        "[{\"error\":{\"contract\":4}}]"
     );
 
     Ok(())

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -4,7 +4,7 @@
 ))]
 #![cfg(all(feature = "std", feature = "serde"))]
 
-use stellar_xdr::{ScError, ScVal, VecM};
+use stellar_xdr::{ContractEventV0, ScError, ScVal, VecM};
 
 #[test]
 fn test_serde_ser() -> Result<(), Box<dyn std::error::Error>> {
@@ -13,8 +13,17 @@ fn test_serde_ser() -> Result<(), Box<dyn std::error::Error>> {
         "{\"error\":{\"contract\":4}}"
     );
     assert_eq!(
-        serde_json::to_string(&VecM::<ScVal, 1>::try_from([ScVal::Error(ScError::Contract(4))])?)?,
+        serde_json::to_string(&VecM::<ScVal, 1>::try_from([ScVal::Error(
+            ScError::Contract(4)
+        )])?)?,
         "[{\"error\":{\"contract\":4}}]"
+    );
+    assert_eq!(
+        serde_json::to_string(&ContractEventV0 {
+            topics: VecM::try_from([ScVal::Error(ScError::Contract(4))])?,
+            data: ScVal::Void,
+        })?,
+        "{\"topics\":[{\"error\":{\"contract\":4}}],\"data\":\"void\"}"
     );
 
     Ok(())

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -1,0 +1,17 @@
+#![cfg(all(
+    any(feature = "curr", feature = "next"),
+    not(all(feature = "curr", feature = "next"))
+))]
+#![cfg(all(feature = "std", feature = "serde"))]
+
+use stellar_xdr::{ScError, ScVal};
+
+#[test]
+fn test_serde_ser() -> Result<(), Box<dyn std::error::Error>> {
+    assert_eq!(
+        serde_json::to_string(&ScVal::Error(ScError::Contract(4)))?,
+        "{\"error\":{\"contract\":4}}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
### What
Add test to check how errors are rendered.

### Why

I wrote the test to confirm the behavior.

In output of stellar-xdr I saw the following:
```json
{
  "error": {
    "type_": "contract",
    "code": "existing_value"
  }
}
```

Writing this test confirmed the correct rendering is:
```json
{
  "error": {
    "contract": 4
   }
}
```

Committing this test because, why not.