### PR TITLE
Update min version of escape-bytes required to get bug fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ stellar-strkey = { version = "0.0.8", optional = true }
 base64 = { version = "0.13.0", optional = true }
 serde = { version = "1.0.139", features = ["derive"], optional = true }
 serde_with = { version = "3.0.0", optional = true }
-escape-bytes = { version = "0.1.0", default-features = false }
+escape-bytes = { version = "0.1.1", default-features = false }
 hex = { version = "0.4.3", optional = true }
 arbitrary = {version = "1.1.3", features = ["derive"], optional = true}
 clap = { version = "4.2.4", default-features = false, features = ["std", "derive", "usage", "help"], optional = true }


### PR DESCRIPTION
### What
Update min version of escape-bytes required to get bug fix

### Why
I accidentally imported alloc into escape-bytes without it being behind a feature gate. That causes alloc to be imported upstream in places it can't be, like the soroban-sdk.