### PR TITLE
Adapt to wasm32v1-none

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,7 +56,7 @@ jobs:
         rust: [msrv, latest]
         sys:
         - os: ubuntu-latest
-          target: wasm32-unknown-unknown
+          target: wasm32v1-none
         - os: ubuntu-latest
           target: x86_64-unknown-linux-gnu
         # TODO: Address GitHub Actions concurrency limits and re-enable.
@@ -89,7 +89,12 @@ jobs:
       with:
         name: cargo-hack
         version: 0.5.16
-    - run: cargo hack clippy $CARGO_HACK_ARGS --target ${{ matrix.sys.target }} --all-targets
+    - name: Run minimal clippy checks on wasm32v1-none
+      if: matrix.sys.target == 'wasm32v1-none'
+      run: cargo clippy --target ${{ matrix.sys.target }} --no-default-features --features curr,next
+    - name: Run full clippy checks on other targets
+      if: matrix.sys.target != 'wasm32v1-none'
+      run: cargo hack clippy $CARGO_HACK_ARGS --target ${{ matrix.sys.target }} --all-targets
 
   test:
     strategy:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Stellar Development Foundation <info@stellar.org>"]
 license = "Apache-2.0"
 version = "22.1.0"
 edition = "2021"
-rust-version = "1.81.0"
+rust-version = "1.84.0"
 
 [[bin]]
 name = "stellar-xdr"

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ test:
 
 build: generate
 	cargo hack clippy $(CARGO_HACK_ARGS) --all-targets
-	cargo hack clippy $(CARGO_HACK_ARGS) --all-targets --release --target wasm32-unknown-unknown
+	cargo clippy --no-default-features --features curr,next --release --target wasm32v1-none
 
 doc:
 	cargo test --doc --all-features

--- a/src/curr/mod.rs
+++ b/src/curr/mod.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::empty_line_after_doc_comments)]
 mod generated;
 mod ledgerkey;
 pub use generated::*;

--- a/src/curr/scval_conversions.rs
+++ b/src/curr/scval_conversions.rs
@@ -212,7 +212,7 @@ pub mod int128_helpers {
         clippy::cast_possible_wrap
     )]
     pub fn i128_from_pieces(hi: i64, lo: u64) -> i128 {
-        (u128::from(hi as u64) << 64 | u128::from(lo)) as i128
+        ((u128::from(hi as u64) << 64) | u128::from(lo)) as i128
     }
 }
 

--- a/src/next/mod.rs
+++ b/src/next/mod.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::empty_line_after_doc_comments)]
 mod generated;
 mod ledgerkey;
 pub use generated::*;

--- a/src/next/scval_conversions.rs
+++ b/src/next/scval_conversions.rs
@@ -212,7 +212,7 @@ pub mod int128_helpers {
         clippy::cast_possible_wrap
     )]
     pub fn i128_from_pieces(hi: i64, lo: u64) -> i128 {
-        (u128::from(hi as u64) << 64 | u128::from(lo)) as i128
+        ((u128::from(hi as u64) << 64) | u128::from(lo)) as i128
     }
 }
 

--- a/tests/tx_read_edge_cases.rs
+++ b/tests/tx_read_edge_cases.rs
@@ -40,7 +40,7 @@ fn test_read_interrupts_and_residuals() -> Result<(), Error> {
                 Interrupted::new(Cursor::new(&v_bytes)),
                 Limits::none(),
             )),
-            Ok(1u64 << 32 | 2u64)
+            Ok((1u64 << 32) | 2u64)
         );
     }
 
@@ -50,7 +50,7 @@ fn test_read_interrupts_and_residuals() -> Result<(), Error> {
         assert_eq!(u32::from_xdr(&v_bytes, Limits::none()), Err(Error::Invalid));
         assert_eq!(
             u64::from_xdr(&v_bytes, Limits::none()),
-            Ok(1u64 << 32 | 2u64)
+            Ok((1u64 << 32) | 2u64)
         );
     }
 
@@ -64,7 +64,7 @@ fn test_read_interrupts_and_residuals() -> Result<(), Error> {
         );
         assert_eq!(
             u64::from_xdr_base64(&v_base64, Limits::none()),
-            Ok(1u64 << 32 | 2u64)
+            Ok((1u64 << 32) | 2u64)
         );
     }
 


### PR DESCRIPTION
Part of https://github.com/stellar/rs-soroban-sdk/issues/1428 -- just moving us to rust 1.84 and wasm32v1-none for the wasm build (and fixing clippy fallout).