### PR TITLE
Add fn for running the root cli command

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -26,6 +26,19 @@ pub struct Root {
     cmd: Cmd,
 }
 
+impl Root {
+    pub fn run(&self) -> Result<(), Error> {
+        match &self.cmd {
+            Cmd::Types(c) => c.run(&self.channel),
+            Cmd::Guess(c) => c.run(&self.channel)?,
+            Cmd::Decode(c) => c.run(&self.channel)?,
+            Cmd::Encode(c) => c.run(&self.channel)?,
+            Cmd::Version => version::Cmd::run(),
+        }
+        Ok(())
+    }
+}
+
 #[derive(ValueEnum, Debug, Clone)]
 pub enum Channel {
     #[value(name = "+curr")]
@@ -78,12 +91,5 @@ where
     T: Into<OsString> + Clone,
 {
     let root = Root::try_parse_from(args)?;
-    match root.cmd {
-        Cmd::Types(c) => c.run(&root.channel),
-        Cmd::Guess(c) => c.run(&root.channel)?,
-        Cmd::Decode(c) => c.run(&root.channel)?,
-        Cmd::Encode(c) => c.run(&root.channel)?,
-        Cmd::Version => version::Cmd::run(),
-    }
-    Ok(())
+    root.run()
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -27,6 +27,11 @@ pub struct Root {
 }
 
 impl Root {
+    /// Run the CLIs root command.
+    ///
+    /// ## Errors
+    ///
+    /// If the root command is configured with state that is invalid.
     pub fn run(&self) -> Result<(), Error> {
         match &self.cmd {
             Cmd::Types(c) => c.run(&self.channel),


### PR DESCRIPTION
### What
Add fn for running the root cli command.

### Why
For embedding into the soroban-cli. The best way to embed the XDR CLI is to reuse the type structures, which we can do, however the internals of the Root command are private and so there's no way to use the XDR CLI Root once parsing by clap is complete.

We could do two things, expose the fields as public, or expose the run behavior that already exists in this lib. Given the goal is to replicate behavior, exposing the existing run function seemed like the appropriate way to solve this problem.

For stellar/soroban-tools#1018

### Releasing

This change is intended for releasing as a patch release then propagating through the env and sdk repos such that the following change could be released:
- https://github.com/stellar/soroban-tools/pull/1135

Even though this change is intended as a patch release this repo has no changes existing or planned on main and since the last release and so this change is targeting main and the patch release will be made from there.