### PR TITLE
Upgrade stellar-strkey to v0.0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,11 +476,12 @@ dependencies = [
 
 [[package]]
 name = "stellar-strkey"
-version = "0.0.7"
+version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0689070126ca7f2effc2c5726584446db52190f0cef043c02eb4040a711c11"
+checksum = "12d2bf45e114117ea91d820a846fd1afbe3ba7d717988fee094ce8227a3bf8bd"
 dependencies = [
  "base32",
+ "crate-git-revision",
  "thiserror",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ doctest = false
 crate-git-revision = "0.0.6"
 
 [dependencies]
-stellar-strkey = { version = "0.0.7", optional = true }
+stellar-strkey = { version = "0.0.8", optional = true }
 base64 = { version = "0.13.0", optional = true }
 serde = { version = "1.0.139", features = ["derive"], optional = true }
 serde_with = { version = "3.0.0", optional = true }


### PR DESCRIPTION
### What
Upgrade stellar-strkey to v0.0.8.

### Why
Get the fixes includes in v0.0.8.