### PR TITLE
Set version to 22.0.0-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "stellar-xdr"
-version = "22.0.0"
+version = "22.0.0-rc.1"
 dependencies = [
  "arbitrary",
  "base64 0.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ homepage = "https://github.com/stellar/rs-stellar-xdr"
 repository = "https://github.com/stellar/rs-stellar-xdr"
 authors = ["Stellar Development Foundation <info@stellar.org>"]
 license = "Apache-2.0"
-version = "22.0.0"
+version = "22.0.0-rc.1"
 edition = "2021"
 rust-version = "1.74.0"
 


### PR DESCRIPTION
### What

Required for us to run the Bump Version action and release the crate.
