### PR TITLE
Upgrade actions/upload-artifact github action to v4

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,7 +51,7 @@ jobs:
         tar xvfz stellar-xdr-$VERSION.crate
         cd stellar-xdr-$VERSION
         cargo build --target-dir=../.. --release --target ${{ matrix.target }} --features cli
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: ${{ env.NAME }}
         path: 'target/${{ matrix.target }}/release/stellar-xdr${{ matrix.ext }}'


### PR DESCRIPTION
### What
Upgrade GitHub actions/upload-artifact from v3 to v4 in the publish workflow.

### Why
v3 has completely stopped working and failed part of the last v22.2.0 release.