### PR TITLE
Fix building with the serde feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,8 @@ serde_json = "1.0.89"
 
 [features]
 default = ["std", "curr"]
-std = ["alloc", "dep:stellar-strkey"]
-alloc = ["dep:hex"]
+std = ["alloc"]
+alloc = ["dep:hex", "dep:stellar-strkey"]
 curr = []
 next = []
 

--- a/src/curr/str.rs
+++ b/src/curr/str.rs
@@ -13,7 +13,7 @@
 //# - SignerKey
 //# - SignerKeyEd25519SignedPayload
 //# - NodeId
-#![cfg(feature = "std")]
+#![cfg(feature = "alloc")]
 
 use super::{
     AccountId, Error, Hash, MuxedAccount, MuxedAccountMed25519, NodeId, PublicKey, ScAddress,
@@ -31,7 +31,7 @@ impl core::fmt::Display for PublicKey {
         match self {
             PublicKey::PublicKeyTypeEd25519(Uint256(k)) => {
                 let k = stellar_strkey::ed25519::PublicKey::from_payload(k)
-                    .map_err(|_| std::fmt::Error)?;
+                    .map_err(|_| core::fmt::Error)?;
                 let s = k.to_string();
                 f.write_str(&s)?;
             }


### PR DESCRIPTION
### What
Shift str impl from the std to alloc feature.

### Why
The str was gated behind the std feature, but the str impl is used by the serde feature, and the serde feature is dependent on the alloc feature, not the std feature.

There's no reason to have str gated by std, as it only uses core and alloc dependencies, so gating it behind alloc should be okay. Technically the strkey lib uses std in name hwen it could use alloc. So this change might also require updating strkey to use alloc. But I want to see how far we can get without doing that as updating strkey to not using std will require forking at least one of its dependencies.