### PR TITLE
Fix string deser bug with i64 and streaming JSON

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CARGO_HACK_ARGS=--feature-powerset --exclude-features default --group-features b
 
 CARGO_DOC_ARGS?=--open
 
-XDRGEN_VERSION=af107f07237a15fcf5f9aea71b2bebfcc1113b45
+XDRGEN_VERSION=5a4785c4d2147319e0eb8350acb1138ddd0d63cf
 # XDRGEN_LOCAL=1
 XDRGEN_TYPES_CUSTOM_STR_IMPL_CURR=PublicKey,AccountId,ContractId,MuxedAccount,MuxedAccountMed25519,SignerKey,SignerKeyEd25519SignedPayload,NodeId,ScAddress,AssetCode,AssetCode4,AssetCode12,ClaimableBalanceId,PoolId,MuxedEd25519Account,Int128Parts,UInt128Parts,Int256Parts,UInt256Parts
 XDRGEN_TYPES_CUSTOM_STR_IMPL_NEXT=PublicKey,AccountId,ContractId,MuxedAccount,MuxedAccountMed25519,SignerKey,SignerKeyEd25519SignedPayload,NodeId,ScAddress,AssetCode,AssetCode4,AssetCode12,ClaimableBalanceId,PoolId,MuxedEd25519Account,Int128Parts,UInt128Parts,Int256Parts,UInt256Parts

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CARGO_HACK_ARGS=--feature-powerset --exclude-features default --group-features b
 
 CARGO_DOC_ARGS?=--open
 
-XDRGEN_VERSION=5a4785c4d2147319e0eb8350acb1138ddd0d63cf
+XDRGEN_VERSION=817c9583a3f6531525a8ce61b82de5b2a43699ac
 # XDRGEN_LOCAL=1
 XDRGEN_TYPES_CUSTOM_STR_IMPL_CURR=PublicKey,AccountId,ContractId,MuxedAccount,MuxedAccountMed25519,SignerKey,SignerKeyEd25519SignedPayload,NodeId,ScAddress,AssetCode,AssetCode4,AssetCode12,ClaimableBalanceId,PoolId,MuxedEd25519Account,Int128Parts,UInt128Parts,Int256Parts,UInt256Parts
 XDRGEN_TYPES_CUSTOM_STR_IMPL_NEXT=PublicKey,AccountId,ContractId,MuxedAccount,MuxedAccountMed25519,SignerKey,SignerKeyEd25519SignedPayload,NodeId,ScAddress,AssetCode,AssetCode4,AssetCode12,ClaimableBalanceId,PoolId,MuxedEd25519Account,Int128Parts,UInt128Parts,Int256Parts,UInt256Parts

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CARGO_HACK_ARGS=--feature-powerset --exclude-features default --group-features b
 
 CARGO_DOC_ARGS?=--open
 
-XDRGEN_VERSION=817c9583a3f6531525a8ce61b82de5b2a43699ac
+XDRGEN_VERSION=1dab9225bd9d7ea4701b1de6f8549c8d74402bed
 # XDRGEN_LOCAL=1
 XDRGEN_TYPES_CUSTOM_STR_IMPL_CURR=PublicKey,AccountId,ContractId,MuxedAccount,MuxedAccountMed25519,SignerKey,SignerKeyEd25519SignedPayload,NodeId,ScAddress,AssetCode,AssetCode4,AssetCode12,ClaimableBalanceId,PoolId,MuxedEd25519Account,Int128Parts,UInt128Parts,Int256Parts,UInt256Parts
 XDRGEN_TYPES_CUSTOM_STR_IMPL_NEXT=PublicKey,AccountId,ContractId,MuxedAccount,MuxedAccountMed25519,SignerKey,SignerKeyEd25519SignedPayload,NodeId,ScAddress,AssetCode,AssetCode4,AssetCode12,ClaimableBalanceId,PoolId,MuxedEd25519Account,Int128Parts,UInt128Parts,Int256Parts,UInt256Parts

--- a/src/curr/generated.rs
+++ b/src/curr/generated.rs
@@ -2406,10 +2406,12 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         #[derive(Deserialize)]
         #[serde(untagged)]
         enum I64OrString<'a> {
-            String(&'a str),
+            Str(&'a str),
+            String(String),
             I64(i64),
         }
         match I64OrString::deserialize(deserializer)? {
+            I64OrString::Str(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::I64(v) => Ok(v),
         }
@@ -2426,10 +2428,12 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
         #[derive(Deserialize)]
         #[serde(untagged)]
         enum U64OrString<'a> {
-            String(&'a str),
+            Str(&'a str),
+            String(String),
             U64(u64),
         }
         match U64OrString::deserialize(deserializer)? {
+            U64OrString::Str(s) => s.parse().map_err(serde::de::Error::custom),
             U64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
             U64OrString::U64(v) => Ok(v),
         }

--- a/src/curr/generated.rs
+++ b/src/curr/generated.rs
@@ -3177,6 +3177,16 @@ mod tests_for_number_or_string {
 
     // --- i64 Deserialization Tests ---
     #[test]
+    fn deserialize_i64_from_json_reader() {
+        let json = r#"{"val": "123"}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(
+            serde_json::from_reader::<_, TestI64>(Cursor::new(json)).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
     fn deserialize_i64_from_json_number_positive() {
         let json = r#"{"val": 123}"#;
         let expected = TestI64 { val: 123 };
@@ -3468,6 +3478,16 @@ mod tests_for_number_or_string {
     }
 
     // --- u64 Deserialization Tests ---
+    #[test]
+    fn deserialize_u64_from_json_reader() {
+        let json = r#"{"val": "123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(
+            serde_json::from_reader::<_, TestU64>(Cursor::new(json)).unwrap(),
+            expected
+        );
+    }
+
     #[test]
     fn deserialize_u64_from_json_number() {
         let json = r#"{"val": 123}"#;

--- a/src/next/generated.rs
+++ b/src/next/generated.rs
@@ -2406,10 +2406,12 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         #[derive(Deserialize)]
         #[serde(untagged)]
         enum I64OrString<'a> {
-            String(&'a str),
+            Str(&'a str),
+            String(String),
             I64(i64),
         }
         match I64OrString::deserialize(deserializer)? {
+            I64OrString::Str(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::I64(v) => Ok(v),
         }
@@ -2426,10 +2428,12 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
         #[derive(Deserialize)]
         #[serde(untagged)]
         enum U64OrString<'a> {
-            String(&'a str),
+            Str(&'a str),
+            String(String),
             U64(u64),
         }
         match U64OrString::deserialize(deserializer)? {
+            U64OrString::Str(s) => s.parse().map_err(serde::de::Error::custom),
             U64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
             U64OrString::U64(v) => Ok(v),
         }

--- a/src/next/generated.rs
+++ b/src/next/generated.rs
@@ -3177,6 +3177,16 @@ mod tests_for_number_or_string {
 
     // --- i64 Deserialization Tests ---
     #[test]
+    fn deserialize_i64_from_json_reader() {
+        let json = r#"{"val": "123"}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(
+            serde_json::from_reader::<_, TestI64>(Cursor::new(json)).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
     fn deserialize_i64_from_json_number_positive() {
         let json = r#"{"val": 123}"#;
         let expected = TestI64 { val: 123 };
@@ -3468,6 +3478,16 @@ mod tests_for_number_or_string {
     }
 
     // --- u64 Deserialization Tests ---
+    #[test]
+    fn deserialize_u64_from_json_reader() {
+        let json = r#"{"val": "123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(
+            serde_json::from_reader::<_, TestU64>(Cursor::new(json)).unwrap(),
+            expected
+        );
+    }
+
     #[test]
     fn deserialize_u64_from_json_number() {
         let json = r#"{"val": 123}"#;


### PR DESCRIPTION
### What

Update xdrgen to get support for deserializing i64 from owned String type in I/U64OrString.

### Why

Some JSON deserializers use owned String instead of borrowed &str when streaming. Without this change, deserializing i64 values from string representation fails in streaming scenarios where the deserialized type cannot take a reference to a string owned elsewhere.

When I wrote the I/U64OrString type, I tested it only with owned strings that could be referenced, not with a reader where the data was not already owned.

### Merging

Dependent on:
- https://github.com/stellar/xdrgen/pull/217