### PR TITLE
`guess`: exit 1 when there are no guesses

### DIFF
--- a/src/cli/guess.rs
+++ b/src/cli/guess.rs
@@ -71,6 +71,7 @@ macro_rules! run_x {
     ($f:ident, $m:ident) => {
         fn $f(&self) -> Result<(), Error> {
             let mut rr = ResetRead::new(self.input()?);
+            let mut guessed = false;
             'variants: for v in crate::$m::TypeVariant::VARIANTS {
                 rr.reset();
                 let count: usize = match self.input_format {
@@ -132,7 +133,11 @@ macro_rules! run_x {
                 };
                 if count > 0 {
                     println!("{}", v.name());
+                    guessed = true;
                 }
+            }
+            if (!guessed) {
+                std::process::exit(1);
             }
             Ok(())
         }


### PR DESCRIPTION
### What

Exit command with code 1 when calling `guess` with invalid XDR

```
# Valid XDR
> cargo run --features=cli guess "AAAAAgAAAAC9yj33uT0b+EZcua+UlGswq2VGc3P8HY5pYp1d3N/YWwAAAGQAAAAAAAAAewAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAC9yj33uT0b+EZcua+UlGswq2VGc3P8HY5pYp1d3N/YWwAAAABJUE+AAAAAAAAAAAA="
FeeBumpTransactionInnerTx
TransactionEnvelope
# Invalid XDR
> cargo run --features=cli guess "AAAAAgAAAAC9yj33uT0b+EZcua+UlGswq2VGc3P8HY5pYp1d3N/YWwAAAGQAAAAAAAAAewAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAC9yj33uT0b+EZcua+UlGswq2VGc3P8HY5pYp1d3N/YWwAAAABJUE+AAAAAAAAAAA=" 
> echo $?
1
```
### Why

#413 

### Known limitations

N/A
