### PR TITLE
Add decode to CBOR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,6 +263,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "half"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,6 +467,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_cbor"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half",
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -544,6 +560,7 @@ dependencies = [
  "hex",
  "schemars",
  "serde",
+ "serde_cbor",
  "serde_json",
  "serde_with",
  "stellar-strkey",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ clap = { version = "4.2.4", default-features = false, features = ["std", "derive
 serde_json = { version = "1.0.89", optional = true }
 thiserror = { version = "1.0.37", optional = true }
 schemars = { version = "0.8.16", optional = true }
+serde_cbor = { version = "0.11.2", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0.89"
@@ -50,7 +51,7 @@ arbitrary = ["std", "dep:arbitrary"]
 hex = []
 
 # Features for the CLI.
-cli = ["std", "curr", "next", "base64", "serde", "serde_json", "schemars", "dep:clap", "dep:thiserror"]
+cli = ["std", "curr", "next", "base64", "serde", "serde_json", "schemars", "dep:clap", "dep:thiserror", "dep:serde_cbor"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/cli/decode.rs
+++ b/src/cli/decode.rs
@@ -23,6 +23,8 @@ pub enum Error {
     ReadFile(#[from] std::io::Error),
     #[error("error generating JSON: {0}")]
     GenerateJson(#[from] serde_json::Error),
+    #[error("error generating CBOR: {0}")]
+    GenerateCbor(#[from] serde_cbor::Error),
 }
 
 #[derive(Args, Debug, Clone)]
@@ -66,6 +68,7 @@ pub enum OutputFormat {
     JsonFormatted,
     RustDebug,
     RustDebugFormatted,
+    Cbor,
 }
 
 impl Default for OutputFormat {
@@ -158,6 +161,9 @@ impl Cmd {
             OutputFormat::JsonFormatted => println!("{}", serde_json::to_string_pretty(v)?),
             OutputFormat::RustDebug => println!("{v:?}"),
             OutputFormat::RustDebugFormatted => println!("{v:#?}"),
+            OutputFormat::Cbor => {
+                serde_cbor::to_writer(std::io::stdout(), v).map_err(Error::GenerateCbor)?
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
### What
Add decode XDR to CBOR.

### Why
I wrote this decode to CBOR to experiment with encoding contract specs in CBOR, that are currently encoded as XDR.

To install the CLI in this PR, run:
```
cargo install --locked --git https://github.com/stellar/rs-stellar-xdr --branch decode-to-cbor --features cli
```

To try out converting some XDR to CBOR:
```
cat spec.xdr | stellar-xdr decode --type ScSpecEntry --input stream --output cbor
```

Related discussion is here:
- https://discord.com/channels/897514728459468821/1283687871491997716/1284006942410539069