### PR TITLE
Move the CLI functionality into the library

### DIFF
--- a/src/bin/stellar-xdr/main.rs
+++ b/src/bin/stellar-xdr/main.rs
@@ -1,73 +1,7 @@
-mod decode;
-mod encode;
-mod guess;
-mod types;
-mod version;
-
-use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
-use std::{error::Error, fmt::Debug};
-
-#[derive(Parser, Debug, Clone)]
-#[command(
-    author,
-    version,
-    about,
-    long_about = None,
-    disable_help_subcommand = true,
-    disable_version_flag = true,
-    disable_colored_help = true,
-    infer_subcommands = true,
-)]
-struct Root {
-    /// Channel of XDR to operate on
-    #[arg(value_enum, default_value_t)]
-    channel: Channel,
-    #[command(subcommand)]
-    cmd: Cmd,
-}
-
-#[derive(ValueEnum, Debug, Clone)]
-pub enum Channel {
-    #[value(name = "+curr")]
-    Curr,
-    #[value(name = "+next")]
-    Next,
-}
-
-impl Default for Channel {
-    fn default() -> Self {
-        Self::Curr
-    }
-}
-
-#[derive(Subcommand, Debug, Clone)]
-enum Cmd {
-    /// View information about types
-    Types(types::Cmd),
-    /// Guess the XDR type
-    Guess(guess::Cmd),
-    /// Decode XDR
-    Decode(decode::Cmd),
-    /// Encode XDR
-    Encode(encode::Cmd),
-    /// Print version information
-    Version,
-}
-
-fn run() -> Result<(), Box<dyn Error>> {
-    let root = Root::parse();
-    match root.cmd {
-        Cmd::Types(c) => c.run(&root.channel)?,
-        Cmd::Guess(c) => c.run(&root.channel)?,
-        Cmd::Decode(c) => c.run(&root.channel)?,
-        Cmd::Encode(c) => c.run(&root.channel)?,
-        Cmd::Version => version::Cmd::run(),
-    }
-    Ok(())
-}
+use stellar_xdr::cli;
 
 fn main() {
-    if let Err(e) = run() {
+    if let Err(e) = cli::run() {
         Root::command()
             .error(clap::error::ErrorKind::ValueValidation, e)
             .exit()

--- a/src/bin/stellar-xdr/main.rs
+++ b/src/bin/stellar-xdr/main.rs
@@ -1,9 +1,8 @@
+use clap::Error;
 use stellar_xdr::cli;
 
 fn main() {
     if let Err(e) = cli::run() {
-        Root::command()
-            .error(clap::error::ErrorKind::ValueValidation, e)
-            .exit()
+        Error::raw(clap::error::ErrorKind::ValueValidation, e).exit();
     }
 }

--- a/src/bin/stellar-xdr/main.rs
+++ b/src/bin/stellar-xdr/main.rs
@@ -4,8 +4,11 @@ use stellar_xdr::cli;
 
 fn main() {
     if let Err(e) = cli::run(env::args_os()) {
-        // TODO: Don't treat the 'help' case as an error.
-        // TODO: Remove Box<dyn Error> and replace with concrete errors.
-        Error::raw(clap::error::ErrorKind::ValueValidation, e).exit();
+        match e {
+            cli::Error::Clap(e) => e.exit(),
+            cli::Error::Guess(_) | cli::Error::Decode(_) | cli::Error::Encode(_) => {
+                Error::raw(clap::error::ErrorKind::ValueValidation, e).exit()
+            }
+        }
     }
 }

--- a/src/bin/stellar-xdr/main.rs
+++ b/src/bin/stellar-xdr/main.rs
@@ -4,6 +4,8 @@ use stellar_xdr::cli;
 
 fn main() {
     if let Err(e) = cli::run(env::args_os()) {
+        // TODO: Don't treat the 'help' case as an error.
+        // TODO: Remove Box<dyn Error> and replace with concrete errors.
         Error::raw(clap::error::ErrorKind::ValueValidation, e).exit();
     }
 }

--- a/src/bin/stellar-xdr/main.rs
+++ b/src/bin/stellar-xdr/main.rs
@@ -1,8 +1,9 @@
 use clap::Error;
+use std::env;
 use stellar_xdr::cli;
 
 fn main() {
-    if let Err(e) = cli::run() {
+    if let Err(e) = cli::run(env::args_os()) {
         Error::raw(clap::error::ErrorKind::ValueValidation, e).exit();
     }
 }

--- a/src/cli/encode.rs
+++ b/src/cli/encode.rs
@@ -7,56 +7,56 @@ use std::{
 
 use clap::{Args, ValueEnum};
 
-use crate::Channel;
+use crate::cli::Channel;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("unknown type {0}, choose one of {1:?}")]
     UnknownType(String, &'static [&'static str]),
     #[error("error decoding JSON: {0}")]
-    ReadJsonCurr(stellar_xdr::curr::Error),
+    ReadJsonCurr(crate::curr::Error),
     #[error("error decoding JSON: {0}")]
-    ReadJsonNext(stellar_xdr::next::Error),
+    ReadJsonNext(crate::next::Error),
     #[error("error reading file: {0}")]
     ReadFile(#[from] std::io::Error),
     #[error("error generating XDR: {0}")]
-    WriteXdrCurr(stellar_xdr::curr::Error),
+    WriteXdrCurr(crate::curr::Error),
     #[error("error generating XDR: {0}")]
-    WriteXdrNext(stellar_xdr::next::Error),
+    WriteXdrNext(crate::next::Error),
 }
 
-impl From<stellar_xdr::curr::Error> for Error {
-    fn from(e: stellar_xdr::curr::Error) -> Self {
+impl From<crate::curr::Error> for Error {
+    fn from(e: crate::curr::Error) -> Self {
         match e {
-            stellar_xdr::curr::Error::Invalid
-            | stellar_xdr::curr::Error::Unsupported
-            | stellar_xdr::curr::Error::LengthExceedsMax
-            | stellar_xdr::curr::Error::LengthMismatch
-            | stellar_xdr::curr::Error::NonZeroPadding
-            | stellar_xdr::curr::Error::Utf8Error(_)
-            | stellar_xdr::curr::Error::InvalidHex
-            | stellar_xdr::curr::Error::Io(_)
-            | stellar_xdr::curr::Error::DepthLimitExceeded
-            | stellar_xdr::curr::Error::LengthLimitExceeded => Error::WriteXdrCurr(e),
-            stellar_xdr::curr::Error::Json(_) => Error::ReadJsonCurr(e),
+            crate::curr::Error::Invalid
+            | crate::curr::Error::Unsupported
+            | crate::curr::Error::LengthExceedsMax
+            | crate::curr::Error::LengthMismatch
+            | crate::curr::Error::NonZeroPadding
+            | crate::curr::Error::Utf8Error(_)
+            | crate::curr::Error::InvalidHex
+            | crate::curr::Error::Io(_)
+            | crate::curr::Error::DepthLimitExceeded
+            | crate::curr::Error::LengthLimitExceeded => Error::WriteXdrCurr(e),
+            crate::curr::Error::Json(_) => Error::ReadJsonCurr(e),
         }
     }
 }
 
-impl From<stellar_xdr::next::Error> for Error {
-    fn from(e: stellar_xdr::next::Error) -> Self {
+impl From<crate::next::Error> for Error {
+    fn from(e: crate::next::Error) -> Self {
         match e {
-            stellar_xdr::next::Error::Invalid
-            | stellar_xdr::next::Error::Unsupported
-            | stellar_xdr::next::Error::LengthExceedsMax
-            | stellar_xdr::next::Error::LengthMismatch
-            | stellar_xdr::next::Error::NonZeroPadding
-            | stellar_xdr::next::Error::Utf8Error(_)
-            | stellar_xdr::next::Error::InvalidHex
-            | stellar_xdr::next::Error::Io(_)
-            | stellar_xdr::next::Error::DepthLimitExceeded
-            | stellar_xdr::next::Error::LengthLimitExceeded => Error::WriteXdrNext(e),
-            stellar_xdr::next::Error::Json(_) => Error::ReadJsonNext(e),
+            crate::next::Error::Invalid
+            | crate::next::Error::Unsupported
+            | crate::next::Error::LengthExceedsMax
+            | crate::next::Error::LengthMismatch
+            | crate::next::Error::NonZeroPadding
+            | crate::next::Error::Utf8Error(_)
+            | crate::next::Error::InvalidHex
+            | crate::next::Error::Io(_)
+            | crate::next::Error::DepthLimitExceeded
+            | crate::next::Error::LengthLimitExceeded => Error::WriteXdrNext(e),
+            crate::next::Error::Json(_) => Error::ReadJsonNext(e),
         }
     }
 }
@@ -107,19 +107,16 @@ impl Default for OutputFormat {
 macro_rules! run_x {
     ($f:ident, $m:ident) => {
         fn $f(&self) -> Result<(), Error> {
-            use stellar_xdr::$m::WriteXdr;
+            use crate::$m::WriteXdr;
             let mut files = self.files()?;
-            let r#type = stellar_xdr::$m::TypeVariant::from_str(&self.r#type).map_err(|_| {
-                Error::UnknownType(
-                    self.r#type.clone(),
-                    &stellar_xdr::$m::TypeVariant::VARIANTS_STR,
-                )
+            let r#type = crate::$m::TypeVariant::from_str(&self.r#type).map_err(|_| {
+                Error::UnknownType(self.r#type.clone(), &crate::$m::TypeVariant::VARIANTS_STR)
             })?;
             for f in &mut files {
                 match self.input {
                     InputFormat::Json => {
-                        let t = stellar_xdr::$m::Type::read_json(r#type, f)?;
-                        let l = stellar_xdr::$m::Limits::none();
+                        let t = crate::$m::Type::read_json(r#type, f)?;
+                        let l = crate::$m::Limits::none();
 
                         match self.output {
                             OutputFormat::Single => stdout().write_all(&t.to_xdr(l)?)?,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,0 +1,67 @@
+mod decode;
+mod encode;
+mod guess;
+mod types;
+mod version;
+
+use clap::{Parser, Subcommand, ValueEnum};
+use std::{error::Error, fmt::Debug};
+
+#[derive(Parser, Debug, Clone)]
+#[command(
+    author,
+    version,
+    about,
+    long_about = None,
+    disable_help_subcommand = true,
+    disable_version_flag = true,
+    disable_colored_help = true,
+    infer_subcommands = true,
+)]
+struct Root {
+    /// Channel of XDR to operate on
+    #[arg(value_enum, default_value_t)]
+    channel: Channel,
+    #[command(subcommand)]
+    cmd: Cmd,
+}
+
+#[derive(ValueEnum, Debug, Clone)]
+pub(crate) enum Channel {
+    #[value(name = "+curr")]
+    Curr,
+    #[value(name = "+next")]
+    Next,
+}
+
+impl Default for Channel {
+    fn default() -> Self {
+        Self::Curr
+    }
+}
+
+#[derive(Subcommand, Debug, Clone)]
+enum Cmd {
+    /// View information about types
+    Types(types::Cmd),
+    /// Guess the XDR type
+    Guess(guess::Cmd),
+    /// Decode XDR
+    Decode(decode::Cmd),
+    /// Encode XDR
+    Encode(encode::Cmd),
+    /// Print version information
+    Version,
+}
+
+pub fn run() -> Result<(), Box<dyn Error>> {
+    let root = Root::try_parse()?;
+    match root.cmd {
+        Cmd::Types(c) => c.run(&root.channel)?,
+        Cmd::Guess(c) => c.run(&root.channel)?,
+        Cmd::Decode(c) => c.run(&root.channel)?,
+        Cmd::Encode(c) => c.run(&root.channel)?,
+        Cmd::Version => version::Cmd::run(),
+    }
+    Ok(())
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -18,7 +18,7 @@ use std::{error::Error, ffi::OsString, fmt::Debug};
     disable_colored_help = true,
     infer_subcommands = true,
 )]
-struct Root {
+pub struct Root {
     /// Channel of XDR to operate on
     #[arg(value_enum, default_value_t)]
     channel: Channel,
@@ -27,7 +27,7 @@ struct Root {
 }
 
 #[derive(ValueEnum, Debug, Clone)]
-pub(crate) enum Channel {
+pub enum Channel {
     #[value(name = "+curr")]
     Curr,
     #[value(name = "+next")]
@@ -41,7 +41,7 @@ impl Default for Channel {
 }
 
 #[derive(Subcommand, Debug, Clone)]
-enum Cmd {
+pub enum Cmd {
     /// View information about types
     Types(types::Cmd),
     /// Guess the XDR type

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -54,6 +54,13 @@ enum Cmd {
     Version,
 }
 
+/// Run the CLI.
+///
+/// TODO: How to pass in input to run from other CLI?
+///
+/// ## Errors
+///
+/// If the input cannot be parsed.
 pub fn run() -> Result<(), Box<dyn Error>> {
     let root = Root::try_parse()?;
     match root.cmd {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -5,7 +5,7 @@ mod types;
 mod version;
 
 use clap::{Parser, Subcommand, ValueEnum};
-use std::{error::Error, fmt::Debug};
+use std::{error::Error, ffi::OsString, fmt::Debug};
 
 #[derive(Parser, Debug, Clone)]
 #[command(
@@ -54,15 +54,17 @@ enum Cmd {
     Version,
 }
 
-/// Run the CLI.
-///
-/// TODO: How to pass in input to run from other CLI?
+/// Run the CLI with the given args.
 ///
 /// ## Errors
 ///
 /// If the input cannot be parsed.
-pub fn run() -> Result<(), Box<dyn Error>> {
-    let root = Root::try_parse()?;
+pub fn run<I, T>(args: I) -> Result<(), Box<dyn Error>>
+where
+    I: IntoIterator<Item = T>,
+    T: Into<OsString> + Clone,
+{
+    let root = Root::try_parse_from(args)?;
     match root.cmd {
         Cmd::Types(c) => c.run(&root.channel)?,
         Cmd::Guess(c) => c.run(&root.channel)?,

--- a/src/cli/types.rs
+++ b/src/cli/types.rs
@@ -1,7 +1,5 @@
 mod list;
 
-use std::error::Error;
-
 use clap::{Args, Subcommand};
 
 use crate::cli::Channel;
@@ -19,10 +17,9 @@ pub enum Sub {
 }
 
 impl Cmd {
-    pub fn run(&self, channel: &Channel) -> Result<(), Box<dyn Error>> {
+    pub fn run(&self, channel: &Channel) {
         match &self.sub {
-            Sub::List(c) => c.run(channel)?,
+            Sub::List(c) => c.run(channel),
         }
-        Ok(())
     }
 }

--- a/src/cli/types.rs
+++ b/src/cli/types.rs
@@ -4,7 +4,7 @@ use std::error::Error;
 
 use clap::{Args, Subcommand};
 
-use crate::Channel;
+use crate::cli::Channel;
 
 #[derive(Args, Debug, Clone)]
 #[command()]

--- a/src/cli/types/list.rs
+++ b/src/cli/types/list.rs
@@ -1,7 +1,7 @@
 use clap::{Args, ValueEnum};
 use std::error::Error;
 
-use crate::Channel;
+use crate::cli::Channel;
 
 #[derive(Args, Debug, Clone)]
 #[command()]
@@ -45,8 +45,8 @@ impl Cmd {
 
     fn types(channel: &Channel) -> Vec<&'static str> {
         let types: &[&str] = match channel {
-            Channel::Curr => &stellar_xdr::curr::TypeVariant::VARIANTS_STR,
-            Channel::Next => &stellar_xdr::next::TypeVariant::VARIANTS_STR,
+            Channel::Curr => &crate::curr::TypeVariant::VARIANTS_STR,
+            Channel::Next => &crate::next::TypeVariant::VARIANTS_STR,
         };
         let mut types: Vec<&'static str> = types.to_vec();
         types.sort_unstable();

--- a/src/cli/types/list.rs
+++ b/src/cli/types/list.rs
@@ -1,5 +1,4 @@
 use clap::{Args, ValueEnum};
-use std::error::Error;
 
 use crate::cli::Channel;
 
@@ -25,7 +24,7 @@ impl Default for OutputFormat {
 }
 
 impl Cmd {
-    pub fn run(&self, channel: &Channel) -> Result<(), Box<dyn Error>> {
+    pub fn run(&self, channel: &Channel) {
         let types = Self::types(channel);
         match self.output {
             OutputFormat::Plain => {
@@ -34,13 +33,12 @@ impl Cmd {
                 }
             }
             OutputFormat::Json => {
-                println!("{}", serde_json::to_string(&types)?);
+                println!("{}", serde_json::to_string(&types).unwrap());
             }
             OutputFormat::JsonFormatted => {
-                println!("{}", serde_json::to_string_pretty(&types)?);
+                println!("{}", serde_json::to_string_pretty(&types).unwrap());
             }
         }
-        Ok(())
     }
 
     fn types(channel: &Channel) -> Vec<&'static str> {

--- a/src/cli/version.rs
+++ b/src/cli/version.rs
@@ -1,12 +1,14 @@
 use clap::Parser;
 
+use crate::VERSION;
+
 #[derive(Parser, Debug, Clone)]
 #[command()]
 pub struct Cmd;
 
 impl Cmd {
     pub fn run() {
-        let v = stellar_xdr::VERSION;
+        let v = VERSION;
         println!(
             "stellar-xdr {} ({})
 xdr (+curr): {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,3 +123,6 @@ pub mod curr;
 
 #[cfg(feature = "next")]
 pub mod next;
+
+#[cfg(feature = "cli")]
+pub mod cli;


### PR DESCRIPTION
### What
Move the CLI functionality into the library.

### Why
So that it can be imported into the soroban-cli.

Close https://github.com/stellar/soroban-tools/issues/1018