### PR TITLE
Add conversion from references of tuples to ScVal

### DIFF
--- a/src/curr/scval_conversions.rs
+++ b/src/curr/scval_conversions.rs
@@ -574,12 +574,35 @@ macro_rules! impl_for_tuple {
         }
 
         #[cfg(feature = "alloc")]
+        impl<$($typ),*> TryFrom<&($($typ,)*)> for ScVec
+        where
+            $($typ: TryInto<ScVal> + Clone),*
+        {
+            type Error = ();
+            fn try_from(v: &($($typ,)*)) -> Result<Self, Self::Error> {
+                let vec: Vec<ScVal> = vec![$(v.$idx.clone().try_into().map_err(|_| ())?),+];
+                Ok(ScVec(vec.try_into()?))
+            }
+        }
+
+        #[cfg(feature = "alloc")]
         impl<$($typ),*> TryFrom<($($typ,)*)> for ScVal
         where
             $($typ: TryInto<ScVal>),*
         {
             type Error = ();
             fn try_from(v: ($($typ,)*)) -> Result<Self, ()> {
+                Ok(ScVal::Vec(Some(<_ as TryInto<ScVec>>::try_into(v)?)))
+            }
+        }
+
+        #[cfg(feature = "alloc")]
+        impl<$($typ),*> TryFrom<&($($typ,)*)> for ScVal
+        where
+            $($typ: TryInto<ScVal> + Clone),*
+        {
+            type Error = ();
+            fn try_from(v: &($($typ,)*)) -> Result<Self, ()> {
                 Ok(ScVal::Vec(Some(<_ as TryInto<ScVec>>::try_into(v)?)))
             }
         }
@@ -793,6 +816,18 @@ mod test {
         let val: ScVal = v.clone().try_into().unwrap();
         let roundtrip: (i32, i64, Vec<bool>) = val.try_into().unwrap();
         assert_eq!(v, roundtrip);
+    }
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn tuple_refs() {
+        extern crate alloc;
+        use alloc::vec;
+        use alloc::vec::Vec;
+        let v = &(1i32, 2i64, vec![true, false]);
+        let val: ScVal = v.try_into().unwrap();
+        let roundtrip: (i32, i64, Vec<bool>) = val.try_into().unwrap();
+        assert_eq!(v, &roundtrip);
     }
 
     #[test]

--- a/src/next/scval_conversions.rs
+++ b/src/next/scval_conversions.rs
@@ -574,12 +574,35 @@ macro_rules! impl_for_tuple {
         }
 
         #[cfg(feature = "alloc")]
+        impl<$($typ),*> TryFrom<&($($typ,)*)> for ScVec
+        where
+            $($typ: TryInto<ScVal> + Clone),*
+        {
+            type Error = ();
+            fn try_from(v: &($($typ,)*)) -> Result<Self, Self::Error> {
+                let vec: Vec<ScVal> = vec![$(v.$idx.clone().try_into().map_err(|_| ())?),+];
+                Ok(ScVec(vec.try_into()?))
+            }
+        }
+
+        #[cfg(feature = "alloc")]
         impl<$($typ),*> TryFrom<($($typ,)*)> for ScVal
         where
             $($typ: TryInto<ScVal>),*
         {
             type Error = ();
             fn try_from(v: ($($typ,)*)) -> Result<Self, ()> {
+                Ok(ScVal::Vec(Some(<_ as TryInto<ScVec>>::try_into(v)?)))
+            }
+        }
+
+        #[cfg(feature = "alloc")]
+        impl<$($typ),*> TryFrom<&($($typ,)*)> for ScVal
+        where
+            $($typ: TryInto<ScVal> + Clone),*
+        {
+            type Error = ();
+            fn try_from(v: &($($typ,)*)) -> Result<Self, ()> {
                 Ok(ScVal::Vec(Some(<_ as TryInto<ScVec>>::try_into(v)?)))
             }
         }
@@ -793,6 +816,18 @@ mod test {
         let val: ScVal = v.clone().try_into().unwrap();
         let roundtrip: (i32, i64, Vec<bool>) = val.try_into().unwrap();
         assert_eq!(v, roundtrip);
+    }
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn tuple_refs() {
+        extern crate alloc;
+        use alloc::vec;
+        use alloc::vec::Vec;
+        let v = &(1i32, 2i64, vec![true, false]);
+        let val: ScVal = v.try_into().unwrap();
+        let roundtrip: (i32, i64, Vec<bool>) = val.try_into().unwrap();
+        assert_eq!(v, &roundtrip);
     }
 
     #[test]


### PR DESCRIPTION
### What

Add impls of TryFrom for references of tuples to ScVec and ScVal.

### Why

Per https://github.com/stellar/rs-soroban-sdk/issues/1124, UDTs currently don't work with tuple fields because the `#[contracttype]` macro generates code that expects the `From` implementation on references of the types it is converting.

### Known limitations

None, but because this enables more forms of UDTs to work, this will impose more requirements on client bindings for non-Rust languages.

---

I have tested the SDK with this patch applied, that UDTs with tuple fields work. After the SDK is updated for these changes I will land corresponding test cases in the SDK based on this patch: https://github.com/brson/rs-soroban-sdk/commit/bcda4faadadabec7f5f0796e341bb84111bbd6b2