### PR TITLE
Add conversions from AccountId and PublicKey to MuxedAccount

### DIFF
--- a/src/curr/account_conversions.rs
+++ b/src/curr/account_conversions.rs
@@ -13,3 +13,12 @@ impl From<PublicKey> for MuxedAccount {
         }
     }
 }
+
+impl MuxedAccount {
+    pub fn account_id(self) -> AccountId {
+        match self {
+            MuxedAccount::Ed25519(k) => AccountId(PublicKey::PublicKeyTypeEd25519(k)),
+            MuxedAccount::MuxedEd25519(m) => AccountId(PublicKey::PublicKeyTypeEd25519(m.ed25519)),
+        }
+    }
+}

--- a/src/curr/account_conversions.rs
+++ b/src/curr/account_conversions.rs
@@ -1,0 +1,15 @@
+use super::{AccountId, MuxedAccount, PublicKey};
+
+impl From<AccountId> for MuxedAccount {
+    fn from(account_id: AccountId) -> Self {
+        account_id.0.into()
+    }
+}
+
+impl From<PublicKey> for MuxedAccount {
+    fn from(public_key: PublicKey) -> Self {
+        match public_key {
+            PublicKey::PublicKeyTypeEd25519(k) => MuxedAccount::Ed25519(k),
+        }
+    }
+}

--- a/src/curr/account_conversions.rs
+++ b/src/curr/account_conversions.rs
@@ -15,6 +15,7 @@ impl From<PublicKey> for MuxedAccount {
 }
 
 impl MuxedAccount {
+    #[must_use]
     pub fn account_id(self) -> AccountId {
         match self {
             MuxedAccount::Ed25519(k) => AccountId(PublicKey::PublicKeyTypeEd25519(k)),

--- a/src/curr/mod.rs
+++ b/src/curr/mod.rs
@@ -6,6 +6,7 @@ mod str;
 
 mod scval_conversions;
 pub use scval_conversions::*;
+mod account_conversions;
 mod transaction_conversions;
 
 mod scval_validations;

--- a/src/next/account_conversions.rs
+++ b/src/next/account_conversions.rs
@@ -13,3 +13,12 @@ impl From<PublicKey> for MuxedAccount {
         }
     }
 }
+
+impl MuxedAccount {
+    pub fn account_id(self) -> AccountId {
+        match self {
+            MuxedAccount::Ed25519(k) => AccountId(PublicKey::PublicKeyTypeEd25519(k)),
+            MuxedAccount::MuxedEd25519(m) => AccountId(PublicKey::PublicKeyTypeEd25519(m.ed25519)),
+        }
+    }
+}

--- a/src/next/account_conversions.rs
+++ b/src/next/account_conversions.rs
@@ -1,0 +1,15 @@
+use super::{AccountId, MuxedAccount, PublicKey};
+
+impl From<AccountId> for MuxedAccount {
+    fn from(account_id: AccountId) -> Self {
+        account_id.0.into()
+    }
+}
+
+impl From<PublicKey> for MuxedAccount {
+    fn from(public_key: PublicKey) -> Self {
+        match public_key {
+            PublicKey::PublicKeyTypeEd25519(k) => MuxedAccount::Ed25519(k),
+        }
+    }
+}

--- a/src/next/account_conversions.rs
+++ b/src/next/account_conversions.rs
@@ -15,6 +15,7 @@ impl From<PublicKey> for MuxedAccount {
 }
 
 impl MuxedAccount {
+    #[must_use]
     pub fn account_id(self) -> AccountId {
         match self {
             MuxedAccount::Ed25519(k) => AccountId(PublicKey::PublicKeyTypeEd25519(k)),

--- a/src/next/mod.rs
+++ b/src/next/mod.rs
@@ -6,6 +6,7 @@ mod str;
 
 mod scval_conversions;
 pub use scval_conversions::*;
+mod account_conversions;
 mod transaction_conversions;
 
 mod scval_validations;

--- a/tests/account_conversions.rs
+++ b/tests/account_conversions.rs
@@ -1,0 +1,27 @@
+#![cfg(all(
+    any(feature = "curr", feature = "next"),
+    not(all(feature = "curr", feature = "next"))
+))]
+#![cfg(feature = "std")]
+
+use ::stellar_xdr::curr::Uint256;
+#[cfg(feature = "curr")]
+use stellar_xdr::curr as stellar_xdr;
+#[cfg(feature = "next")]
+use stellar_xdr::next as stellar_xdr;
+
+use stellar_xdr::{AccountId, MuxedAccount, PublicKey};
+
+#[test]
+fn from_account_id_to_muxed_account() {
+    let account_id = AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([1u8; 32])));
+    let muxed_account: MuxedAccount = account_id.into();
+    assert_eq!(muxed_account, MuxedAccount::Ed25519(Uint256([1u8; 32])));
+}
+
+#[test]
+fn from_public_key_to_muxed_account() {
+    let public_key = PublicKey::PublicKeyTypeEd25519(Uint256([1u8; 32]));
+    let muxed_account: MuxedAccount = public_key.into();
+    assert_eq!(muxed_account, MuxedAccount::Ed25519(Uint256([1u8; 32])));
+}

--- a/tests/account_conversions.rs
+++ b/tests/account_conversions.rs
@@ -4,13 +4,12 @@
 ))]
 #![cfg(feature = "std")]
 
-use ::stellar_xdr::curr::{MuxedAccountMed25519, Uint256};
 #[cfg(feature = "curr")]
 use stellar_xdr::curr as stellar_xdr;
 #[cfg(feature = "next")]
 use stellar_xdr::next as stellar_xdr;
 
-use stellar_xdr::{AccountId, MuxedAccount, PublicKey};
+use stellar_xdr::{AccountId, MuxedAccount, MuxedAccountMed25519, PublicKey, Uint256};
 
 #[test]
 fn from_account_id_to_muxed_account() {

--- a/tests/account_conversions.rs
+++ b/tests/account_conversions.rs
@@ -4,7 +4,7 @@
 ))]
 #![cfg(feature = "std")]
 
-use ::stellar_xdr::curr::Uint256;
+use ::stellar_xdr::curr::{MuxedAccountMed25519, Uint256};
 #[cfg(feature = "curr")]
 use stellar_xdr::curr as stellar_xdr;
 #[cfg(feature = "next")]
@@ -24,4 +24,27 @@ fn from_public_key_to_muxed_account() {
     let public_key = PublicKey::PublicKeyTypeEd25519(Uint256([1u8; 32]));
     let muxed_account: MuxedAccount = public_key.into();
     assert_eq!(muxed_account, MuxedAccount::Ed25519(Uint256([1u8; 32])));
+}
+
+#[test]
+fn from_muxed_account_ed_to_account_id() {
+    let muxed_account: MuxedAccount = MuxedAccount::Ed25519(Uint256([1u8; 32]));
+    let account_id = muxed_account.account_id();
+    assert_eq!(
+        account_id,
+        AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([1u8; 32])))
+    );
+}
+
+#[test]
+fn from_muxed_account_med_to_account_id() {
+    let muxed_account: MuxedAccount = MuxedAccount::MuxedEd25519(MuxedAccountMed25519 {
+        id: 2,
+        ed25519: Uint256([1u8; 32]),
+    });
+    let account_id = muxed_account.account_id();
+    assert_eq!(
+        account_id,
+        AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([1u8; 32])))
+    );
 }


### PR DESCRIPTION
### What
Add conversions from AccountId and PublicKey to MuxedAccount.

### Why
The types are largely compatible and while MuxedAccounts are used in transactions applications often only support G addresses and convenient conversions from the AccountId/PublicKey type used for G addresses to the MuxedAccount type for use in transactions would be helpful.