### PR TITLE
Bump Rust version to 1.79

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Stellar Development Foundation <info@stellar.org>"]
 license = "Apache-2.0"
 version = "21.2.0"
 edition = "2021"
-rust-version = "1.74.0"
+rust-version = "1.79.0"
 
 [[bin]]
 name = "stellar-xdr"
@@ -15,7 +15,7 @@ path = "src/bin/stellar-xdr/main.rs"
 required-features = ["cli"]
 doctest = false
 
-[build_dependencies]
+[build-dependencies]
 crate-git-revision = "0.0.6"
 
 [dependencies]
@@ -31,7 +31,7 @@ serde_json = { version = "1.0.89", optional = true }
 thiserror = { version = "1.0.37", optional = true }
 schemars = { version = "0.8.16", optional = true }
 
-[dev_dependencies]
+[dev-dependencies]
 serde_json = "1.0.89"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Stellar Development Foundation <info@stellar.org>"]
 license = "Apache-2.0"
 version = "21.2.0"
 edition = "2021"
-rust-version = "1.79.0"
+rust-version = "1.74.0"
 
 [[bin]]
 name = "stellar-xdr"

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,4 @@
 pub fn main() {
+    println!("cargo::rustc-check-cfg=cfg(docs)");
     crate_git_revision::init();
 }

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,4 @@
 pub fn main() {
-    println!("cargo::rustc-check-cfg=cfg(docs)");
+    println!("cargo:rustc-check-cfg=cfg(docs)");
     crate_git_revision::init();
 }


### PR DESCRIPTION
### What

Bump Rust version to 1.79

### Why

We're doing this bump for env and we need to fix the XDR library warnings anyways.

### Known limitations

N/A
