### PR TITLE
feat: add support for `no_std` env

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,6 +251,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "embedded-io-cursor"
+version = "0.0.1"
+source = "git+https://github.com/lightsail-network/embedded-io-cursor?rev=0b7ff9270d7ec1d3204375650f04cb0258ac1ada#0b7ff9270d7ec1d3204375650f04cb0258ac1ada"
+dependencies = [
+ "embedded-io",
+]
+
+[[package]]
 name = "escape-bytes"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -523,13 +537,12 @@ dependencies = [
 
 [[package]]
 name = "stellar-strkey"
-version = "0.0.9"
+version = "0.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e3aa3ed00e70082cb43febc1c2afa5056b9bb3e348bbb43d0cd0aa88a611144"
+checksum = "0989c9a05eccbd08b60e603a1c7e3ed3ec92c0de73b8681fc964d272ab2b2697"
 dependencies = [
  "crate-git-revision",
  "data-encoding",
- "thiserror",
 ]
 
 [[package]]
@@ -540,6 +553,8 @@ dependencies = [
  "base64 0.13.0",
  "clap",
  "crate-git-revision",
+ "embedded-io",
+ "embedded-io-cursor",
  "escape-bytes",
  "hex",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,17 +19,20 @@ doctest = false
 crate-git-revision = "0.0.6"
 
 [dependencies]
-stellar-strkey = { version = "0.0.9", optional = true }
+stellar-strkey = { version = "0.0.11", optional = true }
 base64 = { version = "0.13.0", optional = true }
 serde = { version = "1.0.139", features = ["derive"], optional = true }
 serde_with = { version = "3.0.0", optional = true }
 escape-bytes = { version = "0.1.1", default-features = false }
-hex = { version = "0.4.3", optional = true }
-arbitrary = {version = "1.1.3", features = ["derive"], optional = true}
+hex = { version = "0.4.3", default-features = false, optional = true }
+arbitrary = { version = "1.1.3", features = ["derive"], optional = true }
 clap = { version = "4.2.4", default-features = false, features = ["std", "derive", "usage", "help"], optional = true }
 serde_json = { version = "1.0.89", optional = true }
 thiserror = { version = "1.0.37", optional = true }
 schemars = { version = "0.8.16", optional = true }
+embedded-io = { version = "0.6.1", default-features = false, optional = true }
+embedded-io-cursor = { git = "https://github.com/lightsail-network/embedded-io-cursor", rev = "0b7ff9270d7ec1d3204375650f04cb0258ac1ada", default-features = false, features = ["alloc"], optional = true }
+# TODO: embedded-io-cursor not published yet.
 
 [dev-dependencies]
 serde_json = "1.0.89"
@@ -37,7 +40,7 @@ serde_json = "1.0.89"
 [features]
 default = ["std", "curr"]
 std = ["alloc"]
-alloc = ["dep:hex", "dep:stellar-strkey", "escape-bytes/alloc"]
+alloc = ["dep:hex", "dep:stellar-strkey", "dep:embedded-io", "dep:embedded-io-cursor", "escape-bytes/alloc", "hex/alloc"]
 curr = []
 next = []
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ CARGO_HACK_ARGS=--feature-powerset --exclude-features default --group-features b
 
 CARGO_DOC_ARGS?=--open
 
-XDRGEN_VERSION=b7bc57ecdd277c9575930d3e17c12dfaa76655fc
+# TODO: Update this after https://github.com/stellar/xdrgen/pull/205 is merged
+XDRGEN_VERSION=ecf547f1bca98545378e55c7e55aa0ef3cf4e66a
 # XDRGEN_LOCAL=1
 XDRGEN_TYPES_CUSTOM_STR_IMPL_CURR=PublicKey,AccountId,MuxedAccount,MuxedAccountMed25519,SignerKey,SignerKeyEd25519SignedPayload,NodeId,ScAddress,AssetCode,AssetCode4,AssetCode12,ClaimableBalanceId
 XDRGEN_TYPES_CUSTOM_STR_IMPL_NEXT=PublicKey,AccountId,MuxedAccount,MuxedAccountMed25519,SignerKey,SignerKeyEd25519SignedPayload,NodeId,ScAddress,AssetCode,AssetCode4,AssetCode12,ClaimableBalanceId
@@ -44,7 +45,7 @@ src/curr/generated.rs: $(sort $(wildcard xdr/curr/*.x))
 ifeq ($(XDRGEN_LOCAL),)
 	docker run -i --rm -v $$PWD:/wd -w /wd docker.io/library/ruby:latest /bin/bash -c '\
 		gem install specific_install -v 0.3.8 && \
-		gem specific_install https://github.com/stellar/xdrgen.git -b $(XDRGEN_VERSION) && \
+		gem specific_install https://github.com/lightsail-network/xdrgen.git -b $(XDRGEN_VERSION) && \
 		xdrgen --language rust --namespace generated --output src/curr \
 			--rust-types-custom-str-impl $(XDRGEN_TYPES_CUSTOM_STR_IMPL_CURR) \
 			--rust-types-custom-jsonschema-impl '$(XDRGEN_TYPES_CUSTOM_JSONSCHEMA_IMPL_CURR)' \
@@ -69,7 +70,7 @@ src/next/generated.rs: $(sort $(wildcard xdr/next/*.x))
 ifeq ($(XDRGEN_LOCAL),)
 	docker run -i --rm -v $$PWD:/wd -w /wd docker.io/library/ruby:latest /bin/bash -c '\
 		gem install specific_install -v 0.3.8 && \
-		gem specific_install https://github.com/stellar/xdrgen.git -b $(XDRGEN_VERSION) && \
+		gem specific_install https://github.com/lightsail-network/xdrgen.git -b $(XDRGEN_VERSION) && \
 		xdrgen --language rust --namespace generated --output src/next \
 			--rust-types-custom-str-impl $(XDRGEN_TYPES_CUSTOM_STR_IMPL_NEXT) \
 			--rust-types-custom-jsonschema-impl '$(XDRGEN_TYPES_CUSTOM_JSONSCHEMA_IMPL_NEXT)' \

--- a/README.md
+++ b/README.md
@@ -32,14 +32,13 @@ decode), and is the default feature set.
 2. `alloc` – The alloc feature uses `Box` and `Vec` types for recursive
 references and arrays, and is automatically enabled if the std feature is
 enabled. The default global allocator is used. Support for a custom
-allocator will be added in [#39]. No encode or decode capability exists,
-only types. Encode and decode capability will be added in [#46].
+allocator will be added in [#39]. Encode or decode capability exists, 
+but still in an experimental stage, there may be breaking changes at any time.
 3. If std or alloc are not enabled recursive and array types requires static
 lifetime values. No encode or decode capability exists. Encode and decode
 capability will be added in [#47].
 
 [#39]: https://github.com/stellar/rs-stellar-xdr/issues/39
-[#46]: https://github.com/stellar/rs-stellar-xdr/issues/46
 [#47]: https://github.com/stellar/rs-stellar-xdr/issues/47
 
 Ancillary functionality:


### PR DESCRIPTION
### What

Add read/write capabilities to alloc feature when std not enabled.

### Why

Closes #46 

### Known limitations

TODO
