### PR TITLE
feat(CLI): make schema command public

### DIFF
--- a/src/cli/types.rs
+++ b/src/cli/types.rs
@@ -1,5 +1,5 @@
 pub mod list;
-mod schema;
+pub mod schema;
 
 use clap::{Args, Subcommand};
 

--- a/src/cli/types/schema.rs
+++ b/src/cli/types/schema.rs
@@ -55,6 +55,8 @@ macro_rules! run_x {
 }
 
 impl Cmd {
+    /// # Errors
+    /// Fails if the type is unknown or if the JSON generation fails.
     pub fn run(&self, channel: &Channel) -> Result<(), Error> {
         match channel {
             Channel::Curr => self.run_curr()?,


### PR DESCRIPTION
This is needed for allowing the CLI to write the schema for VScode and other editors which support json schema.

### What

[TODO: Short statement about what is changing.]

### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]
