### PR TITLE
Add decode to Message Pack (compact variant)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,7 +118,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -213,7 +219,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.15",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -224,7 +230,7 @@ checksum = "7bfb82b62b1b8a2a9808fb4caf844ede819a76cfc23b2827d7f94eefb49551eb"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -398,21 +404,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.69"
+name = "paste"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rmp"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4"
+dependencies = [
+ "byteorder",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e599a477cf9840e92f2cde9a7189e67b42c57532749bf90aea6ec10facd4db"
+dependencies = [
+ "byteorder",
+ "rmp",
+ "serde",
 ]
 
 [[package]]
@@ -453,22 +487,22 @@ checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
 
 [[package]]
 name = "serde"
-version = "1.0.160"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.160"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -518,7 +552,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -542,6 +576,7 @@ dependencies = [
  "crate-git-revision",
  "escape-bytes",
  "hex",
+ "rmp-serde",
  "schemars",
  "serde",
  "serde_json",
@@ -569,9 +604,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.15"
+version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ clap = { version = "4.2.4", default-features = false, features = ["std", "derive
 serde_json = { version = "1.0.89", optional = true }
 thiserror = { version = "1.0.37", optional = true }
 schemars = { version = "0.8.16", optional = true }
+rmp-serde = { version = "1.3.0", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0.89"
@@ -50,7 +51,7 @@ arbitrary = ["std", "dep:arbitrary"]
 hex = []
 
 # Features for the CLI.
-cli = ["std", "curr", "next", "base64", "serde", "serde_json", "schemars", "dep:clap", "dep:thiserror"]
+cli = ["std", "curr", "next", "base64", "serde", "serde_json", "schemars", "dep:clap", "dep:thiserror", "dep:rmp-serde"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/cli/decode.rs
+++ b/src/cli/decode.rs
@@ -23,6 +23,8 @@ pub enum Error {
     ReadFile(#[from] std::io::Error),
     #[error("error generating JSON: {0}")]
     GenerateJson(#[from] serde_json::Error),
+    #[error("error generating message pack: {0}")]
+    GenerateMessagePack(#[from] rmp_serde::encode::Error),
 }
 
 #[derive(Args, Debug, Clone)]
@@ -66,6 +68,7 @@ pub enum OutputFormat {
     JsonFormatted,
     RustDebug,
     RustDebugFormatted,
+    MessagePack,
 }
 
 impl Default for OutputFormat {
@@ -158,6 +161,10 @@ impl Cmd {
             OutputFormat::JsonFormatted => println!("{}", serde_json::to_string_pretty(v)?),
             OutputFormat::RustDebug => println!("{v:?}"),
             OutputFormat::RustDebugFormatted => println!("{v:#?}"),
+            OutputFormat::MessagePack => {
+                let mut out = std::io::stdout();
+                rmp_serde::encode::write(&mut out, v).map_err(Error::GenerateMessagePack)?;
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
### What
Add decode XDR to Message Pack's compact form.

### Why
I wrote this decode to Message Pack to experiment with encoding contract specs in Message Pack, that are currently encoded as XDR.

To install the CLI in this PR, run:
```
cargo install --locked --git https://github.com/stellar/rs-stellar-xdr --branch decode-to-messagepack --features cli
```

To try out converting some XDR to Message Pack:
```
cat spec.xdr | stellar-xdr decode --type ScSpecEntry --input stream --output message-pack
```

Related discussion is here:
- https://discord.com/channels/897514728459468821/1283687871491997716/1284006942410539069