### PR TITLE
Render asset codes as strings in JSON

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CARGO_HACK_ARGS=--feature-powerset --exclude-features default --group-features b
 CARGO_DOC_ARGS?=--open
 
 XDRGEN_VERSION=cbff4b31
-XDRGEN_TYPES_CUSTOM_STR_IMPL=PublicKey,AccountId,MuxedAccount,MuxedAccountMed25519,SignerKey,SignerKeyEd25519SignedPayload,NodeId,ScAddress
+XDRGEN_TYPES_CUSTOM_STR_IMPL=PublicKey,AccountId,MuxedAccount,MuxedAccountMed25519,SignerKey,SignerKeyEd25519SignedPayload,NodeId,ScAddress,AssetCode,AssetCode4,AssetCode12
 
 all: build test
 

--- a/src/curr/generated.rs
+++ b/src/curr/generated.rs
@@ -10345,23 +10345,6 @@ impl core::fmt::Debug for AssetCode4 {
         Ok(())
     }
 }
-impl core::fmt::Display for AssetCode4 {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let v = &self.0;
-        for b in v {
-            write!(f, "{b:02x}")?;
-        }
-        Ok(())
-    }
-}
-
-#[cfg(feature = "alloc")]
-impl core::str::FromStr for AssetCode4 {
-    type Err = Error;
-    fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
-        hex::decode(s).map_err(|_| Error::InvalidHex)?.try_into()
-    }
-}
 impl From<AssetCode4> for [u8; 4] {
     #[must_use]
     fn from(x: AssetCode4) -> Self {
@@ -10459,23 +10442,6 @@ impl core::fmt::Debug for AssetCode12 {
         }
         write!(f, ")")?;
         Ok(())
-    }
-}
-impl core::fmt::Display for AssetCode12 {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let v = &self.0;
-        for b in v {
-            write!(f, "{b:02x}")?;
-        }
-        Ok(())
-    }
-}
-
-#[cfg(feature = "alloc")]
-impl core::str::FromStr for AssetCode12 {
-    type Err = Error;
-    fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
-        hex::decode(s).map_err(|_| Error::InvalidHex)?.try_into()
     }
 }
 impl From<AssetCode12> for [u8; 12] {
@@ -10689,8 +10655,7 @@ impl WriteXdr for AssetType {
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
-    derive(serde::Serialize, serde::Deserialize),
-    serde(rename_all = "snake_case")
+    derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr)
 )]
 #[allow(clippy::large_enum_variant)]
 pub enum AssetCode {

--- a/src/curr/str.rs
+++ b/src/curr/str.rs
@@ -1,10 +1,6 @@
 //# Custom string representations of the following types, also used for JSON
 //# formatting.
 //#
-//# The types that has impls in this file are given to the xdrgen
-//# --rust-types-custom-str-impl cli option, so that xdrgen does not generate
-//# FromStr and Display impls for them.
-//#
 //# ## Strkey Types (SEP-23)
 //# - PublicKey
 //# - AccountId
@@ -13,11 +9,16 @@
 //# - SignerKey
 //# - SignerKeyEd25519SignedPayload
 //# - NodeId
+//#
+//# ## Asset Codes
+//# - AssetCode
+//# - AssetCode4
+//# - AssetCode12
 #![cfg(feature = "alloc")]
 
 use super::{
-    AccountId, Error, Hash, MuxedAccount, MuxedAccountMed25519, NodeId, PublicKey, ScAddress,
-    SignerKey, SignerKeyEd25519SignedPayload, Uint256,
+    AccountId, AssetCode, AssetCode12, AssetCode4, Error, Hash, MuxedAccount, MuxedAccountMed25519,
+    NodeId, PublicKey, ScAddress, SignerKey, SignerKeyEd25519SignedPayload, Uint256,
 };
 
 impl From<stellar_strkey::DecodeError> for Error {
@@ -253,4 +254,119 @@ impl core::fmt::Display for ScAddress {
         }
         Ok(())
     }
+}
+
+impl core::str::FromStr for AssetCode4 {
+    type Err = Error;
+    fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
+        let b = s.as_bytes();
+        let mut code = AssetCode4([0u8; 4]);
+        if b.len() <= code.0.len() {
+            code.0[..b.len()].copy_from_slice(&b);
+            Ok(code)
+        } else {
+            Err(Error::Invalid)
+        }
+    }
+}
+
+impl core::fmt::Display for AssetCode4 {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        if let Some(last_idx) = self.0.iter().rposition(|c| *c != 0) {
+            write_utf8_lossy_with_nuls(f, &self.0[..=last_idx])
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl core::str::FromStr for AssetCode12 {
+    type Err = Error;
+    fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
+        let b = s.as_bytes();
+        let mut code = AssetCode12([0u8; 12]);
+        if b.len() <= code.0.len() {
+            code.0[..b.len()].copy_from_slice(&b);
+            Ok(code)
+        } else {
+            Err(Error::Invalid)
+        }
+    }
+}
+
+impl core::fmt::Display for AssetCode12 {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        if let Some(last_idx) = self.0.iter().rposition(|c| *c != 0) {
+            write_utf8_lossy_with_nuls(f, &self.0[..=last_idx])
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl core::str::FromStr for AssetCode {
+    type Err = Error;
+    fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
+        let b = s.as_bytes();
+        if b.len() <= 4 {
+            Ok(AssetCode::CreditAlphanum4(AssetCode4::from_str(s)?))
+        } else if b.len() <= 12 {
+            Ok(AssetCode::CreditAlphanum12(AssetCode12::from_str(s)?))
+        } else {
+            Err(Error::Invalid)
+        }
+    }
+}
+
+impl core::fmt::Display for AssetCode {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            AssetCode::CreditAlphanum4(c) => c.fmt(f),
+            AssetCode::CreditAlphanum12(c) => c.fmt(f),
+        }
+    }
+}
+
+/// Writes a byte slice as a utf8 string, replacing any bytes in invalid utf8
+/// sequences as the nul byte.
+///
+/// A modified copy of the Rust stdlib docs examples here:
+/// <https://doc.rust-lang.org/stable/core/str/struct.Utf8Error.html#examples>
+///
+/// This particular implementation preserves the length of the string written
+/// such that exactly one byte is written for every byte in an invalid sequence,
+/// by writing a nul (0x00) byte for each.
+///
+/// Normally it would be common to write a Unicode Replacement Character
+/// (U+FFFD) for lossy coding but doing so would not preserve the length as a
+/// single invalid byte would be replaced by two bytes.
+pub fn write_utf8_lossy_with_nuls(
+    f: &mut impl core::fmt::Write,
+    mut input: &[u8],
+) -> core::fmt::Result {
+    loop {
+        match core::str::from_utf8(input) {
+            Ok(valid) => {
+                write!(f, "{valid}")?;
+                break;
+            }
+            Err(error) => {
+                let (valid, after_valid) = input.split_at(error.valid_up_to());
+                write!(f, "{}", core::str::from_utf8(valid).unwrap())?;
+
+                if let Some(invalid_sequence_length) = error.error_len() {
+                    for _ in 0..invalid_sequence_length {
+                        write!(f, "\0")?;
+                    }
+                    input = &after_valid[invalid_sequence_length..];
+                } else {
+                    for _ in 0..after_valid.len() {
+                        write!(f, "\0")?;
+                    }
+                    break;
+                }
+            }
+        }
+    }
+    Ok(())
 }

--- a/tests/str.rs
+++ b/tests/str.rs
@@ -4,8 +4,8 @@
 use stellar_xdr::curr as stellar_xdr;
 
 use stellar_xdr::{
-    AccountId, Error, Hash, MuxedAccount, MuxedAccountMed25519, NodeId, PublicKey, ScAddress,
-    SignerKey, SignerKeyEd25519SignedPayload, Uint256,
+    AccountId, AssetCode, AssetCode12, AssetCode4, Error, Hash, MuxedAccount, MuxedAccountMed25519,
+    NodeId, PublicKey, ScAddress, SignerKey, SignerKeyEd25519SignedPayload, Uint256,
 };
 
 use std::str::FromStr;
@@ -397,4 +397,147 @@ fn sc_address_from_str_with_invalid() {
         "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVAAAAAAAAAAAAAJLK",
     );
     assert_eq!(v, Err(Error::Invalid));
+}
+
+#[test]
+fn asset_code_4_from_str() {
+    assert_eq!(AssetCode4::from_str(""), Ok(AssetCode4(*b"\0\0\0\0")));
+    assert_eq!(AssetCode4::from_str("a"), Ok(AssetCode4(*b"a\0\0\0")));
+    assert_eq!(AssetCode4::from_str("ab"), Ok(AssetCode4(*b"ab\0\0")));
+    assert_eq!(AssetCode4::from_str("abc"), Ok(AssetCode4(*b"abc\0")));
+    assert_eq!(AssetCode4::from_str("abcd"), Ok(AssetCode4(*b"abcd")));
+
+    assert_eq!(AssetCode4::from_str("abcde"), Err(Error::Invalid));
+}
+
+#[test]
+fn asset_code_4_to_string() {
+    assert_eq!(AssetCode4(*b"\0\0\0\0").to_string(), "");
+    assert_eq!(AssetCode4(*b"a\0\0\0").to_string(), "a");
+    assert_eq!(AssetCode4(*b"ab\0\0").to_string(), "ab");
+    assert_eq!(AssetCode4(*b"abc\0").to_string(), "abc");
+    assert_eq!(AssetCode4(*b"abcd").to_string(), "abcd");
+
+    // Preserve as much of the code as possible, even if it contains nul bytes.
+    assert_eq!(AssetCode4(*b"a\0cd").to_string(), "a\0cd");
+
+    // Replace bytes that are not valid utf8 with the replacement character � and preserve length.
+    assert_eq!(AssetCode4(*b"a\xc3\x28d").to_string(), "a\0(d");
+    assert_eq!(AssetCode4(*b"a\xc3\xc3\x28").to_string(), "a\0\0(");
+    assert_eq!(AssetCode4(*b"a\xc3\xc3\xc3").to_string(), "a\0\0\0");
+}
+
+#[test]
+#[rustfmt::skip]
+fn asset_code_12_from_str() {
+    assert_eq!(AssetCode12::from_str(""), Ok(AssetCode12(*b"\0\0\0\0\0\0\0\0\0\0\0\0")));
+    assert_eq!(AssetCode12::from_str("a"), Ok(AssetCode12(*b"a\0\0\0\0\0\0\0\0\0\0\0")));
+    assert_eq!(AssetCode12::from_str("ab"), Ok(AssetCode12(*b"ab\0\0\0\0\0\0\0\0\0\0")));
+    assert_eq!(AssetCode12::from_str("abc"), Ok(AssetCode12(*b"abc\0\0\0\0\0\0\0\0\0")));
+    assert_eq!(AssetCode12::from_str("abcd"), Ok(AssetCode12(*b"abcd\0\0\0\0\0\0\0\0")));
+    assert_eq!(AssetCode12::from_str("abcde"), Ok(AssetCode12(*b"abcde\0\0\0\0\0\0\0")));
+    assert_eq!(AssetCode12::from_str("abcdef"), Ok(AssetCode12(*b"abcdef\0\0\0\0\0\0")));
+    assert_eq!(AssetCode12::from_str("abcdefg"), Ok(AssetCode12(*b"abcdefg\0\0\0\0\0")));
+    assert_eq!(AssetCode12::from_str("abcdefgh"), Ok(AssetCode12(*b"abcdefgh\0\0\0\0")));
+    assert_eq!(AssetCode12::from_str("abcdefghi"), Ok(AssetCode12(*b"abcdefghi\0\0\0")));
+    assert_eq!(AssetCode12::from_str("abcdefghij"), Ok(AssetCode12(*b"abcdefghij\0\0")));
+    assert_eq!(AssetCode12::from_str("abcdefghijk"), Ok(AssetCode12(*b"abcdefghijk\0")));
+    assert_eq!(AssetCode12::from_str("abcdefghijkl"), Ok(AssetCode12(*b"abcdefghijkl")));
+
+    assert_eq!(AssetCode12::from_str("abcdefghijklm"), Err(Error::Invalid));
+}
+
+#[test]
+#[rustfmt::skip]
+fn asset_code_12_to_string() {
+    assert_eq!(AssetCode12(*b"\0\0\0\0\0\0\0\0\0\0\0\0").to_string(), "");
+    assert_eq!(AssetCode12(*b"a\0\0\0\0\0\0\0\0\0\0\0").to_string(), "a");
+    assert_eq!(AssetCode12(*b"ab\0\0\0\0\0\0\0\0\0\0").to_string(), "ab");
+    assert_eq!(AssetCode12(*b"abc\0\0\0\0\0\0\0\0\0").to_string(), "abc");
+    assert_eq!(AssetCode12(*b"abcd\0\0\0\0\0\0\0\0").to_string(), "abcd");
+    assert_eq!(AssetCode12(*b"abcde\0\0\0\0\0\0\0").to_string(), "abcde");
+    assert_eq!(AssetCode12(*b"abcdef\0\0\0\0\0\0").to_string(), "abcdef");
+    assert_eq!(AssetCode12(*b"abcdefg\0\0\0\0\0").to_string(), "abcdefg");
+    assert_eq!(AssetCode12(*b"abcdefgh\0\0\0\0").to_string(), "abcdefgh");
+    assert_eq!(AssetCode12(*b"abcdefghi\0\0\0").to_string(), "abcdefghi");
+    assert_eq!(AssetCode12(*b"abcdefghij\0\0").to_string(), "abcdefghij");
+    assert_eq!(AssetCode12(*b"abcdefghijk\0").to_string(), "abcdefghijk");
+    assert_eq!(AssetCode12(*b"abcdefghijkl").to_string(), "abcdefghijkl");
+
+    // Preserve as much of the code as possible, even if it contains nul bytes.
+    assert_eq!(AssetCode12(*b"a\0cd\0\0\0\0\0\0\0\0").to_string(), "a\0cd");
+
+    // Replace bytes that are not valid utf8 with the replacement character � and preserve length.
+    assert_eq!(AssetCode12(*b"a\xc3\x28d\0\0\0\0\0\0\0\0").to_string(), "a\0(d");
+    assert_eq!(AssetCode12(*b"a\xc3\xc3\x28d\0\0\0\0\0\0\0").to_string(), "a\0\0(d");
+}
+
+#[test]
+#[rustfmt::skip]
+fn asset_code_from_str() {
+    assert_eq!(AssetCode::from_str(""), Ok(AssetCode::CreditAlphanum4(AssetCode4(*b"\0\0\0\0"))));
+    assert_eq!(AssetCode::from_str("a"), Ok(AssetCode::CreditAlphanum4(AssetCode4(*b"a\0\0\0"))));
+    assert_eq!(AssetCode::from_str("ab"), Ok(AssetCode::CreditAlphanum4(AssetCode4(*b"ab\0\0"))));
+    assert_eq!(AssetCode::from_str("abc"), Ok(AssetCode::CreditAlphanum4(AssetCode4(*b"abc\0"))));
+    assert_eq!(AssetCode::from_str("abcd"), Ok(AssetCode::CreditAlphanum4(AssetCode4(*b"abcd"))));
+
+    assert_eq!(AssetCode::from_str("abcde"), Ok(AssetCode::CreditAlphanum12(AssetCode12(*b"abcde\0\0\0\0\0\0\0"))));
+    assert_eq!(AssetCode::from_str("abcdef"), Ok(AssetCode::CreditAlphanum12(AssetCode12(*b"abcdef\0\0\0\0\0\0"))));
+    assert_eq!(AssetCode::from_str("abcdefg"), Ok(AssetCode::CreditAlphanum12(AssetCode12(*b"abcdefg\0\0\0\0\0"))));
+    assert_eq!(AssetCode::from_str("abcdefgh"), Ok(AssetCode::CreditAlphanum12(AssetCode12(*b"abcdefgh\0\0\0\0"))));
+    assert_eq!(AssetCode::from_str("abcdefghi"), Ok(AssetCode::CreditAlphanum12(AssetCode12(*b"abcdefghi\0\0\0"))));
+    assert_eq!(AssetCode::from_str("abcdefghij"), Ok(AssetCode::CreditAlphanum12(AssetCode12(*b"abcdefghij\0\0"))));
+    assert_eq!(AssetCode::from_str("abcdefghijk"), Ok(AssetCode::CreditAlphanum12(AssetCode12(*b"abcdefghijk\0"))));
+    assert_eq!(AssetCode::from_str("abcdefghijkl"), Ok(AssetCode::CreditAlphanum12(AssetCode12(*b"abcdefghijkl"))));
+
+    assert_eq!(AssetCode::from_str("abcdefghijklm"), Err(Error::Invalid));
+}
+
+#[test]
+#[rustfmt::skip]
+fn asset_code_to_string() {
+    assert_eq!(AssetCode::CreditAlphanum4(AssetCode4(*b"\0\0\0\0")).to_string(), "");
+    assert_eq!(AssetCode::CreditAlphanum4(AssetCode4(*b"a\0\0\0")).to_string(), "a");
+    assert_eq!(AssetCode::CreditAlphanum4(AssetCode4(*b"ab\0\0")).to_string(), "ab");
+    assert_eq!(AssetCode::CreditAlphanum4(AssetCode4(*b"abc\0")).to_string(), "abc");
+    assert_eq!(AssetCode::CreditAlphanum4(AssetCode4(*b"abcd")).to_string(), "abcd");
+
+    assert_eq!(AssetCode::CreditAlphanum12(AssetCode12(*b"\0\0\0\0\0\0\0\0\0\0\0\0")).to_string(), "");
+    assert_eq!(AssetCode::CreditAlphanum12(AssetCode12(*b"a\0\0\0\0\0\0\0\0\0\0\0")).to_string(), "a");
+    assert_eq!(AssetCode::CreditAlphanum12(AssetCode12(*b"ab\0\0\0\0\0\0\0\0\0\0")).to_string(), "ab");
+    assert_eq!(AssetCode::CreditAlphanum12(AssetCode12(*b"abc\0\0\0\0\0\0\0\0\0")).to_string(), "abc");
+    assert_eq!(AssetCode::CreditAlphanum12(AssetCode12(*b"abcd\0\0\0\0\0\0\0\0")).to_string(), "abcd");
+    assert_eq!(AssetCode::CreditAlphanum12(AssetCode12(*b"abcde\0\0\0\0\0\0\0")).to_string(), "abcde");
+    assert_eq!(AssetCode::CreditAlphanum12(AssetCode12(*b"abcdef\0\0\0\0\0\0")).to_string(), "abcdef");
+    assert_eq!(AssetCode::CreditAlphanum12(AssetCode12(*b"abcdefg\0\0\0\0\0")).to_string(), "abcdefg");
+    assert_eq!(AssetCode::CreditAlphanum12(AssetCode12(*b"abcdefgh\0\0\0\0")).to_string(), "abcdefgh");
+    assert_eq!(AssetCode::CreditAlphanum12(AssetCode12(*b"abcdefghi\0\0\0")).to_string(), "abcdefghi");
+    assert_eq!(AssetCode::CreditAlphanum12(AssetCode12(*b"abcdefghij\0\0")).to_string(), "abcdefghij");
+    assert_eq!(AssetCode::CreditAlphanum12(AssetCode12(*b"abcdefghijk\0")).to_string(), "abcdefghijk");
+    assert_eq!(AssetCode::CreditAlphanum12(AssetCode12(*b"abcdefghijkl")).to_string(), "abcdefghijkl");
+
+    // Preserve as much of the code as possible, even if it contains nul bytes.
+    assert_eq!(AssetCode::CreditAlphanum4(AssetCode4(*b"a\0cd")).to_string(), "a\0cd");
+    assert_eq!(AssetCode::CreditAlphanum12(AssetCode12(*b"a\0cd\0\0\0\0\0\0\0\0")).to_string(), "a\0cd");
+
+    // Replace bytes that are not valid utf8 with the replacement character � and preserve length.
+    assert_eq!(AssetCode::CreditAlphanum4(AssetCode4(*b"a\xc3\x28d")).to_string(), "a\0(d");
+    assert_eq!(AssetCode::CreditAlphanum12(AssetCode12(*b"a\xc3\x28d\0\0\0\0\0\0\0\0")).to_string(), "a\0(d");
+    assert_eq!(AssetCode::CreditAlphanum12(AssetCode12(*b"a\xc3\xc3\x28d\0\0\0\0\0\0\0")).to_string(), "a\0\0(d");
+}
+
+#[test]
+#[rustfmt::skip]
+fn asset_code_from_str_to_string_roundtrip_unicode() {
+    // Round tripped to correct variant based on byte length, not code point length.
+    assert_eq!(AssetCode::CreditAlphanum12(AssetCode12(*b"a\xd9\xaa\xd9\xaa\0\0\0\0\0\0\0")).to_string(), "a٪٪");
+    assert_eq!(AssetCode::from_str("a٪٪"), Ok(AssetCode::CreditAlphanum12(AssetCode12(*b"a\xd9\xaa\xd9\xaa\0\0\0\0\0\0\0"))));
+
+    // Round tripped to correct variant based on byte length even when utf8
+    // parsing error occurs. To preserve type consistency when round tripping
+    // the data, the length when parsing errors occur must be consistent with
+    // the input length, which is why a nul byte is expected instead of a
+    // Unicode Replacement Character, which would be two bytes.
+    assert_eq!(AssetCode::CreditAlphanum4(AssetCode4(*b"a\xc3\xc3d")).to_string(), "a\0\0d");
+    assert_eq!(AssetCode::from_str("a\0\0d"), Ok(AssetCode::CreditAlphanum4(AssetCode4(*b"a\0\0d"))));
 }


### PR DESCRIPTION
### What
Render asset codes in JSON as UTF-8 strings, where any invalid byte sequences are encoded as a nul byte for each invalid byte.

### Why
Valid asset codes are some subset of ASCII, but they're currently rendered as hex. It creates a poor and difficult experience when a developer is expecting to see their asset code in the JSON and instead see hex.

The codes are rendered to UTF-8 strings because JSON strings must be Unicode.

Invalid byte sequences are rendered as a single nul byte per byte in the invalid sequence to preserve length. This is because the length of asset codes distinguishes between AssetCode4 and AssetCode12. Typically lossy coding of utf-8 results in Unicode Replacement Character (U+FFFD) being inserted into the output. However that character is two bytes long. If a 4-byte AssetCode4 contains an invalid byte sequence, it would result in rendering as a 5-byte UTF-8 string. When converted back to the Rust type it would be interpreted as an AssetCode12.