### PR TITLE
Add support of strings/files as arguments to guess + refactoring

### DIFF
--- a/src/cli/decode.rs
+++ b/src/cli/decode.rs
@@ -1,15 +1,10 @@
-use crate::cli::{skip_whitespace::SkipWhitespace, util, Channel};
+use std::ffi::OsString;
+use std::{fmt::Debug, str::FromStr};
+
 use clap::{Args, ValueEnum};
 use serde::Serialize;
-use std::ffi::OsString;
-use std::io::Cursor;
-use std::path::Path;
-use std::{
-    fmt::Debug,
-    fs::File,
-    io::{stdin, Read},
-    str::FromStr,
-};
+
+use crate::cli::{skip_whitespace::SkipWhitespace, util, Channel};
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {

--- a/src/cli/encode.rs
+++ b/src/cli/encode.rs
@@ -1,4 +1,4 @@
-use crate::cli::Channel;
+use crate::cli::{util, Channel};
 use clap::{Args, ValueEnum};
 use std::ffi::OsString;
 use std::io::Cursor;
@@ -111,7 +111,7 @@ macro_rules! run_x {
     ($f:ident, $m:ident) => {
         fn $f(&self) -> Result<(), Error> {
             use crate::$m::WriteXdr;
-            let mut input = self.parse_input()?;
+            let mut input = util::parse_input::<Error>(&self.input)?;
             let r#type = crate::$m::TypeVariant::from_str(&self.r#type).map_err(|_| {
                 Error::UnknownType(self.r#type.clone(), &crate::$m::TypeVariant::VARIANTS_STR)
             })?;
@@ -167,25 +167,4 @@ impl Cmd {
 
     run_x!(run_curr, curr);
     run_x!(run_next, next);
-
-    fn parse_input(&self) -> Result<Vec<Box<dyn Read>>, Error> {
-        if self.input.is_empty() {
-            Ok(vec![Box::new(stdin())])
-        } else {
-            Ok(self
-                .input
-                .iter()
-                .map(|input| {
-                    let exist = Path::new(input).try_exists();
-                    if let Ok(true) = exist {
-                        let file = File::open(input)?;
-                        Ok::<Box<dyn Read>, Error>(Box::new(file) as Box<dyn Read>)
-                    } else {
-                        Ok(Box::new(Cursor::new(input.clone().into_encoded_bytes()))
-                            as Box<dyn Read>)
-                    }
-                })
-                .collect::<Result<Vec<_>, _>>()?)
-        }
-    }
 }

--- a/src/cli/encode.rs
+++ b/src/cli/encode.rs
@@ -1,13 +1,12 @@
-use crate::cli::{util, Channel};
-use clap::{Args, ValueEnum};
 use std::ffi::OsString;
-use std::io::Cursor;
-use std::path::Path;
 use std::{
-    fs::File,
-    io::{stdin, stdout, Read, Write},
+    io::{stdout, Write},
     str::FromStr,
 };
+
+use clap::{Args, ValueEnum};
+
+use crate::cli::{util, Channel};
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {

--- a/src/cli/guess.rs
+++ b/src/cli/guess.rs
@@ -1,11 +1,10 @@
-use clap::{Args, ValueEnum};
 use std::ffi::OsString;
 use std::{
     cmp,
-    fs::File,
-    io::{self, stdin, Read},
-    path::PathBuf,
+    io::{self, Read},
 };
+
+use clap::{Args, ValueEnum};
 
 use crate::cli::{skip_whitespace::SkipWhitespace, util, Channel};
 

--- a/src/cli/guess.rs
+++ b/src/cli/guess.rs
@@ -19,8 +19,6 @@ pub enum Error {
     ReadXdrNext(#[from] crate::next::Error),
     #[error("error reading file: {0}")]
     ReadFile(#[from] std::io::Error),
-    #[error("couldn't guess XDR type")]
-    InvalidType,
 }
 
 #[derive(Args, Debug, Clone)]
@@ -73,7 +71,6 @@ macro_rules! run_x {
     ($f:ident, $m:ident) => {
         fn $f(&self) -> Result<(), Error> {
             let mut rr = ResetRead::new(self.input()?);
-            let mut guessed = false;
             'variants: for v in crate::$m::TypeVariant::VARIANTS {
                 rr.reset();
                 let count: usize = match self.input_format {
@@ -135,11 +132,7 @@ macro_rules! run_x {
                 };
                 if count > 0 {
                     println!("{}", v.name());
-                    guessed = true;
                 }
-            }
-            if (!guessed) {
-                return Err(Error::InvalidType);
             }
             Ok(())
         }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2,7 +2,7 @@ pub mod compare;
 pub mod decode;
 pub mod encode;
 pub mod guess;
-mod skip_whitespace;
+pub mod skip_whitespace;
 pub mod types;
 mod util;
 mod version;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -66,7 +66,7 @@ impl Default for Channel {
 pub enum Cmd {
     /// View information about types
     Types(types::Cmd),
-    /// Guesses the XDR type.
+    /// Guess the XDR type.
     ///
     /// Prints a list of types that the XDR values can be decoded into.
     Guess(guess::Cmd),

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -4,6 +4,7 @@ pub mod encode;
 pub mod guess;
 mod skip_whitespace;
 pub mod types;
+mod util;
 mod version;
 
 use clap::{Parser, Subcommand, ValueEnum};
@@ -65,7 +66,9 @@ impl Default for Channel {
 pub enum Cmd {
     /// View information about types
     Types(types::Cmd),
-    /// Guess the XDR type
+    /// Guesses the XDR type. All possible types are be printed for given XDR using given output format
+    /// (list views with each item on a new line by default).
+    /// For multiple inputs results are separated by an empty line for each input.
     Guess(guess::Cmd),
     /// Decode XDR
     Decode(decode::Cmd),

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -68,7 +68,6 @@ pub enum Cmd {
     Types(types::Cmd),
     /// Guesses the XDR type. All possible types are be printed for given XDR using given output format
     /// (list views with each item on a new line by default).
-    /// For multiple inputs results are separated by an empty line for each input.
     Guess(guess::Cmd),
     /// Decode XDR
     Decode(decode::Cmd),

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -66,8 +66,9 @@ impl Default for Channel {
 pub enum Cmd {
     /// View information about types
     Types(types::Cmd),
-    /// Guesses the XDR type. All possible types are be printed for given XDR using given output format
-    /// (list views with each item on a new line by default).
+    /// Guesses the XDR type.
+    ///
+    /// Prints a list of types that the XDR values can be decoded into.
     Guess(guess::Cmd),
     /// Decode XDR
     Decode(decode::Cmd),

--- a/src/cli/util.rs
+++ b/src/cli/util.rs
@@ -1,0 +1,26 @@
+use std::ffi::OsString;
+use std::fs::File;
+use std::io::{stdin, Cursor, Read};
+use std::path::Path;
+
+pub fn parse_input<E>(input: &Vec<OsString>) -> Result<Vec<Box<dyn Read>>, E>
+where
+    E: From<std::io::Error>,
+{
+    if input.is_empty() {
+        Ok(vec![Box::new(stdin())])
+    } else {
+        Ok(input
+            .iter()
+            .map(|input| {
+                let exist = Path::new(input).try_exists();
+                if let Ok(true) = exist {
+                    let file = File::open(input)?;
+                    Ok::<Box<dyn Read>, E>(Box::new(file) as Box<dyn Read>)
+                } else {
+                    Ok(Box::new(Cursor::new(input.clone().into_encoded_bytes())) as Box<dyn Read>)
+                }
+            })
+            .collect::<Result<Vec<_>, _>>()?)
+    }
+}


### PR DESCRIPTION
### What

Followup for #407 

* Adds support of guessing string and files 
* Refactored original implementation to remove copy-paste and slightly improve UX of guess command
 
### Why

Part of #406 

### Known limitations

N/A