### PR TITLE
Remove re-export of types into top-level

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ To use the library, include in your toml:
 stellar-xdr = { version = "...", default-features = true, features = [] }
 ```
 
+XDR types are available under modules, with the `curr` module containing XDR
+types built from the `stellar/stellar-xdr` `curr` branch. Other top-level
+modules are built from other `stellar/stellar-xdr` branches and releases if
+enabled with features.
+
 ##### Features
 
 The crate has several features, tiers of functionality, ancillary

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,10 +120,6 @@ pub const VERSION: Version = Version {
 
 #[cfg(feature = "curr")]
 pub mod curr;
-#[cfg(all(feature = "curr", not(feature = "next")))]
-pub use curr::*;
 
 #[cfg(feature = "next")]
 pub mod next;
-#[cfg(all(not(feature = "curr"), feature = "next"))]
-pub use next::*;

--- a/tests/tx_debug_display.rs
+++ b/tests/tx_debug_display.rs
@@ -3,6 +3,11 @@
     not(all(feature = "curr", feature = "next"))
 ))]
 
+#[cfg(feature = "curr")]
+use stellar_xdr::curr as stellar_xdr;
+#[cfg(feature = "next")]
+use stellar_xdr::next as stellar_xdr;
+
 use stellar_xdr::{BytesM, Error, Hash, StringM, VecM};
 
 #[test]

--- a/tests/tx_prot18.rs
+++ b/tests/tx_prot18.rs
@@ -4,6 +4,11 @@
 ))]
 #![cfg(all(feature = "std", feature = "base64"))]
 
+#[cfg(feature = "curr")]
+use stellar_xdr::curr as stellar_xdr;
+#[cfg(feature = "next")]
+use stellar_xdr::next as stellar_xdr;
+
 use stellar_xdr::{Error, OperationBody, ReadXdr, SequenceNumber, TransactionEnvelope};
 
 #[test]

--- a/tests/tx_read_edge_cases.rs
+++ b/tests/tx_read_edge_cases.rs
@@ -4,6 +4,11 @@
 ))]
 #![cfg(all(feature = "std", feature = "base64"))]
 
+#[cfg(feature = "curr")]
+use stellar_xdr::curr as stellar_xdr;
+#[cfg(feature = "next")]
+use stellar_xdr::next as stellar_xdr;
+
 use std::io::{self, Cursor};
 use stellar_xdr::Error;
 use stellar_xdr::{DepthLimitedRead, ReadXdr, WriteXdr, DEFAULT_XDR_RW_DEPTH_LIMIT};

--- a/tests/tx_serde.rs
+++ b/tests/tx_serde.rs
@@ -4,6 +4,11 @@
 ))]
 #![cfg(all(feature = "std", feature = "serde"))]
 
+#[cfg(feature = "curr")]
+use stellar_xdr::curr as stellar_xdr;
+#[cfg(feature = "next")]
+use stellar_xdr::next as stellar_xdr;
+
 use stellar_xdr::{BytesM, Hash, StringM, VecM};
 
 #[test]

--- a/tests/tx_small.rs
+++ b/tests/tx_small.rs
@@ -3,6 +3,11 @@
     not(all(feature = "curr", feature = "next"))
 ))]
 
+#[cfg(feature = "curr")]
+use stellar_xdr::curr as stellar_xdr;
+#[cfg(feature = "next")]
+use stellar_xdr::next as stellar_xdr;
+
 use stellar_xdr::{
     Error, Memo, MuxedAccount, Preconditions, SequenceNumber, Transaction, TransactionEnvelope,
     TransactionExt, TransactionV1Envelope, Uint256,


### PR DESCRIPTION
### What
Remove the re-export of types into top-level that occurs when only one of the `curr` or `next` features are enabled.

### Why
It is confusing that when both `curr` and `next` are enabled that the top-level exports change. It's also difficult to debug.

In most cases applications could just depend on the specific module they'd like to use, and as such can reference `stellar_xdr::curr::...`.