### PR TITLE
Update xdrgen to get iter_mut to VecM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CARGO_HACK_ARGS=--feature-powerset --exclude-features default --group-features b
 
 CARGO_DOC_ARGS?=--open
 
-XDRGEN_VERSION=69b77af63a96abe7874186e392d3bcb96d8ee309
+XDRGEN_VERSION=4bee5ee59cd579869903a029eb70451f5dc1fa75
 # XDRGEN_LOCAL=1
 XDRGEN_TYPES_CUSTOM_STR_IMPL_CURR=PublicKey,AccountId,ContractId,MuxedAccount,MuxedAccountMed25519,SignerKey,SignerKeyEd25519SignedPayload,NodeId,ScAddress,AssetCode,AssetCode4,AssetCode12,ClaimableBalanceId,PoolId,MuxedEd25519Account
 XDRGEN_TYPES_CUSTOM_STR_IMPL_NEXT=PublicKey,AccountId,ContractId,MuxedAccount,MuxedAccountMed25519,SignerKey,SignerKeyEd25519SignedPayload,NodeId,ScAddress,AssetCode,AssetCode4,AssetCode12,ClaimableBalanceId,PoolId,MuxedEd25519Account

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CARGO_HACK_ARGS=--feature-powerset --exclude-features default --group-features b
 
 CARGO_DOC_ARGS?=--open
 
-XDRGEN_VERSION=4bee5ee59cd579869903a029eb70451f5dc1fa75
+XDRGEN_VERSION=db6306eff29100a7c0105cbdd282a759aa66a8ef
 # XDRGEN_LOCAL=1
 XDRGEN_TYPES_CUSTOM_STR_IMPL_CURR=PublicKey,AccountId,ContractId,MuxedAccount,MuxedAccountMed25519,SignerKey,SignerKeyEd25519SignedPayload,NodeId,ScAddress,AssetCode,AssetCode4,AssetCode12,ClaimableBalanceId,PoolId,MuxedEd25519Account
 XDRGEN_TYPES_CUSTOM_STR_IMPL_NEXT=PublicKey,AccountId,ContractId,MuxedAccount,MuxedAccountMed25519,SignerKey,SignerKeyEd25519SignedPayload,NodeId,ScAddress,AssetCode,AssetCode4,AssetCode12,ClaimableBalanceId,PoolId,MuxedEd25519Account

--- a/src/curr/generated.rs
+++ b/src/curr/generated.rs
@@ -997,6 +997,22 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     }
 }
 
+#[cfg(feature = "alloc")]
+impl<T, const MAX: u32> VecM<T, MAX> {
+    pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
+        self.0.iter_mut()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
+    type Item = &'a mut T;
+    type IntoIter = core::slice::IterMut<'a, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {
     #[must_use]
     #[cfg(feature = "alloc")]

--- a/src/next/generated.rs
+++ b/src/next/generated.rs
@@ -997,6 +997,22 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     }
 }
 
+#[cfg(feature = "alloc")]
+impl<T, const MAX: u32> VecM<T, MAX> {
+    pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
+        self.0.iter_mut()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
+    type Item = &'a mut T;
+    type IntoIter = core::slice::IterMut<'a, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {
     #[must_use]
     #[cfg(feature = "alloc")]


### PR DESCRIPTION
### What
Update xdrgen to latest version.

### Why
Enables mutable iteration over VecM collections, simplifying code that needs to modify elements in place.

Close stellar/xdrgen#209

Dependent on:
- stellar/xdrgen#210