### PR TITLE
Run CI via in merge queue

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  merge_group:
 
 env:
   RUSTFLAGS: -Dwarnings -Dclippy::all -Dclippy::pedantic


### PR DESCRIPTION
### What

Run the CI checks during the merge queue runs.

### Why

The CI checks need to run for the pull requests in the merge queue to be merged.

