### PR TITLE
Encode claimable balance ids to match Horizon in JSON

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ CARGO_HACK_ARGS=--feature-powerset --exclude-features default --group-features b
 CARGO_DOC_ARGS?=--open
 
 XDRGEN_VERSION=e2cac557162d99b12ae73b846cf3d5bfe16636de
-XDRGEN_TYPES_CUSTOM_STR_IMPL_CURR=PublicKey,AccountId,MuxedAccount,MuxedAccountMed25519,SignerKey,SignerKeyEd25519SignedPayload,NodeId,ScAddress,AssetCode,AssetCode4,AssetCode12
-XDRGEN_TYPES_CUSTOM_STR_IMPL_NEXT=PublicKey,AccountId,MuxedAccount,MuxedAccountMed25519,SignerKey,SignerKeyEd25519SignedPayload,NodeId,ScAddress,AssetCode,AssetCode4,AssetCode12
+XDRGEN_TYPES_CUSTOM_STR_IMPL_CURR=PublicKey,AccountId,MuxedAccount,MuxedAccountMed25519,SignerKey,SignerKeyEd25519SignedPayload,NodeId,ScAddress,AssetCode,AssetCode4,AssetCode12,ClaimableBalanceId
+XDRGEN_TYPES_CUSTOM_STR_IMPL_NEXT=PublicKey,AccountId,MuxedAccount,MuxedAccountMed25519,SignerKey,SignerKeyEd25519SignedPayload,NodeId,ScAddress,AssetCode,AssetCode4,AssetCode12,ClaimableBalanceId
 
 all: build test
 

--- a/src/curr/generated.rs
+++ b/src/curr/generated.rs
@@ -14504,8 +14504,7 @@ impl WriteXdr for ClaimableBalanceIdType {
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
-    derive(serde::Serialize, serde::Deserialize),
-    serde(rename_all = "snake_case")
+    derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr)
 )]
 #[allow(clippy::large_enum_variant)]
 pub enum ClaimableBalanceId {

--- a/src/curr/str.rs
+++ b/src/curr/str.rs
@@ -18,11 +18,15 @@
 //# - AssetCode
 //# - AssetCode4
 //# - AssetCode12
-#![cfg(feature = "alloc")]
+//#
+//# ## Other
+//# - ClaimableBalanceId
+#![cfg(feature = "std")]
 
 use super::{
-    AccountId, AssetCode, AssetCode12, AssetCode4, Error, Hash, MuxedAccount, MuxedAccountMed25519,
-    NodeId, PublicKey, ScAddress, SignerKey, SignerKeyEd25519SignedPayload, Uint256,
+    AccountId, AssetCode, AssetCode12, AssetCode4, ClaimableBalanceId, Error, Hash, Limits,
+    MuxedAccount, MuxedAccountMed25519, NodeId, PublicKey, ReadXdr, ScAddress, SignerKey,
+    SignerKeyEd25519SignedPayload, Uint256, WriteXdr,
 };
 
 impl From<stellar_strkey::DecodeError> for Error {
@@ -334,5 +338,34 @@ impl core::fmt::Display for AssetCode {
             AssetCode::CreditAlphanum4(c) => c.fmt(f),
             AssetCode::CreditAlphanum12(c) => c.fmt(f),
         }
+    }
+}
+
+impl core::str::FromStr for ClaimableBalanceId {
+    type Err = Error;
+    fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
+        let bytes = hex::decode(s).map_err(|_| Error::InvalidHex)?;
+        ClaimableBalanceId::from_xdr(
+            bytes,
+            // No limit is safe for encoding ClaimableBalanceId as the type is a
+            // fixed size type.
+            Limits::none(),
+        )
+    }
+}
+
+impl core::fmt::Display for ClaimableBalanceId {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let bytes = self
+            .to_xdr(
+                // No limit is safe for encoding ClaimableBalanceId as the type is a
+                // fixed size type.
+                Limits::none(),
+            )
+            .map_err(|_| core::fmt::Error)?;
+        for b in bytes {
+            write!(f, "{b:02x}")?;
+        }
+        Ok(())
     }
 }

--- a/src/curr/str.rs
+++ b/src/curr/str.rs
@@ -344,6 +344,10 @@ impl core::fmt::Display for AssetCode {
 impl core::str::FromStr for ClaimableBalanceId {
     type Err = Error;
     fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
+        // This conversion to a hex string could be done by XDR encoding the
+        // self value, but because XDR encoding requires the std feature, this
+        // approach is taken instead to preserve the fact that the serde feature
+        // is available with alloc only.
         let bytes = hex::decode(s).map_err(|_| Error::InvalidHex)?;
         match bytes.as_slice() {
             [0, 0, 0, 0, ..] => Ok(ClaimableBalanceId::ClaimableBalanceIdTypeV0(Hash(
@@ -356,6 +360,10 @@ impl core::str::FromStr for ClaimableBalanceId {
 
 impl core::fmt::Display for ClaimableBalanceId {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        // This conversion from a hex string could be done by XDR decoding the
+        // self value, but because XDR decoding requires the std feature, this
+        // approach is taken instead to preserve the fact that the serde feature
+        // is available with alloc only.
         match self {
             ClaimableBalanceId::ClaimableBalanceIdTypeV0(Hash(bytes)) => {
                 for b in [0u8, 0, 0, 0] {

--- a/src/next/generated.rs
+++ b/src/next/generated.rs
@@ -14504,8 +14504,7 @@ impl WriteXdr for ClaimableBalanceIdType {
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
-    derive(serde::Serialize, serde::Deserialize),
-    serde(rename_all = "snake_case")
+    derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr)
 )]
 #[allow(clippy::large_enum_variant)]
 pub enum ClaimableBalanceId {

--- a/src/next/str.rs
+++ b/src/next/str.rs
@@ -21,12 +21,12 @@
 //#
 //# ## Other
 //# - ClaimableBalanceId
-#![cfg(feature = "std")]
+#![cfg(feature = "alloc")]
 
 use super::{
-    AccountId, AssetCode, AssetCode12, AssetCode4, ClaimableBalanceId, Error, Hash, Limits,
-    MuxedAccount, MuxedAccountMed25519, NodeId, PublicKey, ReadXdr, ScAddress, SignerKey,
-    SignerKeyEd25519SignedPayload, Uint256, WriteXdr,
+    AccountId, AssetCode, AssetCode12, AssetCode4, ClaimableBalanceId, Error, Hash, MuxedAccount,
+    MuxedAccountMed25519, NodeId, PublicKey, ScAddress, SignerKey, SignerKeyEd25519SignedPayload,
+    Uint256,
 };
 
 impl From<stellar_strkey::DecodeError> for Error {
@@ -333,27 +333,35 @@ impl core::fmt::Display for AssetCode {
 impl core::str::FromStr for ClaimableBalanceId {
     type Err = Error;
     fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
+        // This conversion to a hex string could be done by XDR encoding the
+        // self value, but because XDR encoding requires the std feature, this
+        // approach is taken instead to preserve the fact that the serde feature
+        // is available with alloc only.
         let bytes = hex::decode(s).map_err(|_| Error::InvalidHex)?;
-        ClaimableBalanceId::from_xdr(
-            bytes,
-            // No limit is safe for encoding ClaimableBalanceId as the type is a
-            // fixed size type.
-            Limits::none(),
-        )
+        match bytes.as_slice() {
+            [0, 0, 0, 0, ..] => Ok(ClaimableBalanceId::ClaimableBalanceIdTypeV0(Hash(
+                (&bytes[4..]).try_into()?,
+            ))),
+            _ => Err(Error::Invalid),
+        }
     }
 }
 
 impl core::fmt::Display for ClaimableBalanceId {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let bytes = self
-            .to_xdr(
-                // No limit is safe for encoding ClaimableBalanceId as the type is a
-                // fixed size type.
-                Limits::none(),
-            )
-            .map_err(|_| core::fmt::Error)?;
-        for b in bytes {
-            write!(f, "{b:02x}")?;
+        // This conversion from a hex string could be done by XDR decoding the
+        // self value, but because XDR decoding requires the std feature, this
+        // approach is taken instead to preserve the fact that the serde feature
+        // is available with alloc only.
+        match self {
+            ClaimableBalanceId::ClaimableBalanceIdTypeV0(Hash(bytes)) => {
+                for b in [0u8, 0, 0, 0] {
+                    write!(f, "{b:02x}")?;
+                }
+                for b in bytes {
+                    write!(f, "{b:02x}")?;
+                }
+            }
         }
         Ok(())
     }

--- a/src/next/str.rs
+++ b/src/next/str.rs
@@ -18,11 +18,15 @@
 //# - AssetCode
 //# - AssetCode4
 //# - AssetCode12
-#![cfg(feature = "alloc")]
+//#
+//# ## Other
+//# - ClaimableBalanceId
+#![cfg(feature = "std")]
 
 use super::{
-    AccountId, AssetCode, AssetCode12, AssetCode4, Error, Hash, MuxedAccount, MuxedAccountMed25519,
-    NodeId, PublicKey, ScAddress, SignerKey, SignerKeyEd25519SignedPayload, Uint256,
+    AccountId, AssetCode, AssetCode12, AssetCode4, ClaimableBalanceId, Error, Hash, Limits,
+    MuxedAccount, MuxedAccountMed25519, NodeId, PublicKey, ReadXdr, ScAddress, SignerKey,
+    SignerKeyEd25519SignedPayload, Uint256, WriteXdr,
 };
 
 impl From<stellar_strkey::DecodeError> for Error {
@@ -323,5 +327,34 @@ impl core::fmt::Display for AssetCode {
             AssetCode::CreditAlphanum4(c) => c.fmt(f),
             AssetCode::CreditAlphanum12(c) => c.fmt(f),
         }
+    }
+}
+
+impl core::str::FromStr for ClaimableBalanceId {
+    type Err = Error;
+    fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
+        let bytes = hex::decode(s).map_err(|_| Error::InvalidHex)?;
+        ClaimableBalanceId::from_xdr(
+            bytes,
+            // No limit is safe for encoding ClaimableBalanceId as the type is a
+            // fixed size type.
+            Limits::none(),
+        )
+    }
+}
+
+impl core::fmt::Display for ClaimableBalanceId {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let bytes = self
+            .to_xdr(
+                // No limit is safe for encoding ClaimableBalanceId as the type is a
+                // fixed size type.
+                Limits::none(),
+            )
+            .map_err(|_| core::fmt::Error)?;
+        for b in bytes {
+            write!(f, "{b:02x}")?;
+        }
+        Ok(())
     }
 }

--- a/tests/str.rs
+++ b/tests/str.rs
@@ -555,11 +555,11 @@ fn claimable_balance_id() {
     // Half byte short.
     assert_eq!(ClaimableBalanceId::from_str("00000000010101010101010101010101010101010101010101010101010101010101010"), Err(Error::InvalidHex));
     // Full byte short.
-    assert_eq!(ClaimableBalanceId::from_str("0000000001010101010101010101010101010101010101010101010101010101010101"), Err(Error::Io(std::io::Error::new(std::io::ErrorKind::UnexpectedEof, "failed to fill whole buffer"))));
+    assert_eq!(ClaimableBalanceId::from_str("0000000001010101010101010101010101010101010101010101010101010101010101"), Err(Error::LengthMismatch));
     // Half byte too long.
     assert_eq!(ClaimableBalanceId::from_str("0000000001010101010101010101010101010101010101010101010101010101010101011"), Err(Error::InvalidHex));
     // Full byte too long.
-    assert_eq!(ClaimableBalanceId::from_str("00000000010101010101010101010101010101010101010101010101010101010101010101"), Err(Error::Invalid));
+    assert_eq!(ClaimableBalanceId::from_str("00000000010101010101010101010101010101010101010101010101010101010101010101"), Err(Error::LengthMismatch));
     // Unrecognized discriminant value.
     assert_eq!(ClaimableBalanceId::from_str("000000010101010101010101010101010101010101010101010101010101010101010101"), Err(Error::Invalid));
 }

--- a/tests/str.rs
+++ b/tests/str.rs
@@ -4,8 +4,9 @@
 use stellar_xdr::curr as stellar_xdr;
 
 use stellar_xdr::{
-    AccountId, AssetCode, AssetCode12, AssetCode4, Error, Hash, MuxedAccount, MuxedAccountMed25519,
-    NodeId, PublicKey, ScAddress, SignerKey, SignerKeyEd25519SignedPayload, Uint256,
+    AccountId, AssetCode, AssetCode12, AssetCode4, ClaimableBalanceId, Error, Hash, MuxedAccount,
+    MuxedAccountMed25519, NodeId, PublicKey, ScAddress, SignerKey, SignerKeyEd25519SignedPayload,
+    Uint256,
 };
 
 use std::str::FromStr;
@@ -540,4 +541,25 @@ fn asset_code_from_str_to_string_roundtrip_unicode() {
     // Unicode Replacement Character, which would be two bytes.
     assert_eq!(AssetCode::CreditAlphanum4(AssetCode4(*b"a\xc3\xc3d")).to_string(), r"a\xc3\xc3d");
     assert_eq!(AssetCode::from_str(r"a\xc3\xc3d"), Ok(AssetCode::CreditAlphanum4(AssetCode4(*b"a\xc3\xc3d"))));
+}
+
+#[test]
+#[rustfmt::skip]
+fn claimable_balance_id() {
+    assert_eq!(
+        ClaimableBalanceId::ClaimableBalanceIdTypeV0(Hash([1u8; 32])).to_string(),
+        "000000000101010101010101010101010101010101010101010101010101010101010101",
+    );
+    // Valid
+    assert_eq!(ClaimableBalanceId::from_str("000000000101010101010101010101010101010101010101010101010101010101010101"), Ok(ClaimableBalanceId::ClaimableBalanceIdTypeV0(Hash([1u8; 32]))));
+    // Half byte short.
+    assert_eq!(ClaimableBalanceId::from_str("00000000010101010101010101010101010101010101010101010101010101010101010"), Err(Error::InvalidHex));
+    // Full byte short.
+    assert_eq!(ClaimableBalanceId::from_str("0000000001010101010101010101010101010101010101010101010101010101010101"), Err(Error::Io(std::io::Error::new(std::io::ErrorKind::UnexpectedEof, "failed to fill whole buffer"))));
+    // Half byte too long.
+    assert_eq!(ClaimableBalanceId::from_str("0000000001010101010101010101010101010101010101010101010101010101010101011"), Err(Error::InvalidHex));
+    // Full byte too long.
+    assert_eq!(ClaimableBalanceId::from_str("00000000010101010101010101010101010101010101010101010101010101010101010101"), Err(Error::Invalid));
+    // Unrecognized discriminant value.
+    assert_eq!(ClaimableBalanceId::from_str("000000010101010101010101010101010101010101010101010101010101010101010101"), Err(Error::Invalid));
 }


### PR DESCRIPTION
### What
Encode claimable balance ids to match Horizon in JSON

### Why
Claimable balances are rendered as a hex string contained in an object with the v0 discriminant.

In Horizon, claimable balance IDs are rendered by hex encoding the XDR for the object structure.

Given that folks are used to the Horizon rendering, we should use that in the JSON <> XDR as well.

Close #367