### PR TITLE
Skip whitespace in base64 encoded inputs given to the CLI

### DIFF
--- a/src/cli/decode.rs
+++ b/src/cli/decode.rs
@@ -84,32 +84,32 @@ macro_rules! run_x {
             for f in &mut files {
                 match self.input {
                     InputFormat::Single => {
-                        let mut f = crate::$m::Limited::new(f, crate::$m::Limits::none());
-                        let t = crate::$m::Type::read_xdr_to_end(r#type, &mut f)?;
+                        let mut l = crate::$m::Limited::new(f, crate::$m::Limits::none());
+                        let t = crate::$m::Type::read_xdr_to_end(r#type, &mut l)?;
                         self.out(&t)?;
                     }
                     InputFormat::SingleBase64 => {
-                        let f = SkipWhitespace::new(f);
-                        let mut f = crate::$m::Limited::new(f, crate::$m::Limits::none());
-                        let t = crate::$m::Type::read_xdr_base64_to_end(r#type, &mut f)?;
+                        let sw = SkipWhitespace::new(f);
+                        let mut l = crate::$m::Limited::new(sw, crate::$m::Limits::none());
+                        let t = crate::$m::Type::read_xdr_base64_to_end(r#type, &mut l)?;
                         self.out(&t)?;
                     }
                     InputFormat::Stream => {
-                        let mut f = crate::$m::Limited::new(f, crate::$m::Limits::none());
-                        for t in crate::$m::Type::read_xdr_iter(r#type, &mut f) {
+                        let mut l = crate::$m::Limited::new(f, crate::$m::Limits::none());
+                        for t in crate::$m::Type::read_xdr_iter(r#type, &mut l) {
                             self.out(&t?)?;
                         }
                     }
                     InputFormat::StreamBase64 => {
-                        let f = SkipWhitespace::new(f);
-                        let mut f = crate::$m::Limited::new(f, crate::$m::Limits::none());
-                        for t in crate::$m::Type::read_xdr_base64_iter(r#type, &mut f) {
+                        let sw = SkipWhitespace::new(f);
+                        let mut l = crate::$m::Limited::new(sw, crate::$m::Limits::none());
+                        for t in crate::$m::Type::read_xdr_base64_iter(r#type, &mut l) {
                             self.out(&t?)?;
                         }
                     }
                     InputFormat::StreamFramed => {
-                        let mut f = crate::$m::Limited::new(f, crate::$m::Limits::none());
-                        for t in crate::$m::Type::read_xdr_framed_iter(r#type, &mut f) {
+                        let mut l = crate::$m::Limited::new(f, crate::$m::Limits::none());
+                        for t in crate::$m::Type::read_xdr_framed_iter(r#type, &mut l) {
                             self.out(&t?)?;
                         }
                     }

--- a/src/cli/decode.rs
+++ b/src/cli/decode.rs
@@ -9,7 +9,7 @@ use std::{
 use clap::{Args, ValueEnum};
 use serde::Serialize;
 
-use crate::cli::Channel;
+use crate::cli::{skip_whitespace::SkipWhitespace, Channel};
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -82,27 +82,33 @@ macro_rules! run_x {
                 Error::UnknownType(self.r#type.clone(), &crate::$m::TypeVariant::VARIANTS_STR)
             })?;
             for f in &mut files {
-                let mut f = crate::$m::Limited::new(f, crate::$m::Limits::none());
                 match self.input {
                     InputFormat::Single => {
+                        let mut f = crate::$m::Limited::new(f, crate::$m::Limits::none());
                         let t = crate::$m::Type::read_xdr_to_end(r#type, &mut f)?;
                         self.out(&t)?;
                     }
                     InputFormat::SingleBase64 => {
+                        let f = SkipWhitespace::new(f);
+                        let mut f = crate::$m::Limited::new(f, crate::$m::Limits::none());
                         let t = crate::$m::Type::read_xdr_base64_to_end(r#type, &mut f)?;
                         self.out(&t)?;
                     }
                     InputFormat::Stream => {
+                        let mut f = crate::$m::Limited::new(f, crate::$m::Limits::none());
                         for t in crate::$m::Type::read_xdr_iter(r#type, &mut f) {
                             self.out(&t?)?;
                         }
                     }
                     InputFormat::StreamBase64 => {
+                        let f = SkipWhitespace::new(f);
+                        let mut f = crate::$m::Limited::new(f, crate::$m::Limits::none());
                         for t in crate::$m::Type::read_xdr_base64_iter(r#type, &mut f) {
                             self.out(&t?)?;
                         }
                     }
                     InputFormat::StreamFramed => {
+                        let mut f = crate::$m::Limited::new(f, crate::$m::Limits::none());
                         for t in crate::$m::Type::read_xdr_framed_iter(r#type, &mut f) {
                             self.out(&t?)?;
                         }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,6 +1,7 @@
 pub mod decode;
 pub mod encode;
 pub mod guess;
+mod skip_whitespace;
 pub mod types;
 mod version;
 

--- a/src/cli/skip_whitespace.rs
+++ b/src/cli/skip_whitespace.rs
@@ -1,0 +1,70 @@
+use std::io::Read;
+
+/// Forwards read operations to the wrapped object, skipping over any whitespace
+/// in what is written to buf when the function returns.
+pub struct SkipWhitespace<R: Read> {
+    inner: R,
+}
+
+impl<R: Read> SkipWhitespace<R> {
+    pub fn new(inner: R) -> Self {
+        SkipWhitespace { inner }
+    }
+}
+
+impl<R: Read> Read for SkipWhitespace<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.inner.read(buf)?;
+
+        let mut written = 0;
+        for read in 0..n {
+            if !buf[read].is_ascii_whitespace() {
+                buf[written] = buf[read];
+                written += 1;
+            }
+        }
+
+        Ok(written)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test() {
+        struct Test {
+            input: &'static [u8],
+            output: &'static [u8],
+        }
+        let tests = [
+            Test {
+                input: b"",
+                output: b"",
+            },
+            Test {
+                input: b" \n\t\r",
+                output: b"",
+            },
+            Test {
+                input: b"a c",
+                output: b"ac",
+            },
+            Test {
+                input: b"ab cd",
+                output: b"abcd",
+            },
+            Test {
+                input: b" ab \n cd ",
+                output: b"abcd",
+            },
+        ];
+        for (i, t) in tests.iter().enumerate() {
+            let mut skip = SkipWhitespace::new(t.input);
+            let mut output = Vec::new();
+            skip.read_to_end(&mut output).unwrap();
+            assert_eq!(output, t.output, "#{i}");
+        }
+    }
+}

--- a/src/cli/skip_whitespace.rs
+++ b/src/cli/skip_whitespace.rs
@@ -1,9 +1,9 @@
 use std::io::Read;
 
-/// Forwards read operations to the wrapped object, skipping over any whitespace
-/// in what is written to buf when the function returns.
+/// Forwards read operations to the wrapped object, skipping over any
+/// whitespace.
 pub struct SkipWhitespace<R: Read> {
-    inner: R,
+    pub inner: R,
 }
 
 impl<R: Read> SkipWhitespace<R> {


### PR DESCRIPTION
### What
Skip whitespace in base64 encoded inputs given to the CLI.

### Why
It's easy for spaces and new lines to end up in base64 inputs either because folks copy a base64 input and the following new line, or they pipe a value using `echo` without the `-n`, or they pipe a value from another command line tool that appends a new line, or they copy a base64 value that has been hard wrapped.

There's not really any reason to fail parsing these inputs in the CLI. The CLI is intended to be convenient to use by humans.

Note that I considered making this change to the base64 decoder in the XDR library itself, but I think this convenience feature is most impactful and meaningful to users when they are interacting with the CLI, and to introduce this into other places like the XDR lib is likely to not be impactful or if it is in a surprising way.

Close #375