### PR TITLE
Bump Rust XDR version to 22.0.0.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "stellar-xdr"
-version = "21.2.0"
+version = "22.0.0"
 dependencies = [
  "arbitrary",
  "base64 0.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ homepage = "https://github.com/stellar/rs-stellar-xdr"
 repository = "https://github.com/stellar/rs-stellar-xdr"
 authors = ["Stellar Development Foundation <info@stellar.org>"]
 license = "Apache-2.0"
-version = "21.2.0"
+version = "22.0.0"
 edition = "2021"
 rust-version = "1.74.0"
 


### PR DESCRIPTION
### What

Bump Rust XDR version to 22.0.0.

### Why

It is necessary to bump XDR in order to be able to integrate XDR changes into Core (currently both old and new hosts use XDR v21.2.0).

### Known limitations

This is not the 'final' commit before the actual release and it is expected that we'll continue updating protocol 22 Wasm.
