### PR TITLE
Move xdrgen Rust generator into this repository

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,13 +35,13 @@ generate: generate-xdrgen-files xdr/curr-version xdr/next-version xdr-json/curr 
 generate-xdrgen-files: src/curr/generated.rs src/next/generated.rs
 	docker run -i --rm -v $$PWD:/wd -w /wd docker.io/library/ruby:3.1 /bin/bash -c \
 		'cd xdr-generator && bundle install --quiet && bundle exec ruby generate.rb'
-	#rustfmt $^
+	rustfmt $^
 
 src/next/generated.rs: $(sort $(wildcard xdr/curr/*.x))
-	@:
+	> $@
 
 src/curr/generated.rs: $(sort $(wildcard xdr/next/*.x))
-	@:
+	> $@
 
 xdr/curr-version: $(wildcard .git/modules/xdr/curr/**/*) $(wildcard xdr/curr/*.x)
 	git submodule status -- xdr/curr | sed 's/^ *//g' | cut -f 1 -d " " | tr -d '\n' | tr -d '+' > xdr/curr-version

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ generate: generate-xdrgen-files xdr/curr-version xdr/next-version xdr-json/curr 
 generate-xdrgen-files: src/curr/generated.rs src/next/generated.rs
 	docker run -i --rm -v $$PWD:/wd -w /wd docker.io/library/ruby:3.1 /bin/bash -c \
 		'cd xdr-generator && bundle install --quiet && bundle exec ruby generate.rb'
-	rustfmt $^
+	#rustfmt $^
 
 src/next/generated.rs: $(sort $(wildcard xdr/curr/*.x))
 	@:

--- a/Makefile
+++ b/Makefile
@@ -4,15 +4,6 @@ CARGO_HACK_ARGS=--feature-powerset --exclude-features default --group-features b
 
 CARGO_DOC_ARGS?=--open
 
-XDRGEN_VERSION=c9aa0917679c208f793a9276a38edee016ca93c7
-# XDRGEN_LOCAL=1
-XDRGEN_TYPES_CUSTOM_DEFAULT_IMPL_CURR=TransactionEnvelope
-XDRGEN_TYPES_CUSTOM_DEFAULT_IMPL_NEXT=TransactionEnvelope
-XDRGEN_TYPES_CUSTOM_STR_IMPL_CURR=PublicKey,AccountId,ContractId,MuxedAccount,MuxedAccountMed25519,SignerKey,SignerKeyEd25519SignedPayload,NodeId,ScAddress,AssetCode,AssetCode4,AssetCode12,ClaimableBalanceId,PoolId,MuxedEd25519Account,Int128Parts,UInt128Parts,Int256Parts,UInt256Parts
-XDRGEN_TYPES_CUSTOM_STR_IMPL_NEXT=PublicKey,AccountId,ContractId,MuxedAccount,MuxedAccountMed25519,SignerKey,SignerKeyEd25519SignedPayload,NodeId,ScAddress,AssetCode,AssetCode4,AssetCode12,ClaimableBalanceId,PoolId,MuxedEd25519Account,Int128Parts,UInt128Parts,Int256Parts,UInt256Parts
-XDRGEN_TYPES_CUSTOM_JSONSCHEMA_IMPL_CURR=PublicKey,AccountId,ContractId,MuxedAccount,MuxedAccountMed25519,SignerKey,SignerKeyEd25519SignedPayload,NodeId,ScAddress,AssetCode,AssetCode4,AssetCode12,ClaimableBalanceId,PoolId,MuxedEd25519Account,Int128Parts,UInt128Parts,Int256Parts,UInt256Parts
-XDRGEN_TYPES_CUSTOM_JSONSCHEMA_IMPL_NEXT=PublicKey,AccountId,ContractId,MuxedAccount,MuxedAccountMed25519,SignerKey,SignerKeyEd25519SignedPayload,NodeId,ScAddress,AssetCode,AssetCode4,AssetCode12,ClaimableBalanceId,PoolId,MuxedEd25519Account,Int128Parts,UInt128Parts,Int256Parts,UInt256Parts
-
 all: build test
 
 test:
@@ -39,58 +30,21 @@ readme:
 watch:
 	cargo watch --clear --watch-when-idle --shell '$(MAKE)'
 
-generate: src/curr/generated.rs xdr/curr-version src/next/generated.rs xdr/next-version xdr-json/curr xdr-json/next
+generate: generate-xdrgen-files xdr/curr-version xdr/next-version xdr-json/curr xdr-json/next
 
-src/curr/generated.rs: $(sort $(wildcard xdr/curr/*.x))
-	> $@
-ifeq ($(XDRGEN_LOCAL),)
-	docker run -i --rm -v $$PWD:/wd -w /wd docker.io/library/ruby:latest /bin/bash -c '\
-		gem install specific_install -v 0.3.8 && \
-		gem specific_install https://github.com/stellar/xdrgen.git -b $(XDRGEN_VERSION) && \
-		xdrgen --language rust --namespace generated --output src/curr \
-			--rust-types-custom-default-impl $(XDRGEN_TYPES_CUSTOM_DEFAULT_IMPL_CURR) \
-			--rust-types-custom-str-impl $(XDRGEN_TYPES_CUSTOM_STR_IMPL_CURR) \
-			--rust-types-custom-jsonschema-impl '$(XDRGEN_TYPES_CUSTOM_JSONSCHEMA_IMPL_CURR)' \
-		$^ \
-		'
-else
-	docker run -i --rm -v $$PWD/../xdrgen:/xdrgen -v $$PWD:/wd -w /wd docker.io/library/ruby:latest /bin/bash -c '\
-		pushd /xdrgen && bundle install --deployment && rake install && popd && \
-		xdrgen --language rust --namespace generated --output src/curr \
-			--rust-types-custom-default-impl $(XDRGEN_TYPES_CUSTOM_DEFAULT_IMPL_CURR) \
-			--rust-types-custom-str-impl $(XDRGEN_TYPES_CUSTOM_STR_IMPL_CURR) \
-			--rust-types-custom-jsonschema-impl '$(XDRGEN_TYPES_CUSTOM_JSONSCHEMA_IMPL_CURR)' \
-		$^ \
-		'
-endif
-	rustfmt $@
+generate-xdrgen-files: src/curr/generated.rs src/next/generated.rs
+	docker run -i --rm -v $$PWD:/wd -w /wd docker.io/library/ruby:3.1 /bin/bash -c \
+		'cd xdr-generator && bundle install --quiet && bundle exec ruby generate.rb'
+	rustfmt $^
+
+src/next/generated.rs: $(sort $(wildcard xdr/curr/*.x))
+	@:
+
+src/curr/generated.rs: $(sort $(wildcard xdr/next/*.x))
+	@:
 
 xdr/curr-version: $(wildcard .git/modules/xdr/curr/**/*) $(wildcard xdr/curr/*.x)
 	git submodule status -- xdr/curr | sed 's/^ *//g' | cut -f 1 -d " " | tr -d '\n' | tr -d '+' > xdr/curr-version
-
-src/next/generated.rs: $(sort $(wildcard xdr/next/*.x))
-	> $@
-ifeq ($(XDRGEN_LOCAL),)
-	docker run -i --rm -v $$PWD:/wd -w /wd docker.io/library/ruby:latest /bin/bash -c '\
-		gem install specific_install -v 0.3.8 && \
-		gem specific_install https://github.com/stellar/xdrgen.git -b $(XDRGEN_VERSION) && \
-		xdrgen --language rust --namespace generated --output src/next \
-			--rust-types-custom-default-impl $(XDRGEN_TYPES_CUSTOM_DEFAULT_IMPL_NEXT) \
-			--rust-types-custom-str-impl $(XDRGEN_TYPES_CUSTOM_STR_IMPL_NEXT) \
-			--rust-types-custom-jsonschema-impl '$(XDRGEN_TYPES_CUSTOM_JSONSCHEMA_IMPL_NEXT)' \
-		$^ \
-		'
-else
-	docker run -i --rm -v $$PWD/../xdrgen:/xdrgen -v $$PWD:/wd -w /wd docker.io/library/ruby:latest /bin/bash -c '\
-		pushd /xdrgen && bundle install --deployment && rake install && popd && \
-		xdrgen --language rust --namespace generated --output src/next \
-			--rust-types-custom-default-impl $(XDRGEN_TYPES_CUSTOM_DEFAULT_IMPL_NEXT) \
-			--rust-types-custom-str-impl $(XDRGEN_TYPES_CUSTOM_STR_IMPL_NEXT) \
-			--rust-types-custom-jsonschema-impl '$(XDRGEN_TYPES_CUSTOM_JSONSCHEMA_IMPL_NEXT)' \
-		$^ \
-		'
-endif
-	rustfmt $@
 
 xdr/next-version: $(wildcard .git/modules/xdr/next/**/*) $(wildcard xdr/next/*.x)
 	git submodule status -- xdr/next | sed 's/^ *//g' | cut -f 1 -d " " | tr -d '\n' | tr -d '+' > xdr/next-version
@@ -106,7 +60,7 @@ clean:
 	rm -f xdr/*-version
 	rm -f xdr-json/curr/*.json
 	rm -f xdr-json/next/*.json
-	cargo clean
+	cargo clean --quiet
 
 fmt:
 	cargo fmt --all

--- a/Makefile
+++ b/Makefile
@@ -50,16 +50,18 @@ xdr/next-version: $(wildcard .git/modules/xdr/next/**/*) $(wildcard xdr/next/*.x
 	git submodule status -- xdr/next | sed 's/^ *//g' | cut -f 1 -d " " | tr -d '\n' | tr -d '+' > xdr/next-version
 
 xdr-json/curr: src/curr/generated.rs
+	mkdir -p xdr-json/curr
 	cargo run --features cli -- +curr types schema-files --out-dir xdr-json/curr
 
 xdr-json/next: src/next/generated.rs
+	mkdir -p xdr-json/next
 	cargo run --features cli -- +next types schema-files --out-dir xdr-json/next
 
 clean:
 	rm -f src/*/generated.rs
 	rm -f xdr/*-version
-	rm -f xdr-json/curr/*.json
-	rm -f xdr-json/next/*.json
+	rm -fr xdr-json/curr
+	rm -fr xdr-json/next
 	cargo clean --quiet
 
 fmt:

--- a/xdr-generator/Gemfile
+++ b/xdr-generator/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "xdrgen", git: "https://github.com/stellar/xdrgen", branch: "custom-generators"

--- a/xdr-generator/Gemfile
+++ b/xdr-generator/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem "xdrgen", git: "https://github.com/stellar/xdrgen", branch: "custom-generators"
+gem "xdrgen", git: "https://github.com/stellar/xdrgen", branch: "master"

--- a/xdr-generator/Gemfile.lock
+++ b/xdr-generator/Gemfile.lock
@@ -1,0 +1,45 @@
+GIT
+  remote: https://github.com/stellar/xdrgen
+  revision: 3baa928dfb19dd3e04733fedc0503a9dec2eeb84
+  branch: custom-generators
+  specs:
+    xdrgen (0.1.3)
+      activesupport (~> 6)
+      concurrent-ruby (<= 1.3.4)
+      memoist (~> 0.11.0)
+      slop (~> 3.4)
+      treetop (~> 1.5.3)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (6.1.6.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
+    concurrent-ruby (1.1.10)
+    i18n (1.12.0)
+      concurrent-ruby (~> 1.0)
+    memoist (0.11.0)
+    minitest (5.16.3)
+    polyglot (0.3.5)
+    slop (3.6.0)
+    treetop (1.5.3)
+      polyglot (~> 0.3)
+    tzinfo (2.0.5)
+      concurrent-ruby (~> 1.0)
+    zeitwerk (2.6.0)
+
+PLATFORMS
+  aarch64-linux
+  arm-linux
+  universal-darwin-21
+  x86_64-linux
+
+DEPENDENCIES
+  xdrgen!
+
+BUNDLED WITH
+   2.3.27

--- a/xdr-generator/Gemfile.lock
+++ b/xdr-generator/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/stellar/xdrgen
-  revision: 3baa928dfb19dd3e04733fedc0503a9dec2eeb84
-  branch: custom-generators
+  revision: a532c56f74122d3c2aa90746dd668c923b32a095
+  branch: master
   specs:
     xdrgen (0.1.3)
       activesupport (~> 6)

--- a/xdr-generator/README.md
+++ b/xdr-generator/README.md
@@ -1,0 +1,17 @@
+# xdr-generator
+
+The Ruby script in this directory generates Rust code for the curr and next
+XDR. The script uses [xdrgen] with a custom generator.
+
+## Usage
+
+From the root directory of the repository run:
+
+```
+make clean generate
+```
+
+This scripts entry point, [generate.rb], will be called.
+
+[xdrgen]: https://github.com/stellar/xdrgen
+[generate.rb]: ./generate.rb

--- a/xdr-generator/generate.rb
+++ b/xdr-generator/generate.rb
@@ -1,0 +1,37 @@
+require 'xdrgen'
+require_relative 'generator/generator'
+
+# Operate on the root directory of the repo.
+Dir.chdir("..")
+
+# Shared options for both compilations (curr, and next).
+options = {
+  custom_default_impl: [
+    "TransactionEnvelope",
+  ],
+  custom_str_impl: [
+    "PublicKey", "AccountId", "ContractId", "MuxedAccount",
+    "MuxedAccountMed25519", "SignerKey", "SignerKeyEd25519SignedPayload",
+    "NodeId", "ScAddress", "AssetCode", "AssetCode4", "AssetCode12",
+    "ClaimableBalanceId", "PoolId", "MuxedEd25519Account", "Int128Parts",
+    "UInt128Parts", "Int256Parts", "UInt256Parts",
+  ],
+}
+
+# Compile the curr XDR into Rust.
+Xdrgen::Compilation.new(
+  Dir.glob("xdr/curr/*.x"),
+  output_dir: "src/curr/",
+  generator: Generator,
+  namespace: "generated",
+  options: options,
+).compile
+
+# Compile the next XDR into Rust.
+Xdrgen::Compilation.new(
+  Dir.glob("xdr/next/*.x"),
+  output_dir: "src/next/",
+  generator: Generator,
+  namespace: "generated",
+  options: options,
+).compile

--- a/xdr-generator/generate.rb
+++ b/xdr-generator/generate.rb
@@ -1,6 +1,8 @@
 require 'xdrgen'
 require_relative 'generator/generator'
 
+puts "Generating..."
+
 # Operate on the root directory of the repo.
 Dir.chdir("..")
 

--- a/xdr-generator/generator/generator.rb
+++ b/xdr-generator/generator/generator.rb
@@ -1,0 +1,1282 @@
+require 'xdrgen'
+
+class Generator < Xdrgen::Generators::Base
+
+  AST = Xdrgen::AST
+
+  def generate
+    @already_rendered = []
+    path = "#{@namespace}.rs"
+    out = @output.open(path)
+
+    @types = build_type_list(@top)
+    @type_field_types = build_type_field_types(@top)
+
+    render_top_matter(out)
+    render_lib(out)
+    render_definitions(out, @top)
+    render_enum_of_all_types(out, @types)
+    out.break
+  end
+
+  private
+
+  def build_type_list(node)
+    types = Set.new
+    ingest_node = lambda do |n|
+      case n
+      when AST::Definitions::Struct, AST::Definitions::Enum, AST::Definitions::Union, AST::Definitions::Typedef
+        types << name(n)
+      end
+      n.definitions.each{ |nn| ingest_node.call(nn) } if n.respond_to?(:definitions)
+      n.nested_definitions.each{ |nn| ingest_node.call(nn) } if n.respond_to?(:nested_definitions)
+    end
+    ingest_node.call(node)
+    types
+  end
+
+  def build_type_field_types(node)
+    types = Hash.new { |h, k| h[k] = [] }
+    ingest_node = lambda do |n|
+      n.definitions.each{ |nn| ingest_node.call(nn) } if n.respond_to?(:definitions)
+      n.nested_definitions.each{ |nn| ingest_node.call(nn) } if n.respond_to?(:nested_definitions)
+      case n
+      when AST::Definitions::Struct
+        n.members.each do |m|
+          types[name(n)] << base_reference(m.declaration.type)
+        end
+      when AST::Definitions::Union ;
+        union_cases(n) do |_, arm|
+          types[name(n)] << base_reference(arm.type) unless arm.void?
+        end
+      end
+    end
+    ingest_node.call(node)
+    types
+  end
+
+  # Determines if 'type' is referenced directly or indirectly by 'type_with_fields'.
+  # Used to determine if 'type_with_fields' has a recursive relationship to 'type'.
+  def is_type_in_type_field_types(type_with_fields, type, seen = [])
+    return false if seen.include?(type_with_fields)
+    seen << type_with_fields
+    @type_field_types[type_with_fields].any? do |field_type|
+      if field_type == type
+        true
+      else
+        is_type_in_type_field_types(field_type, type, seen)
+      end
+    end
+  end
+
+  def render_top_matter(out)
+    out.puts <<-EOS.strip_heredoc
+      // Module #{@namepsace} is generated from:
+      //  #{@output.relative_source_paths.join("\n//  ")}
+    EOS
+    out.break
+    out.puts "#![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]"
+    out.break
+    source_paths_sha256_hashes = @output.relative_source_path_sha256_hashes
+    out.puts <<-EOS.strip_heredoc
+      /// `XDR_FILES_SHA256` is a list of pairs of source files and their SHA256 hashes.
+      pub const XDR_FILES_SHA256: [(&str, &str); #{source_paths_sha256_hashes.count}] = [
+        #{source_paths_sha256_hashes.map(){ |path, hash| %{("#{path}", "#{hash}")} }.join(",\n")}
+      ];
+    EOS
+    out.break
+  end
+
+  def render_lib(out)
+    header = IO.read(__dir__ + "/header.rs")
+    out.puts(header)
+    out.break
+  end
+
+  def render_enum_of_all_types(out, types)
+    out.puts <<-EOS.strip_heredoc
+    #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+    #[cfg_attr(
+      all(feature = "serde", feature = "alloc"),
+      derive(serde::Serialize, serde::Deserialize),
+      serde(rename_all = "snake_case")
+    )]
+    #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+    pub enum TypeVariant {
+        #{types.map { |t| "#{t}," }.join("\n")}
+    }
+
+    impl TypeVariant {
+        pub const VARIANTS: [TypeVariant; #{types.count}] = [ #{types.map { |t| "TypeVariant::#{t}," }.join("\n")} ];
+        pub const VARIANTS_STR: [&'static str; #{types.count}] = [ #{types.map { |t| "\"#{t}\"," }.join("\n")} ];
+
+        #[must_use]
+        #[allow(clippy::too_many_lines)]
+        pub const fn name(&self) -> &'static str {
+            match self {
+                #{types.map { |t| "Self::#{t} => \"#{t}\"," }.join("\n")}
+            }
+        }
+
+        #[must_use]
+        #[allow(clippy::too_many_lines)]
+        pub const fn variants() -> [TypeVariant; #{types.count}] {
+            Self::VARIANTS
+        }
+
+        #[cfg(feature = "schemars")]
+        #[must_use]
+        #[allow(clippy::too_many_lines)]
+        pub fn json_schema(&self, gen: schemars::gen::SchemaGenerator) -> schemars::schema::RootSchema {
+            match self {
+                #{types.map { |t| "Self::#{t} => gen.into_root_schema_for::<#{t}>()," }.join("\n")}
+            }
+        }
+    }
+
+    impl Name for TypeVariant {
+        #[must_use]
+        fn name(&self) -> &'static str {
+            Self::name(self)
+        }
+    }
+
+    impl Variants<TypeVariant> for TypeVariant {
+        fn variants() -> slice::Iter<'static, TypeVariant> {
+            Self::VARIANTS.iter()
+        }
+    }
+
+    impl core::str::FromStr for TypeVariant {
+        type Err = Error;
+        #[allow(clippy::too_many_lines)]
+        fn from_str(s: &str) -> Result<Self, Error> {
+            match s {
+                #{types.map { |t| "\"#{t}\" => Ok(Self::#{t})," }.join("\n")}
+                _ => Err(Error::Invalid),
+            }
+        }
+    }
+
+    #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+    #[cfg_attr(
+      all(feature = "serde", feature = "alloc"),
+      derive(serde::Serialize, serde::Deserialize),
+      serde(rename_all = "snake_case"),
+      serde(untagged),
+    )]
+    #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+    pub enum Type {
+        #{types.map { |t| "#{t}(Box<#{t}>)," }.join("\n")}
+    }
+
+    impl Type {
+        pub const VARIANTS: [TypeVariant; #{types.count}] = [ #{types.map { |t| "TypeVariant::#{t}," }.join("\n")} ];
+        pub const VARIANTS_STR: [&'static str; #{types.count}] = [ #{types.map { |t| "\"#{t}\"," }.join("\n")} ];
+
+        #[cfg(feature = "std")]
+        #[allow(clippy::too_many_lines)]
+        pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
+            match v {
+                #{types.map { |t| "TypeVariant::#{t} => r.with_limited_depth(|r| Ok(Self::#{t}(Box::new(#{t}::read_xdr(r)?))))," }.join("\n")}
+            }
+        }
+
+        #[cfg(feature = "base64")]
+        pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
+            let mut dec = Limited::new(
+                base64::read::DecoderReader::new(
+                    SkipWhitespace::new(&mut r.inner),
+                    &base64::engine::general_purpose::STANDARD,
+                ),
+                r.limits.clone(),
+            );
+            let t = Self::read_xdr(v, &mut dec)?;
+            Ok(t)
+        }
+
+        #[cfg(feature = "std")]
+        pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
+            let s = Self::read_xdr(v, r)?;
+            // Check that any further reads, such as this read of one byte, read no
+            // data, indicating EOF. If a byte is read the data is invalid.
+            if r.read(&mut [0u8; 1])? == 0 {
+                Ok(s)
+            } else {
+                Err(Error::Invalid)
+            }
+        }
+
+        #[cfg(feature = "base64")]
+        pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
+            let mut dec = Limited::new(
+                base64::read::DecoderReader::new(
+                    SkipWhitespace::new(&mut r.inner),
+                    &base64::engine::general_purpose::STANDARD,
+                ),
+                r.limits.clone(),
+            );
+            let t = Self::read_xdr_to_end(v, &mut dec)?;
+            Ok(t)
+        }
+
+        #[cfg(feature = "std")]
+        #[allow(clippy::too_many_lines)]
+        pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
+            match v {
+                #{types.map { |t| "TypeVariant::#{t} => Box::new(ReadXdrIter::<_, #{t}>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::#{t}(Box::new(t)))))," }.join("\n")}
+            }
+        }
+
+        #[cfg(feature = "std")]
+        #[allow(clippy::too_many_lines)]
+        pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
+            match v {
+                #{types.map { |t| "TypeVariant::#{t} => Box::new(ReadXdrIter::<_, Frame<#{t}>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::#{t}(Box::new(t.0)))))," }.join("\n")}
+            }
+        }
+
+        #[cfg(feature = "base64")]
+        #[allow(clippy::too_many_lines)]
+        pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
+            let dec = base64::read::DecoderReader::new(
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
+            );
+            match v {
+                #{types.map { |t| "TypeVariant::#{t} => Box::new(ReadXdrIter::<_, #{t}>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::#{t}(Box::new(t)))))," }.join("\n")}
+            }
+        }
+
+        #[cfg(feature = "std")]
+        pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self, Error> {
+            let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
+            let t = Self::read_xdr_to_end(v, &mut cursor)?;
+            Ok(t)
+        }
+
+        #[cfg(feature = "base64")]
+        pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
+            let mut dec = Limited::new(
+                base64::read::DecoderReader::new(
+                    SkipWhitespace::new(Cursor::new(b64)),
+                    &base64::engine::general_purpose::STANDARD,
+                ),
+                limits,
+            );
+            let t = Self::read_xdr_to_end(v, &mut dec)?;
+            Ok(t)
+        }
+
+        #[cfg(all(feature = "std", feature = "serde_json"))]
+        #[deprecated(note = "use from_json")]
+        pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self, Error> {
+            Self::from_json(v, r)
+        }
+
+        #[cfg(all(feature = "std", feature = "serde_json"))]
+        #[allow(clippy::too_many_lines)]
+        pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self, Error> {
+            match v {
+                #{types.map { |t| "TypeVariant::#{t} => Ok(Self::#{t}(Box::new(serde_json::from_reader(r)?)))," }.join("\n")}
+            }
+        }
+
+        #[cfg(all(feature = "std", feature = "serde_json"))]
+        #[allow(clippy::too_many_lines)]
+        pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self, Error> {
+            match v {
+                #{types.map { |t| "TypeVariant::#{t} => Ok(Self::#{t}(Box::new(serde::de::Deserialize::deserialize(r)?)))," }.join("\n")}
+            }
+        }
+
+        #[cfg(feature = "arbitrary")]
+        #[allow(clippy::too_many_lines)]
+        pub fn arbitrary(v: TypeVariant, u: &mut arbitrary::Unstructured<'_>) -> Result<Self, Error> {
+            match v {
+                #{types.map { |t| "TypeVariant::#{t} => Ok(Self::#{t}(Box::new(#{t}::arbitrary(u)?)))," }.join("\n")}
+            }
+        }
+
+        #[cfg(feature = "alloc")]
+        #[must_use]
+        #[allow(clippy::too_many_lines)]
+        pub fn default(v: TypeVariant) -> Self {
+            match v {
+                #{types.map { |t| "TypeVariant::#{t} => Self::#{t}(Box::default())," }.join("\n")}
+            }
+        }
+
+        #[cfg(feature = "alloc")]
+        #[must_use]
+        #[allow(clippy::too_many_lines)]
+        pub fn value(&self) -> &dyn core::any::Any {
+            #[allow(clippy::match_same_arms)]
+            match self {
+                #{types.map { |t| "Self::#{t}(ref v) => v.as_ref()," }.join("\n")}
+            }
+        }
+
+        #[must_use]
+        #[allow(clippy::too_many_lines)]
+        pub const fn name(&self) -> &'static str {
+            match self {
+                #{types.map { |t| "Self::#{t}(_) => \"#{t}\"," }.join("\n")}
+            }
+        }
+
+        #[must_use]
+        #[allow(clippy::too_many_lines)]
+        pub const fn variants() -> [TypeVariant; #{types.count}] {
+            Self::VARIANTS
+        }
+
+        #[must_use]
+        #[allow(clippy::too_many_lines)]
+        pub const fn variant(&self) -> TypeVariant {
+            match self {
+                #{types.map { |t| "Self::#{t}(_) => TypeVariant::#{t}," }.join("\n")}
+            }
+        }
+    }
+
+    impl Name for Type {
+        #[must_use]
+        fn name(&self) -> &'static str {
+            Self::name(self)
+        }
+    }
+
+    impl Variants<TypeVariant> for Type {
+        fn variants() -> slice::Iter<'static, TypeVariant> {
+            Self::VARIANTS.iter()
+        }
+    }
+
+    impl WriteXdr for Type {
+        #[cfg(feature = "std")]
+        #[allow(clippy::too_many_lines)]
+        fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
+            match self {
+                #{types.map { |t| "Self::#{t}(v) => v.write_xdr(w)," }.join("\n")}
+            }
+        }
+    }
+    EOS
+    out.break
+  end
+
+  def render_definitions(out, node)
+    node.definitions.each{|n| render_definition out, n }
+    node.namespaces.each{|n| render_definitions out, n }
+  end
+
+  def render_definition(out, defn)
+    if @already_rendered.include? name(defn)
+
+      unless defn.is_a?(AST::Definitions::Namespace)
+        $stderr.puts "warn: #{name(defn)} is defined twice.  skipping"
+      end
+
+      return
+    end
+
+    render_nested_definitions(out, defn)
+    render_source_comment(out, defn)
+
+    @already_rendered << name(defn)
+
+    case defn
+    when AST::Definitions::Struct ;
+      render_struct out, defn
+    when AST::Definitions::Enum ;
+      render_enum out, defn
+    when AST::Definitions::Union ;
+      render_union out, defn
+    when AST::Definitions::Typedef ;
+      render_typedef out, defn
+    when AST::Definitions::Const ;
+      render_const out, defn
+    end
+  end
+
+  def render_nested_definitions(out, defn)
+    return unless defn.respond_to? :nested_definitions
+    defn.nested_definitions.each{|ndefn| render_definition out, ndefn}
+  end
+
+  def render_source_comment(out, defn)
+    return if defn.is_a?(AST::Definitions::Namespace)
+
+    out.puts <<-EOS.strip_heredoc
+      /// #{name defn} is an XDR #{defn.class.name.demodulize} defines as:
+      ///
+      /// ```text
+    EOS
+
+    out.puts "/// " + defn.text_value.split("\n").join("\n/// ")
+
+    out.puts <<-EOS.strip_heredoc
+      /// ```
+      ///
+    EOS
+  end
+
+  def render_struct(out, struct)
+    out.puts %{#[cfg_attr(feature = "alloc", derive(Default))]} if !@options[:custom_default_impl].include?(name struct)
+    out.puts "#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]"
+    out.puts %{#[cfg_eval::cfg_eval]}
+    out.puts %{#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]}
+    if @options[:custom_str_impl].include?(name struct)
+      out.puts %{#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde_with::SerializeDisplay))]}
+    else
+      out.puts %{#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]}
+    end
+    if !@options[:custom_str_impl].include?(name struct)
+      out.puts %{#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]}
+    end
+    out.puts "pub struct #{name struct} {"
+    out.indent do
+      struct.members.each do |m|
+        out.puts_if(field_attrs(struct, m.declaration.type)) if !@options[:custom_str_impl].include?(name struct)
+        out.puts "pub #{field_name m}: #{reference(struct, m.declaration.type)},"
+      end
+    end
+    out.puts "}"
+    out.puts ""
+    out.puts <<-EOS.strip_heredoc
+    impl ReadXdr for #{name struct} {
+        #[cfg(feature = "std")]
+        fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
+            r.with_limited_depth(|r| {
+                Ok(Self{
+                  #{struct.members.map do |m|
+                    "#{field_name(m)}: #{reference_to_call(struct, m.declaration.type)}::read_xdr(r)?,"
+                  end.join("\n")}
+                })
+            })
+        }
+    }
+
+    impl WriteXdr for #{name struct} {
+        #[cfg(feature = "std")]
+        fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
+            w.with_limited_depth(|w| {
+                #{struct.members.map do |m|
+                  "self.#{field_name(m)}.write_xdr(w)?;"
+                end.join("\n")}
+                Ok(())
+            })
+        }
+    }
+    EOS
+    # Include a deserializer that will deserialize via the FromStr
+    # implementation, but also deserialize the original struct, present in
+    # the JSON as a map. The reason for the second option for
+    # deserialization is that types that we're adding string
+    # representations for were previously deserializable via a map to their
+    # struct, and so this improves the backwards compatibility.
+    # Note that this is only done for structs and not other types (typedef,
+    # enum, union), because struct is the only type that maps to JSON in a
+    # way that is unambiguous with a secondary form in string type.
+    out.puts <<-EOS.strip_heredoc if @options[:custom_str_impl].include?(name struct)
+    #[cfg(all(feature = "serde", feature = "alloc"))]
+    impl<'de> serde::Deserialize<'de> for #{name struct} {
+        fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error> where D: serde::Deserializer<'de> {
+            use serde::Deserialize;
+            #[derive(Deserialize)]
+            struct #{name struct} {
+                #{struct.members.map do |m|
+                  "#{field_name(m)}: #{reference(struct, m.declaration.type)},"
+                end.join("\n")}
+            }
+            #[derive(Deserialize)]
+            #[serde(untagged)]
+            enum #{name struct}OrString<'a> {
+                Str(&'a str),
+                String(String),
+                #{name struct}(#{name struct}),
+            }
+            match #{name struct}OrString::deserialize(deserializer)? {
+                #{name struct}OrString::Str(s) => s.parse().map_err(serde::de::Error::custom),
+                #{name struct}OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+                #{name struct}OrString::#{name struct}(#{name struct} {
+                    #{struct.members.map do |m| "#{field_name(m)}," end.join(" ")}
+                }) => Ok(self::#{name struct} {
+                    #{struct.members.map do |m| "#{field_name(m)}," end.join(" ")}
+                }),
+            }
+        }
+    }
+    EOS
+    out.break
+  end
+
+  def render_enum(out, enum)
+    out.puts "// enum"
+    out.puts %{#[cfg_attr(feature = "alloc", derive(Default))]} if !@options[:custom_default_impl].include?(name enum)
+    out.puts "#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]"
+    out.puts %{#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]}
+    if @options[:custom_str_impl].include?(name enum)
+      out.puts %{#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]}
+    else
+      out.puts %{#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]}
+    end
+    if !@options[:custom_str_impl].include?(name enum)
+      out.puts %{#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]}
+    end
+    out.puts "#[repr(i32)]"
+    out.puts "pub enum #{name enum} {"
+    out.indent do
+      enum.members.each_with_index do |m, i|
+        out.puts(%{#[cfg_attr(feature = "alloc", default)]}) if i == 0
+        out.puts "#{name m} = #{m.value},"
+      end
+    end
+    out.puts '}'
+    out.puts ""
+    out.puts <<-EOS.strip_heredoc
+    impl #{name enum} {
+        pub const VARIANTS: [#{name enum}; #{enum.members.count}] = [ #{enum.members.map { |m| "#{name enum}::#{name m}," }.join("\n")} ];
+        pub const VARIANTS_STR: [&'static str; #{enum.members.count}] = [ #{enum.members.map { |m| "\"#{name m}\"," }.join("\n")} ];
+
+        #[must_use]
+        pub const fn name(&self) -> &'static str {
+            match self {
+                #{enum.members.map do |m|
+                  "Self::#{name m} => \"#{name m}\","
+                end.join("\n")}
+            }
+        }
+
+        #[must_use]
+        pub const fn variants() -> [#{name enum}; #{enum.members.count}] {
+            Self::VARIANTS
+        }
+    }
+
+    impl Name for #{name enum} {
+        #[must_use]
+        fn name(&self) -> &'static str {
+            Self::name(self)
+        }
+    }
+
+    impl Variants<#{name enum}> for #{name enum} {
+        fn variants() -> slice::Iter<'static, #{name enum}> {
+            Self::VARIANTS.iter()
+        }
+    }
+
+    impl Enum for #{name enum} {}
+
+    impl fmt::Display for #{name enum} {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str(self.name())
+        }
+    }
+
+    impl TryFrom<i32> for #{name enum} {
+        type Error = Error;
+
+        fn try_from(i: i32) -> Result<Self, Error> {
+            let e = match i {
+                #{enum.members.map do |m| "#{m.value} => #{name enum}::#{name m}," end.join("\n")}
+                #[allow(unreachable_patterns)]
+                _ => return Err(Error::Invalid),
+            };
+            Ok(e)
+        }
+    }
+
+    impl From<#{name enum}> for i32 {
+        #[must_use]
+        fn from(e: #{name enum}) -> Self {
+            e as Self
+        }
+    }
+
+    impl ReadXdr for #{name enum} {
+        #[cfg(feature = "std")]
+        fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
+            r.with_limited_depth(|r| {
+                let e = i32::read_xdr(r)?;
+                let v: Self = e.try_into()?;
+                Ok(v)
+            })
+        }
+    }
+
+    impl WriteXdr for #{name enum} {
+        #[cfg(feature = "std")]
+        fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
+            w.with_limited_depth(|w| {
+                let i: i32 = (*self).into();
+                i.write_xdr(w)
+            })
+        }
+    }
+    EOS
+    out.break
+  end
+
+  def union_is_idents(union)
+    union.normal_arms.first&.cases.first&.value.is_a?(AST::Identifier)
+  end
+
+  def union_cases(union)
+    results = []
+    union.normal_arms.each do |arm|
+      arm.cases.each do |kase|
+          if kase.value.is_a?(AST::Identifier)
+            case_name = kase.name_short.underscore.camelize
+            value = nil
+          else
+            case_name = "V#{kase.value.value}"
+            value = kase.value.value
+          end
+          results << yield(case_name, arm, value)
+      end
+    end
+    results
+  end
+
+  def render_union(out, union)
+    if union.default_arm.present?
+      $stderr.puts "warn: union #{name union} includes default arms and default arms are not supported in the rust generator"
+    end
+    discriminant_type = reference(nil, union.discriminant.type)
+    discriminant_type_builtin = is_builtin_type(union.discriminant.type) || (is_builtin_type(union.discriminant.type.resolved_type.type) if union.discriminant.type.respond_to?(:resolved_type) && AST::Definitions::Typedef === union.discriminant.type.resolved_type)
+    out.puts "// union with discriminant #{discriminant_type}"
+    out.puts %{#[cfg_eval::cfg_eval]}
+    out.puts "#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]"
+    out.puts %{#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]}
+    if @options[:custom_str_impl].include?(name union)
+      out.puts %{#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]}
+    else
+      out.puts %{#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]}
+    end
+    if !@options[:custom_str_impl].include?(name union)
+      out.puts %{#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]}
+    end
+    out.puts "#[allow(clippy::large_enum_variant)]"
+    out.puts "pub enum #{name union} {"
+    union_case_count = 0
+    out.indent do
+      union_cases(union) do |case_name, arm|
+        union_case_count += 1
+        if arm.void?
+          out.puts "#{case_name}#{"(())" unless arm.void?},"
+        else
+          out.puts "#{case_name}("
+          out.puts_if(field_attrs(union, arm.type)) if !@options[:custom_str_impl].include?(name union)
+          out.puts "  #{reference(union, arm.type)}"
+          out.puts "),"
+        end
+      end
+    end
+    out.puts '}'
+    out.puts ""
+    if !@options[:custom_default_impl].include?(name union)
+      union_cases(union) do |case_name, arm|
+        out.puts <<-EOS.strip_heredoc
+        #[cfg(feature = "alloc")]
+        impl Default for #{name union} {
+            fn default() -> Self {
+                Self::#{case_name}#{"(#{reference_to_call(union, arm.type)}::default())" if !arm.void?}
+            }
+        }
+        EOS
+        break # output the above for the first union case
+      end
+      out.puts ""
+    end
+    out.puts <<-EOS.strip_heredoc
+    impl #{name union} {
+        pub const VARIANTS: [#{discriminant_type}; #{union_case_count}] = [
+            #{union_cases(union) do |case_name, arm, value|
+              value.nil?                ? "#{discriminant_type}::#{case_name}," :
+              discriminant_type_builtin ? "#{value}," :
+                                          "#{discriminant_type}(#{value}),"
+            end.join("\n")}
+        ];
+        pub const VARIANTS_STR: [&'static str; #{union_case_count}] = [
+            #{union_cases(union) do |case_name, arm, value|
+              "\"#{case_name}\","
+            end.join("\n")}
+        ];
+
+        #[must_use]
+        pub const fn name(&self) -> &'static str {
+            match self {
+                #{union_cases(union) do |case_name, arm|
+                  "Self::#{case_name}#{"(_)" unless arm.void?} => \"#{case_name}\","
+                end.join("\n")}
+            }
+        }
+
+        #[must_use]
+        pub const fn discriminant(&self) -> #{discriminant_type} {
+            #[allow(clippy::match_same_arms)]
+            match self {
+                #{union_cases(union) do |case_name, arm, value|
+                  "Self::#{case_name}#{"(_)" unless arm.void?} => #{
+                    value.nil?                ? "#{discriminant_type}::#{case_name}" :
+                    discriminant_type_builtin ? "#{value}" :
+                                                "#{discriminant_type}(#{value})"
+                  },"
+                end.join("\n")}
+            }
+        }
+
+        #[must_use]
+        pub const fn variants() -> [#{discriminant_type}; #{union_case_count}] {
+            Self::VARIANTS
+        }
+    }
+
+    impl Name for #{name union} {
+        #[must_use]
+        fn name(&self) -> &'static str {
+            Self::name(self)
+        }
+    }
+
+    impl Discriminant<#{discriminant_type}> for #{name union} {
+        #[must_use]
+        fn discriminant(&self) -> #{discriminant_type} {
+            Self::discriminant(self)
+        }
+    }
+
+    impl Variants<#{discriminant_type}> for #{name union} {
+        fn variants() -> slice::Iter<'static, #{discriminant_type}> {
+            Self::VARIANTS.iter()
+        }
+    }
+
+    impl Union<#{discriminant_type}> for #{name union} {}
+
+    impl ReadXdr for #{name union} {
+        #[cfg(feature = "std")]
+        fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
+            r.with_limited_depth(|r| {
+                let dv: #{discriminant_type} = <#{discriminant_type} as ReadXdr>::read_xdr(r)?;
+                #[allow(clippy::match_same_arms, clippy::match_wildcard_for_single_variants)]
+                let v = match dv {
+                    #{union_cases(union) do |case_name, arm, value|
+                      "#{
+                        value.nil? ? "#{discriminant_type}::#{case_name}" : "#{value}"
+                      } => #{
+                        arm.void? ? "Self::#{case_name}" : "Self::#{case_name}(#{reference_to_call(union, arm.type)}::read_xdr(r)?)"
+                      },"
+                    end.join("\n")}
+                    #[allow(unreachable_patterns)]
+                    _ => return Err(Error::Invalid),
+                };
+                Ok(v)
+            })
+        }
+    }
+
+    impl WriteXdr for #{name union} {
+        #[cfg(feature = "std")]
+        fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
+            w.with_limited_depth(|w| {
+                self.discriminant().write_xdr(w)?;
+                #[allow(clippy::match_same_arms)]
+                match self {
+                    #{union_cases(union) do |case_name, arm, value|
+                      if arm.void?
+                        "Self::#{case_name} => ().write_xdr(w)?,"
+                      else
+                        "Self::#{case_name}(v) => v.write_xdr(w)?,"
+                      end
+                    end.join("\n")}
+                };
+                Ok(())
+            })
+        }
+    }
+    EOS
+    out.break
+  end
+
+  def render_typedef(out, typedef)
+    if is_builtin_type(typedef.type)
+      out.puts "pub type #{name typedef} = #{reference(typedef, typedef.type)};"
+    else
+      out.puts %{#[cfg_eval::cfg_eval]}
+      if !@options[:custom_default_impl].include?(name typedef)
+        if is_var_array_type(typedef.type)
+          out.puts "#[derive(Default)]"
+        else
+          out.puts %{#[cfg_attr(feature = "alloc", derive(Default))]}
+        end
+      end
+      out.puts "#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]"
+      out.puts %{#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]}
+      if is_fixed_array_opaque(typedef.type) || @options[:custom_str_impl].include?(name typedef)
+        out.puts %{#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]}
+      else
+        out.puts %{#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]}
+      end
+      if !is_fixed_array_opaque(typedef.type) && !@options[:custom_str_impl].include?(name typedef)
+        out.puts %{#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]}
+      end
+      if !is_fixed_array_opaque(typedef.type)
+        out.puts "#[derive(Debug)]"
+      end
+      out.puts "pub struct #{name typedef}("
+      out.puts_if(field_attrs(typedef, typedef.type)) if !@options[:custom_str_impl].include?(name typedef)
+      out.puts "  pub #{reference(typedef, typedef.type)}"
+      out.puts ");"
+      out.puts ""
+      if is_fixed_array_opaque(typedef.type)
+      out.puts <<-EOS.strip_heredoc
+      impl core::fmt::Debug for #{name typedef} {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            let v = &self.0;
+            write!(f, "#{name typedef}(")?;
+            for b in v {
+                write!(f, "{b:02x}")?;
+            }
+            write!(f, ")")?;
+            Ok(())
+        }
+      }
+      EOS
+      end
+      if is_fixed_array_opaque(typedef.type) && !@options[:custom_str_impl].include?(name typedef)
+      out.puts <<-EOS.strip_heredoc
+      impl core::fmt::Display for #{name typedef} {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            let v = &self.0;
+            for b in v {
+                write!(f, "{b:02x}")?;
+            }
+            Ok(())
+        }
+      }
+
+      #[cfg(feature = "alloc")]
+      impl core::str::FromStr for #{name typedef} {
+        type Err = Error;
+        fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
+            hex::decode(s).map_err(|_| Error::InvalidHex)?.try_into()
+        }
+      }
+      EOS
+      end
+      if is_fixed_array_opaque(typedef.type) && !@options[:custom_str_impl].include?(name typedef)
+      out.puts <<-EOS.strip_heredoc
+      #[cfg(feature = "schemars")]
+      impl schemars::JsonSchema for #{name typedef} {
+          fn schema_name() -> String {
+              "#{name typedef}".to_string()
+          }
+
+          fn is_referenceable() -> bool {
+              false
+          }
+
+          fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+              let schema = String::json_schema(gen);
+              if let schemars::schema::Schema::Object(mut schema) = schema {
+                  schema.extensions.insert(
+                      "contentEncoding".to_owned(),
+                      serde_json::Value::String("hex".to_string()),
+                  );
+                  schema.extensions.insert(
+                      "contentMediaType".to_owned(),
+                      serde_json::Value::String("application/binary".to_string()),
+                  );
+                  let string = *schema.string.unwrap_or_default().clone();
+                  schema.string = Some(Box::new(schemars::schema::StringValidation {
+                      max_length: #{typedef.type.size}_u32.checked_mul(2).map(Some).unwrap_or_default(),
+                      min_length: #{typedef.type.size}_u32.checked_mul(2).map(Some).unwrap_or_default(),
+                      ..string
+                  }));
+                  schema.into()
+              } else {
+                  schema
+              }
+          }
+      }
+      EOS
+      end
+      out.puts <<-EOS.strip_heredoc
+      impl From<#{name typedef}> for #{reference(typedef, typedef.type)} {
+          #[must_use]
+          fn from(x: #{name typedef}) -> Self {
+              x.0
+          }
+      }
+
+      impl From<#{reference(typedef, typedef.type)}> for #{name typedef} {
+          #[must_use]
+          fn from(x: #{reference(typedef, typedef.type)}) -> Self {
+              #{name typedef}(x)
+          }
+      }
+
+      impl AsRef<#{reference(typedef, typedef.type)}> for #{name typedef} {
+          #[must_use]
+          fn as_ref(&self) -> &#{reference(typedef, typedef.type)} {
+              &self.0
+          }
+      }
+
+      impl ReadXdr for #{name typedef} {
+          #[cfg(feature = "std")]
+          fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
+              r.with_limited_depth(|r| {
+                  let i = #{reference_to_call(typedef, typedef.type)}::read_xdr(r)?;
+                  let v = #{name typedef}(i);
+                  Ok(v)
+              })
+          }
+      }
+
+      impl WriteXdr for #{name typedef} {
+          #[cfg(feature = "std")]
+          fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
+              w.with_limited_depth(|w|{ self.0.write_xdr(w) })
+          }
+      }
+      EOS
+      if is_fixed_array_type(typedef.type)
+        out.break
+        out.puts <<-EOS.strip_heredoc
+        impl #{name typedef} {
+            #[must_use]
+            pub fn as_slice(&self) -> &[#{element_type_for_vec(typedef.type)}] {
+                &self.0
+            }
+        }
+
+        #[cfg(feature = "alloc")]
+        impl TryFrom<Vec<#{element_type_for_vec(typedef.type)}>> for #{name typedef} {
+            type Error = Error;
+            fn try_from(x: Vec<#{element_type_for_vec(typedef.type)}>) -> Result<Self, Error> {
+                x.as_slice().try_into()
+            }
+        }
+
+        #[cfg(feature = "alloc")]
+        impl TryFrom<&Vec<#{element_type_for_vec(typedef.type)}>> for #{name typedef} {
+            type Error = Error;
+            fn try_from(x: &Vec<#{element_type_for_vec(typedef.type)}>) -> Result<Self, Error> {
+                x.as_slice().try_into()
+            }
+        }
+
+        impl TryFrom<&[#{element_type_for_vec(typedef.type)}]> for #{name typedef} {
+            type Error = Error;
+            fn try_from(x: &[#{element_type_for_vec(typedef.type)}]) -> Result<Self, Error> {
+                Ok(#{name typedef}(x.try_into()?))
+            }
+        }
+
+        impl AsRef<[#{element_type_for_vec(typedef.type)}]> for #{name typedef} {
+            #[must_use]
+            fn as_ref(&self) -> &[#{element_type_for_vec(typedef.type)}] {
+                &self.0
+            }
+        }
+        EOS
+      end
+      if is_var_array_type(typedef.type)
+        out.break
+        out.puts <<-EOS.strip_heredoc
+        impl Deref for #{name typedef} {
+          type Target = #{reference(typedef, typedef.type)};
+          fn deref(&self) -> &Self::Target {
+              &self.0
+          }
+        }
+
+        impl From<#{name typedef}> for Vec<#{element_type_for_vec(typedef.type)}> {
+            #[must_use]
+            fn from(x: #{name typedef}) -> Self {
+                x.0.0
+            }
+        }
+
+        impl TryFrom<Vec<#{element_type_for_vec(typedef.type)}>> for #{name typedef} {
+            type Error = Error;
+            fn try_from(x: Vec<#{element_type_for_vec(typedef.type)}>) -> Result<Self, Error> {
+                Ok(#{name typedef}(x.try_into()?))
+            }
+        }
+
+        #[cfg(feature = "alloc")]
+        impl TryFrom<&Vec<#{element_type_for_vec(typedef.type)}>> for #{name typedef} {
+            type Error = Error;
+            fn try_from(x: &Vec<#{element_type_for_vec(typedef.type)}>) -> Result<Self, Error> {
+                Ok(#{name typedef}(x.try_into()?))
+            }
+        }
+
+        impl AsRef<Vec<#{element_type_for_vec(typedef.type)}>> for #{name typedef} {
+            #[must_use]
+            fn as_ref(&self) -> &Vec<#{element_type_for_vec(typedef.type)}> {
+                &self.0.0
+            }
+        }
+
+        impl AsRef<[#{element_type_for_vec(typedef.type)}]> for #{name typedef} {
+            #[cfg(feature = "alloc")]
+            #[must_use]
+            fn as_ref(&self) -> &[#{element_type_for_vec(typedef.type)}] {
+                &self.0.0
+            }
+            #[cfg(not(feature = "alloc"))]
+            #[must_use]
+            fn as_ref(&self) -> &[#{element_type_for_vec(typedef.type)}] {
+                self.0.0
+            }
+        }
+        EOS
+      end
+    end
+    out.break
+  end
+
+  def render_const(out, const)
+    out.puts "pub const #{name(const).underscore.upcase}: u64 = #{const.value};"
+    out.break
+  end
+
+  def is_builtin_type(type)
+    [
+      AST::Typespecs::Bool,
+      AST::Typespecs::Double, AST::Typespecs::Float,
+      AST::Typespecs::UnsignedHyper, AST::Typespecs::UnsignedInt,
+      AST::Typespecs::Hyper, AST::Typespecs::Int,
+    ].any? { |t| t === type }
+  end
+
+  def is_fixed_array_opaque(type)
+    (AST::Typespecs::Opaque === type && type.fixed?)
+  end
+
+  def is_fixed_array_type(type)
+    (AST::Typespecs::Opaque === type && type.fixed?) ||
+    (type.sub_type == :array)
+  end
+
+  def is_var_array_type(type)
+    (AST::Typespecs::Opaque === type && !type.fixed?) ||
+    (AST::Typespecs::String === type) ||
+    (type.sub_type == :var_array)
+  end
+
+  def base_reference(type)
+    case type
+    when AST::Typespecs::Bool
+      'bool'
+    when AST::Typespecs::Double
+      $stderr.puts "warn: rust generator has not implemented f64 support"
+      'f64'
+    when AST::Typespecs::Float
+      $stderr.puts "warn: rust generator has not implemented f64 support"
+      'f32'
+    when AST::Typespecs::UnsignedHyper
+      'u64'
+    when AST::Typespecs::UnsignedInt
+      'u32'
+    when AST::Typespecs::Hyper
+      'i64'
+    when AST::Typespecs::Int
+      'i32'
+    when AST::Typespecs::Quadruple
+      raise 'no quadruple support for rust'
+    when AST::Typespecs::String
+      if !type.decl.resolved_size.nil?
+        "StringM::<#{type.decl.resolved_size}>"
+      else
+        "StringM"
+      end
+    when AST::Typespecs::Opaque
+      if type.fixed?
+        "[u8; #{type.size}]"
+      elsif !type.decl.resolved_size.nil?
+        "BytesM::<#{type.decl.resolved_size}>"
+      else
+        "BytesM"
+      end
+    when AST::Typespecs::Simple, AST::Definitions::Base, AST::Concerns::NestedDefinition
+      if type.respond_to?(:resolved_type) && AST::Definitions::Typedef === type.resolved_type && is_builtin_type(type.resolved_type.type)
+        base_reference(type.resolved_type.type)
+      else
+        name type
+      end
+    else
+      raise "Unknown reference type: #{type.class.name}, #{type.class.ancestors}"
+    end
+  end
+
+  def array_size(type)
+    _, size = type.array_size
+    size = name @top.find_definition(size) if is_named
+    size
+  end
+
+  def field_attrs(parent, type)
+    base_ref = base_reference(type)
+    if ['i64','u64'].include?(base_ref)
+      ref = reference(parent, type, 'NumberOrString')
+      "#[cfg_attr(all(feature = \"serde\", feature = \"alloc\"), serde_as(as = \"#{ref}\"))]"
+    else
+      nil
+    end
+  end
+
+  def reference(parent, type, base_ref = nil)
+    base_ref = base_reference(type) if base_ref.nil?
+
+    parent_name = name(parent) if parent
+    cyclic = is_type_in_type_field_types(base_ref, parent_name)
+
+    case type.sub_type
+    when :simple
+      if cyclic
+        "Box<#{base_ref}>"
+      else
+        base_ref
+      end
+    when :optional
+      if cyclic
+        "Option<Box<#{base_ref}>>"
+      else
+        "Option<#{base_ref}>"
+      end
+    when :array
+      is_named, size = type.array_size
+      size = name @top.find_definition(size) if is_named
+      "[#{base_ref}; #{size}]"
+    when :var_array
+      if !type.decl.resolved_size.nil?
+        "VecM<#{base_ref}, #{type.decl.resolved_size}>"
+      else
+        "VecM<#{base_ref}>"
+      end
+    else
+      raise "Unknown sub_type: #{type.sub_type}"
+    end
+  end
+
+  def element_type_for_vec(type)
+    case type
+    when AST::Typespecs::String
+      "u8"
+    when AST::Typespecs::Opaque
+      "u8"
+    when AST::Typespecs::Simple, AST::Definitions::Base, AST::Concerns::NestedDefinition
+      if type.respond_to?(:resolved_type) && AST::Definitions::Typedef === type.resolved_type && is_builtin_type(type.resolved_type.type)
+        base_reference(type.resolved_type.type)
+      else
+        name type
+      end
+    else
+      raise "Unknown element type for vec: #{type.class.name}, #{type.class.ancestors}"
+    end
+  end
+
+  def base_reference_to_call(type)
+    case type
+    when AST::Typespecs::String
+      if !type.decl.resolved_size.nil?
+        "StringM::<#{type.decl.resolved_size}>"
+      else
+        "StringM"
+      end
+    when AST::Typespecs::Opaque
+      if type.fixed?
+        "[u8; #{type.size}]"
+      elsif !type.decl.resolved_size.nil?
+        "BytesM::<#{type.decl.resolved_size}>"
+      else
+        "BytesM"
+      end
+    when AST::Typespecs::Simple, AST::Definitions::Base, AST::Concerns::NestedDefinition
+      if type.respond_to?(:resolved_type) && AST::Definitions::Typedef === type.resolved_type && is_builtin_type(type.resolved_type.type)
+        base_reference_to_call(type.resolved_type.type)
+      else
+        base_reference(type)
+      end
+    else
+      base_reference(type)
+    end
+  end
+
+  def reference_to_call(parent, type)
+    base_ref = base_reference_to_call(type)
+
+    parent_name = name(parent) if parent
+    cyclic = is_type_in_type_field_types(base_ref, parent_name)
+
+    ref = case type.sub_type
+    when :simple
+      if cyclic
+        "Box<#{base_ref}>"
+      else
+        base_ref
+      end
+    when :optional
+      if cyclic
+        "Option::<Box<#{base_ref}>>"
+      else
+        "Option::<#{base_ref}>"
+      end
+    when :array
+      is_named, size = type.array_size
+      size = name @top.find_definition(size) if is_named
+      "[#{base_ref}; #{size}]"
+    when :var_array
+      if !type.decl.resolved_size.nil?
+        "VecM::<#{base_ref}, #{type.decl.resolved_size}>"
+      else
+        "VecM::<#{base_ref}>"
+      end
+    else
+      raise "Unknown sub_type: #{type.sub_type}"
+    end
+
+    if ref.starts_with?("[") && ref.ends_with?("]")
+      "<#{ref}>"
+    elsif ref.starts_with?("Box<") && ref.ends_with?(">")
+      "Box::#{ref.delete_prefix("Box")}"
+    else
+      ref
+    end
+  end
+
+  def name(named)
+    parent = name named.parent_defn if named.is_a?(AST::Concerns::NestedDefinition)
+
+    base = if named.respond_to?(:name_short)
+      named.name_short
+    elsif named.respond_to?(:name)
+      named.name
+    else
+      named.text_value
+    end
+    base = escape_name(base)
+    "#{parent}#{base.underscore.camelize}"
+  end
+
+  def field_name(named)
+    escape_name named.name.underscore
+  end
+
+  def escape_name(name)
+    case name
+    when 'type' then 'type_'
+    when 'Error' then 'SError'
+    else name
+    end
+  end
+
+end

--- a/xdr-generator/generator/header.rs
+++ b/xdr-generator/generator/header.rs
@@ -1,0 +1,3958 @@
+use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref, slice};
+
+#[cfg(feature = "std")]
+use core::marker::PhantomData;
+
+// When feature alloc is turned off use static lifetime Box and Vec types.
+#[cfg(not(feature = "alloc"))]
+mod noalloc {
+    pub mod boxed {
+        pub type Box<T> = &'static T;
+    }
+    pub mod vec {
+        pub type Vec<T> = &'static [T];
+    }
+}
+#[cfg(not(feature = "alloc"))]
+use noalloc::{boxed::Box, vec::Vec};
+
+// When feature std is turned off, but feature alloc is turned on import the
+// alloc crate and use its Box and Vec types.
+#[cfg(all(not(feature = "std"), feature = "alloc"))]
+extern crate alloc;
+#[cfg(all(not(feature = "std"), feature = "alloc"))]
+use alloc::{
+    borrow::ToOwned,
+    boxed::Box,
+    string::{FromUtf8Error, String},
+    vec::Vec,
+};
+#[cfg(feature = "std")]
+use std::string::FromUtf8Error;
+
+#[cfg(feature = "arbitrary")]
+use arbitrary::Arbitrary;
+
+#[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
+use std::borrow::Cow;
+#[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
+use alloc::borrow::Cow;
+
+// TODO: Add support for read/write xdr fns when std not available.
+
+#[cfg(feature = "std")]
+use std::{
+    error, io,
+    io::{BufRead, BufReader, Cursor, Read, Write},
+};
+
+/// Error contains all errors returned by functions in this crate. It can be
+/// compared via `PartialEq`, however any contained IO errors will only be
+/// compared on their `ErrorKind`.
+#[derive(Debug)]
+pub enum Error {
+    Invalid,
+    Unsupported,
+    LengthExceedsMax,
+    LengthMismatch,
+    NonZeroPadding,
+    Utf8Error(core::str::Utf8Error),
+    #[cfg(feature = "alloc")]
+    InvalidHex,
+    #[cfg(feature = "std")]
+    Io(io::Error),
+    DepthLimitExceeded,
+    #[cfg(feature = "serde_json")]
+    Json(serde_json::Error),
+    LengthLimitExceeded,
+    #[cfg(feature = "arbitrary")]
+    Arbitrary(arbitrary::Error),
+}
+
+impl PartialEq for Error {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Utf8Error(l), Self::Utf8Error(r)) => l == r,
+
+            // IO errors cannot be compared, but in the absence of any more
+            // meaningful way to compare the errors we compare the kind of error
+            // and ignore the embedded source error or OS error. The main use
+            // case for comparing errors outputted by the XDR library is for
+            // error case testing, and a lack of the ability to compare has a
+            // detrimental affect on failure testing, so this is a tradeoff.
+            #[cfg(feature = "std")]
+            (Self::Io(l), Self::Io(r)) => l.kind() == r.kind(),
+
+            #[cfg(feature = "arbitrary")]
+            (Self::Arbitrary(l), Self::Arbitrary(r)) => l == r,
+
+            _ => core::mem::discriminant(self) == core::mem::discriminant(other),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl error::Error for Error {
+    #[must_use]
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match self {
+            Self::Io(e) => Some(e),
+            #[cfg(feature = "serde_json")]
+            Self::Json(e) => Some(e),
+            #[cfg(feature = "arbitrary")]
+            Self::Arbitrary(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::Invalid => write!(f, "xdr value invalid"),
+            Error::Unsupported => write!(f, "xdr value unsupported"),
+            Error::LengthExceedsMax => write!(f, "xdr value max length exceeded"),
+            Error::LengthMismatch => write!(f, "xdr value length does not match"),
+            Error::NonZeroPadding => write!(f, "xdr padding contains non-zero bytes"),
+            Error::Utf8Error(e) => write!(f, "{e}"),
+            #[cfg(feature = "alloc")]
+            Error::InvalidHex => write!(f, "hex invalid"),
+            #[cfg(feature = "std")]
+            Error::Io(e) => write!(f, "{e}"),
+            Error::DepthLimitExceeded => write!(f, "depth limit exceeded"),
+            #[cfg(feature = "serde_json")]
+            Error::Json(e) => write!(f, "{e}"),
+            Error::LengthLimitExceeded => write!(f, "length limit exceeded"),
+            #[cfg(feature = "arbitrary")]
+            Error::Arbitrary(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl From<TryFromSliceError> for Error {
+    fn from(_: TryFromSliceError) -> Error {
+        Error::LengthMismatch
+    }
+}
+
+impl From<core::str::Utf8Error> for Error {
+    #[must_use]
+    fn from(e: core::str::Utf8Error) -> Self {
+        Error::Utf8Error(e)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl From<FromUtf8Error> for Error {
+    #[must_use]
+    fn from(e: FromUtf8Error) -> Self {
+        Error::Utf8Error(e.utf8_error())
+    }
+}
+
+#[cfg(feature = "std")]
+impl From<io::Error> for Error {
+    #[must_use]
+    fn from(e: io::Error) -> Self {
+        Error::Io(e)
+    }
+}
+
+#[cfg(feature = "serde_json")]
+impl From<serde_json::Error> for Error {
+    #[must_use]
+    fn from(e: serde_json::Error) -> Self {
+        Error::Json(e)
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl From<arbitrary::Error> for Error {
+    #[must_use]
+    fn from(e: arbitrary::Error) -> Self {
+        Error::Arbitrary(e)
+    }
+}
+
+impl From<Error> for () {
+    fn from(_: Error) {}
+}
+
+/// Name defines types that assign a static name to their value, such as the
+/// name given to an identifier in an XDR enum, or the name given to the case in
+/// a union.
+pub trait Name {
+    fn name(&self) -> &'static str;
+}
+
+/// Discriminant defines types that may contain a one-of value determined
+/// according to the discriminant, and exposes the value of the discriminant for
+/// that type, such as in an XDR union.
+pub trait Discriminant<D> {
+    fn discriminant(&self) -> D;
+}
+
+/// Iter defines types that have variants that can be iterated.
+pub trait Variants<V> {
+    fn variants() -> slice::Iter<'static, V>
+    where
+        V: Sized;
+}
+
+// Enum defines a type that is represented as an XDR enumeration when encoded.
+pub trait Enum: Name + Variants<Self> + Sized {}
+
+// Union defines a type that is represented as an XDR union when encoded.
+pub trait Union<D>: Name + Discriminant<D> + Variants<D>
+where
+    D: Sized,
+{
+}
+
+/// `Limits` contains the limits that a limited reader or writer will be
+/// constrained to.
+#[cfg(feature = "std")]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Limits {
+    /// Defines the maximum depth for recursive calls in `Read/WriteXdr` to
+    /// prevent stack overflow.
+    ///
+    /// The depth limit is akin to limiting stack depth. Its purpose is to
+    /// prevent the program from hitting the maximum stack size allowed by Rust,
+    /// which would result in an unrecoverable `SIGABRT`.  For more information
+    /// about Rust's stack size limit, refer to the [Rust
+    /// documentation](https://doc.rust-lang.org/std/thread/#stack-size).
+    pub depth: u32,
+
+    /// Defines the maximum number of bytes that will be read or written.
+    pub len: usize,
+}
+
+#[cfg(feature = "std")]
+impl Limits {
+    #[must_use]
+    pub fn none() -> Self {
+        Self {
+            depth: u32::MAX,
+            len: usize::MAX,
+        }
+    }
+
+    #[must_use]
+    pub fn depth(depth: u32) -> Self {
+        Limits {
+            depth,
+            ..Limits::none()
+        }
+    }
+
+    #[must_use]
+    pub fn len(len: usize) -> Self {
+        Limits {
+            len,
+            ..Limits::none()
+        }
+    }
+}
+
+/// `Limited` wraps an object and provides functions for enforcing limits.
+///
+/// Intended for use with readers and writers and limiting their reads and
+/// writes.
+#[cfg(feature = "std")]
+pub struct Limited<L> {
+    pub inner: L,
+    pub(crate) limits: Limits,
+}
+
+#[cfg(feature = "std")]
+impl<L> Limited<L> {
+    /// Constructs a new `Limited`.
+    ///
+    /// - `inner`: The value being limited.
+    /// - `limits`: The limits to enforce.
+    pub fn new(inner: L, limits: Limits) -> Self {
+        Limited { inner, limits }
+    }
+
+    /// Consume the given length from the internal remaining length limit.
+    ///
+    /// ### Errors
+    ///
+    /// If the length would consume more length than the remaining length limit
+    /// allows.
+    pub(crate) fn consume_len(&mut self, len: usize) -> Result<(), Error> {
+        if let Some(len) = self.limits.len.checked_sub(len) {
+            self.limits.len = len;
+            Ok(())
+        } else {
+            Err(Error::LengthLimitExceeded)
+        }
+    }
+
+    /// Consumes a single depth for the duration of the given function.
+    ///
+    /// ### Errors
+    ///
+    /// If the depth limit is already exhausted.
+    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T, Error>
+    where
+        F: FnOnce(&mut Self) -> Result<T, Error>,
+    {
+        if let Some(depth) = self.limits.depth.checked_sub(1) {
+            self.limits.depth = depth;
+            let res = f(self);
+            self.limits.depth = self.limits.depth.saturating_add(1);
+            res
+        } else {
+            Err(Error::DepthLimitExceeded)
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for Limited<R> {
+    /// Forwards the read operation to the wrapped object.
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.inner.read(buf)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: BufRead> BufRead for Limited<R> {
+    /// Forwards the read operation to the wrapped object.
+    fn fill_buf(&mut self) -> std::io::Result<&[u8]> {
+        self.inner.fill_buf()
+    }
+
+    /// Forwards the read operation to the wrapped object.
+    fn consume(&mut self, amt: usize) {
+        self.inner.consume(amt);
+    }
+}
+
+#[cfg(feature = "std")]
+impl<W: Write> Write for Limited<W> {
+    /// Forwards the write operation to the wrapped object.
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.inner.write(buf)
+    }
+
+    /// Forwards the flush operation to the wrapped object.
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+#[cfg(feature = "std")]
+pub struct ReadXdrIter<R: Read, S: ReadXdr> {
+    reader: Limited<BufReader<R>>,
+    _s: PhantomData<S>,
+}
+
+#[cfg(feature = "std")]
+impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
+    fn new(r: R, limits: Limits) -> Self {
+        Self {
+            reader: Limited {
+                inner: BufReader::new(r),
+                limits,
+            },
+            _s: PhantomData,
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
+    type Item = Result<S, Error>;
+
+    // Next reads the internal reader and XDR decodes it into the Self type. If
+    // the EOF is reached without reading any new bytes `None` is returned. If
+    // EOF is reached after reading some bytes a truncated entry is assumed an
+    // an `Error::Io` containing an `UnexpectedEof`. If any other IO error
+    // occurs it is returned. Iteration of this iterator stops naturally when
+    // `None` is returned, but not when a `Some(Err(...))` is returned. The
+    // caller is responsible for checking each Result.
+    fn next(&mut self) -> Option<Self::Item> {
+        // Try to fill the buffer to see if the EOF has been reached or not.
+        // This happens to effectively peek to see if the stream has finished
+        // and there are no more items.  It is necessary to do this because the
+        // xdr types in this crate heavily use the `std::io::Read::read_exact`
+        // method that doesn't distinguish between an EOF at the beginning of a
+        // read and an EOF after a partial fill of a read_exact.
+        match self.reader.fill_buf() {
+            // If the reader has no more data and is unable to fill any new data
+            // into its internal buf, then the EOF has been reached.
+            Ok([]) => return None,
+            // If an error occurs filling the buffer, treat that as an error and stop.
+            Err(e) => return Some(Err(Error::Io(e))),
+            // If there is data in the buf available for reading, continue.
+            Ok([..]) => (),
+        };
+        // Read the buf into the type.
+        let r = self.reader.with_limited_depth(|dlr| S::read_xdr(dlr));
+        match r {
+            Ok(s) => Some(Ok(s)),
+            Err(e) => Some(Err(e)),
+        }
+    }
+}
+
+pub trait ReadXdr
+where
+    Self: Sized,
+{
+    /// Read the XDR and construct the type.
+    ///
+    /// Read bytes from the given read implementation, decoding the bytes as
+    /// XDR, and construct the type implementing this interface from those
+    /// bytes.
+    ///
+    /// Just enough bytes are read from the read implementation to construct the
+    /// type. Any residual bytes remain in the read implementation.
+    ///
+    /// All implementations should continue if the read implementation returns
+    /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
+    ///
+    /// Use [`ReadXdR: Read_xdr_to_end`] when the intent is for all bytes in the
+    /// read implementation to be consumed by the read.
+    #[cfg(feature = "std")]
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error>;
+
+    /// Construct the type from the XDR bytes base64 encoded.
+    ///
+    /// An error is returned if the bytes are not completely consumed by the
+    /// deserialization.
+    #[cfg(feature = "base64")]
+    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
+        let mut dec = Limited::new(
+            base64::read::DecoderReader::new(
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
+            ),
+            r.limits.clone(),
+        );
+        let t = Self::read_xdr(&mut dec)?;
+        Ok(t)
+    }
+
+    /// Read the XDR and construct the type, and consider it an error if the
+    /// read does not completely consume the read implementation.
+    ///
+    /// Read bytes from the given read implementation, decoding the bytes as
+    /// XDR, and construct the type implementing this interface from those
+    /// bytes.
+    ///
+    /// Just enough bytes are read from the read implementation to construct the
+    /// type, and then confirm that no further bytes remain. To confirm no
+    /// further bytes remain additional bytes are attempted to be read from the
+    /// read implementation. If it is possible to read any residual bytes from
+    /// the read implementation an error is returned. The read implementation
+    /// may not be exhaustively read if there are residual bytes, and it is
+    /// considered undefined how many residual bytes or how much of the residual
+    /// buffer are consumed in this case.
+    ///
+    /// All implementations should continue if the read implementation returns
+    /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
+    #[cfg(feature = "std")]
+    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
+        let s = Self::read_xdr(r)?;
+        // Check that any further reads, such as this read of one byte, read no
+        // data, indicating EOF. If a byte is read the data is invalid.
+        if r.read(&mut [0u8; 1])? == 0 {
+            Ok(s)
+        } else {
+            Err(Error::Invalid)
+        }
+    }
+
+    /// Construct the type from the XDR bytes base64 encoded.
+    ///
+    /// An error is returned if the bytes are not completely consumed by the
+    /// deserialization.
+    #[cfg(feature = "base64")]
+    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
+        let mut dec = Limited::new(
+            base64::read::DecoderReader::new(
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
+            ),
+            r.limits.clone(),
+        );
+        let t = Self::read_xdr_to_end(&mut dec)?;
+        Ok(t)
+    }
+
+    /// Read the XDR and construct the type.
+    ///
+    /// Read bytes from the given read implementation, decoding the bytes as
+    /// XDR, and construct the type implementing this interface from those
+    /// bytes.
+    ///
+    /// Just enough bytes are read from the read implementation to construct the
+    /// type. Any residual bytes remain in the read implementation.
+    ///
+    /// All implementations should continue if the read implementation returns
+    /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
+    ///
+    /// Use [`ReadXdR: Read_xdr_into_to_end`] when the intent is for all bytes
+    /// in the read implementation to be consumed by the read.
+    #[cfg(feature = "std")]
+    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<(), Error> {
+        *self = Self::read_xdr(r)?;
+        Ok(())
+    }
+
+    /// Read the XDR into the existing value, and consider it an error if the
+    /// read does not completely consume the read implementation.
+    ///
+    /// Read bytes from the given read implementation, decoding the bytes as
+    /// XDR, and construct the type implementing this interface from those
+    /// bytes.
+    ///
+    /// Just enough bytes are read from the read implementation to construct the
+    /// type, and then confirm that no further bytes remain. To confirm no
+    /// further bytes remain additional bytes are attempted to be read from the
+    /// read implementation. If it is possible to read any residual bytes from
+    /// the read implementation an error is returned. The read implementation
+    /// may not be exhaustively read if there are residual bytes, and it is
+    /// considered undefined how many residual bytes or how much of the residual
+    /// buffer are consumed in this case.
+    ///
+    /// All implementations should continue if the read implementation returns
+    /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
+    #[cfg(feature = "std")]
+    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<(), Error> {
+        Self::read_xdr_into(self, r)?;
+        // Check that any further reads, such as this read of one byte, read no
+        // data, indicating EOF. If a byte is read the data is invalid.
+        if r.read(&mut [0u8; 1])? == 0 {
+            Ok(())
+        } else {
+            Err(Error::Invalid)
+        }
+    }
+
+    /// Create an iterator that reads the read implementation as a stream of
+    /// values that are read into the implementing type.
+    ///
+    /// Read bytes from the given read implementation, decoding the bytes as
+    /// XDR, and construct the type implementing this interface from those
+    /// bytes.
+    ///
+    /// Just enough bytes are read from the read implementation to construct the
+    /// type, and then confirm that no further bytes remain. To confirm no
+    /// further bytes remain additional bytes are attempted to be read from the
+    /// read implementation. If it is possible to read any residual bytes from
+    /// the read implementation an error is returned. The read implementation
+    /// may not be exhaustively read if there are residual bytes, and it is
+    /// considered undefined how many residual bytes or how much of the residual
+    /// buffer are consumed in this case.
+    ///
+    /// All implementations should continue if the read implementation returns
+    /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
+    #[cfg(feature = "std")]
+    fn read_xdr_iter<R: Read>(r: &mut Limited<R>) -> ReadXdrIter<&mut R, Self> {
+        ReadXdrIter::new(&mut r.inner, r.limits.clone())
+    }
+
+    /// Create an iterator that reads the read implementation as a stream of
+    /// values that are read into the implementing type.
+    #[cfg(feature = "base64")]
+    fn read_xdr_base64_iter<R: Read>(
+        r: &mut Limited<R>,
+    ) -> ReadXdrIter<
+        base64::read::DecoderReader<
+            base64::engine::general_purpose::GeneralPurpose,
+            SkipWhitespace<&mut R>,
+        >,
+        Self
+    > {
+        let dec = base64::read::DecoderReader::new(
+            SkipWhitespace::new(&mut r.inner),
+            &base64::engine::general_purpose::STANDARD,
+        );
+        ReadXdrIter::new(dec, r.limits.clone())
+    }
+
+    /// Construct the type from the XDR bytes.
+    ///
+    /// An error is returned if the bytes are not completely consumed by the
+    /// deserialization.
+    #[cfg(feature = "std")]
+    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
+        let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
+        let t = Self::read_xdr_to_end(&mut cursor)?;
+        Ok(t)
+    }
+
+    /// Construct the type from the XDR bytes base64 encoded.
+    ///
+    /// An error is returned if the bytes are not completely consumed by the
+    /// deserialization.
+    #[cfg(feature = "base64")]
+    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
+        let b64_reader = Cursor::new(b64);
+        let mut dec = Limited::new(
+            base64::read::DecoderReader::new(
+                SkipWhitespace::new(b64_reader),
+                &base64::engine::general_purpose::STANDARD,
+            ),
+            limits,
+        );
+        let t = Self::read_xdr_to_end(&mut dec)?;
+        Ok(t)
+    }
+}
+
+pub trait WriteXdr {
+    #[cfg(feature = "std")]
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error>;
+
+    #[cfg(feature = "std")]
+    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>, Error> {
+        let mut cursor = Limited::new(Cursor::new(vec![]), limits);
+        self.write_xdr(&mut cursor)?;
+        let bytes = cursor.inner.into_inner();
+        Ok(bytes)
+    }
+
+    #[cfg(feature = "base64")]
+    fn to_xdr_base64(&self, limits: Limits) -> Result<String, Error> {
+        let mut enc = Limited::new(
+            base64::write::EncoderStringWriter::new(&base64::engine::general_purpose::STANDARD),
+            limits,
+        );
+        self.write_xdr(&mut enc)?;
+        let b64 = enc.inner.into_inner();
+        Ok(b64)
+    }
+}
+
+/// `Pad_len` returns the number of bytes to pad an XDR value of the given
+/// length to make the final serialized size a multiple of 4.
+#[cfg(feature = "std")]
+fn pad_len(len: usize) -> usize {
+    (4 - (len % 4)) % 4
+}
+
+impl ReadXdr for i32 {
+    #[cfg(feature = "std")]
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
+        let mut b = [0u8; 4];
+        r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
+            r.read_exact(&mut b)?;
+            Ok(i32::from_be_bytes(b))
+        })
+    }
+}
+
+impl WriteXdr for i32 {
+    #[cfg(feature = "std")]
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
+        let b: [u8; 4] = self.to_be_bytes();
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
+    }
+}
+
+impl ReadXdr for u32 {
+    #[cfg(feature = "std")]
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
+        let mut b = [0u8; 4];
+        r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
+            r.read_exact(&mut b)?;
+            Ok(u32::from_be_bytes(b))
+        })
+    }
+}
+
+impl WriteXdr for u32 {
+    #[cfg(feature = "std")]
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
+        let b: [u8; 4] = self.to_be_bytes();
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
+    }
+}
+
+impl ReadXdr for i64 {
+    #[cfg(feature = "std")]
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
+        let mut b = [0u8; 8];
+        r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
+            r.read_exact(&mut b)?;
+            Ok(i64::from_be_bytes(b))
+        })
+    }
+}
+
+impl WriteXdr for i64 {
+    #[cfg(feature = "std")]
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
+        let b: [u8; 8] = self.to_be_bytes();
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
+    }
+}
+
+impl ReadXdr for u64 {
+    #[cfg(feature = "std")]
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
+        let mut b = [0u8; 8];
+        r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
+            r.read_exact(&mut b)?;
+            Ok(u64::from_be_bytes(b))
+        })
+    }
+}
+
+impl WriteXdr for u64 {
+    #[cfg(feature = "std")]
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
+        let b: [u8; 8] = self.to_be_bytes();
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
+    }
+}
+
+impl ReadXdr for f32 {
+    #[cfg(feature = "std")]
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
+        todo!()
+    }
+}
+
+impl WriteXdr for f32 {
+    #[cfg(feature = "std")]
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
+        todo!()
+    }
+}
+
+impl ReadXdr for f64 {
+    #[cfg(feature = "std")]
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
+        todo!()
+    }
+}
+
+impl WriteXdr for f64 {
+    #[cfg(feature = "std")]
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
+        todo!()
+    }
+}
+
+impl ReadXdr for bool {
+    #[cfg(feature = "std")]
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
+        r.with_limited_depth(|r| {
+            let i = u32::read_xdr(r)?;
+            let b = i == 1;
+            Ok(b)
+        })
+    }
+}
+
+impl WriteXdr for bool {
+    #[cfg(feature = "std")]
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
+        w.with_limited_depth(|w| {
+            let i = u32::from(*self); // true = 1, false = 0
+            i.write_xdr(w)
+        })
+    }
+}
+
+impl<T: ReadXdr> ReadXdr for Option<T> {
+    #[cfg(feature = "std")]
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
+        r.with_limited_depth(|r| {
+            let i = u32::read_xdr(r)?;
+            match i {
+                0 => Ok(None),
+                1 => {
+                    let t = T::read_xdr(r)?;
+                    Ok(Some(t))
+                }
+                _ => Err(Error::Invalid),
+            }
+        })
+    }
+}
+
+impl<T: WriteXdr> WriteXdr for Option<T> {
+    #[cfg(feature = "std")]
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
+        w.with_limited_depth(|w| {
+            if let Some(t) = self {
+                1u32.write_xdr(w)?;
+                t.write_xdr(w)?;
+            } else {
+                0u32.write_xdr(w)?;
+            }
+            Ok(())
+        })
+    }
+}
+
+impl<T: ReadXdr> ReadXdr for Box<T> {
+    #[cfg(feature = "std")]
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
+        r.with_limited_depth(|r| Ok(Box::new(T::read_xdr(r)?)))
+    }
+}
+
+impl<T: WriteXdr> WriteXdr for Box<T> {
+    #[cfg(feature = "std")]
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
+        w.with_limited_depth(|w| T::write_xdr(self, w))
+    }
+}
+
+impl ReadXdr for () {
+    #[cfg(feature = "std")]
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
+        Ok(())
+    }
+}
+
+impl WriteXdr for () {
+    #[cfg(feature = "std")]
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+impl<const N: usize> ReadXdr for [u8; N] {
+    #[cfg(feature = "std")]
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
+        r.with_limited_depth(|r| {
+            r.consume_len(N)?;
+            let padding = pad_len(N);
+            r.consume_len(padding)?;
+            let mut arr = [0u8; N];
+            r.read_exact(&mut arr)?;
+            let pad = &mut [0u8; 3][..padding];
+            r.read_exact(pad)?;
+            if pad.iter().any(|b| *b != 0) {
+                return Err(Error::NonZeroPadding);
+            }
+            Ok(arr)
+        })
+    }
+}
+
+impl<const N: usize> WriteXdr for [u8; N] {
+    #[cfg(feature = "std")]
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
+        w.with_limited_depth(|w| {
+            w.consume_len(N)?;
+            let padding = pad_len(N);
+            w.consume_len(padding)?;
+            w.write_all(self)?;
+            w.write_all(&[0u8; 3][..padding])?;
+            Ok(())
+        })
+    }
+}
+
+impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
+    #[cfg(feature = "std")]
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
+        r.with_limited_depth(|r| {
+            let mut vec = Vec::with_capacity(N);
+            for _ in 0..N {
+                let t = T::read_xdr(r)?;
+                vec.push(t);
+            }
+            let arr: [T; N] = vec.try_into().unwrap_or_else(|_: Vec<T>| unreachable!());
+            Ok(arr)
+        })
+    }
+}
+
+impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
+    #[cfg(feature = "std")]
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
+        w.with_limited_depth(|w| {
+            for t in self {
+                t.write_xdr(w)?;
+            }
+            Ok(())
+        })
+    }
+}
+
+// VecM ------------------------------------------------------------------------
+
+#[cfg(feature = "alloc")]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", serde_with::serde_as, derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
+
+#[cfg(not(feature = "alloc"))]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>)
+where
+    T: 'static;
+
+impl<T, const MAX: u32> Deref for VecM<T, MAX> {
+    type Target = Vec<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T, const MAX: u32> Default for VecM<T, MAX> {
+    fn default() -> Self {
+        Self(Vec::default())
+    }
+}
+
+#[cfg(feature = "schemars")]
+impl<T: schemars::JsonSchema, const MAX: u32> schemars::JsonSchema for VecM<T, MAX> {
+    fn schema_name() -> String {
+        format!("VecM<{}, {}>", T::schema_name(), MAX)
+    }
+
+    fn is_referenceable() -> bool {
+        false
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        let schema = Vec::<T>::json_schema(gen);
+        if let schemars::schema::Schema::Object(mut schema) = schema {
+            if let Some(array) = schema.array.clone() {
+                schema.array = Some(Box::new(schemars::schema::ArrayValidation {
+                    max_items: Some(MAX),
+                    ..*array
+                }));
+            }
+            schema.into()
+        } else {
+            schema
+        }
+    }
+}
+
+#[cfg(feature = "schemars")]
+impl<T, TA, const MAX: u32> serde_with::schemars_0_8::JsonSchemaAs<VecM<T, MAX>> for VecM<TA, MAX>
+where
+    TA: serde_with::schemars_0_8::JsonSchemaAs<T>,
+{
+    fn schema_name() -> String {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<T, U, const MAX: u32> serde_with::SerializeAs<VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::SerializeAs<T>,
+{
+    fn serialize_as<S>(source: &VecM<T, MAX>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(source.iter().map(|item| serde_with::ser::SerializeAsWrap::<T, U>::new(item)))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, T, U, const MAX: u32> serde_with::DeserializeAs<'de, VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::DeserializeAs<'de, T>,
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<VecM<T, MAX>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
+        vec.try_into().map_err(serde::de::Error::custom)
+    }
+}
+
+impl<T, const MAX: u32> VecM<T, MAX> {
+    pub const MAX_LEN: usize = { MAX as usize };
+
+    #[must_use]
+    #[allow(clippy::unused_self)]
+    pub fn max_len(&self) -> usize {
+        Self::MAX_LEN
+    }
+
+    #[must_use]
+    pub fn as_vec(&self) -> &Vec<T> {
+        self.as_ref()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T, const MAX: u32> VecM<T, MAX> {
+    pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
+        self.0.iter_mut()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
+    type Item = &'a mut T;
+    type IntoIter = core::slice::IterMut<'a, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
+impl<T: Clone, const MAX: u32> VecM<T, MAX> {
+    #[must_use]
+    #[cfg(feature = "alloc")]
+    pub fn to_vec(&self) -> Vec<T> {
+        self.into()
+    }
+
+    #[must_use]
+    pub fn into_vec(self) -> Vec<T> {
+        self.into()
+    }
+}
+
+impl<const MAX: u32> VecM<u8, MAX> {
+    #[cfg(feature = "alloc")]
+    pub fn to_string(&self) -> Result<String, Error> {
+        self.try_into()
+    }
+
+    #[cfg(feature = "alloc")]
+    pub fn into_string(self) -> Result<String, Error> {
+        self.try_into()
+    }
+
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn to_string_lossy(&self) -> String {
+        String::from_utf8_lossy(&self.0).into_owned()
+    }
+
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn into_string_lossy(self) -> String {
+        String::from_utf8_lossy(&self.0).into_owned()
+    }
+}
+
+impl<T: Clone> VecM<T, 1> {
+    #[must_use]
+    pub fn to_option(&self) -> Option<T> {
+        if self.len() > 0 {
+            Some(self.0[0].clone())
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(not(feature = "alloc"))]
+impl<T: Clone> From<VecM<T, 1>> for Option<T> {
+    #[must_use]
+    fn from(v: VecM<T, 1>) -> Self {
+        v.to_option()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T> VecM<T, 1> {
+    #[must_use]
+    pub fn into_option(mut self) -> Option<T> {
+        self.0.drain(..).next()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T> From<VecM<T, 1>> for Option<T> {
+    #[must_use]
+    fn from(v: VecM<T, 1>) -> Self {
+        v.into_option()
+    }
+}
+
+impl<T, const MAX: u32> TryFrom<Vec<T>> for VecM<T, MAX> {
+    type Error = Error;
+
+    fn try_from(v: Vec<T>) -> Result<Self, Error> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(VecM(v))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+impl<T, const MAX: u32> From<VecM<T, MAX>> for Vec<T> {
+    #[must_use]
+    fn from(v: VecM<T, MAX>) -> Self {
+        v.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T: Clone, const MAX: u32> From<&VecM<T, MAX>> for Vec<T> {
+    #[must_use]
+    fn from(v: &VecM<T, MAX>) -> Self {
+        v.0.clone()
+    }
+}
+
+impl<T, const MAX: u32> AsRef<Vec<T>> for VecM<T, MAX> {
+    #[must_use]
+    fn as_ref(&self) -> &Vec<T> {
+        &self.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
+    type Error = Error;
+
+    fn try_from(v: &Vec<T>) -> Result<Self, Error> {
+        v.as_slice().try_into()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T: Clone, const MAX: u32> TryFrom<&[T]> for VecM<T, MAX> {
+    type Error = Error;
+
+    fn try_from(v: &[T]) -> Result<Self, Error> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(VecM(v.to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+impl<T, const MAX: u32> AsRef<[T]> for VecM<T, MAX> {
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    fn as_ref(&self) -> &[T] {
+        self.0.as_ref()
+    }
+    #[cfg(not(feature = "alloc"))]
+    #[must_use]
+    fn as_ref(&self) -> &[T] {
+        self.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T: Clone, const N: usize, const MAX: u32> TryFrom<[T; N]> for VecM<T, MAX> {
+    type Error = Error;
+
+    fn try_from(v: [T; N]) -> Result<Self, Error> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(VecM(v.to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T: Clone, const N: usize, const MAX: u32> TryFrom<VecM<T, MAX>> for [T; N] {
+    type Error = VecM<T, MAX>;
+
+    fn try_from(v: VecM<T, MAX>) -> core::result::Result<Self, Self::Error> {
+        let s: [T; N] = v.0.try_into().map_err(|v: Vec<T>| VecM::<T, MAX>(v))?;
+        Ok(s)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX> {
+    type Error = Error;
+
+    fn try_from(v: &[T; N]) -> Result<Self, Error> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(VecM(v.to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(not(feature = "alloc"))]
+impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM<T, MAX> {
+    type Error = Error;
+
+    fn try_from(v: &'static [T; N]) -> Result<Self, Error> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(VecM(v))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
+    type Error = Error;
+
+    fn try_from(v: &String) -> Result<Self, Error> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(VecM(v.as_bytes().to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
+    type Error = Error;
+
+    fn try_from(v: String) -> Result<Self, Error> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(VecM(v.into()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
+    type Error = Error;
+
+    fn try_from(v: VecM<u8, MAX>) -> Result<Self, Error> {
+        Ok(String::from_utf8(v.0)?)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
+    type Error = Error;
+
+    fn try_from(v: &VecM<u8, MAX>) -> Result<Self, Error> {
+        Ok(core::str::from_utf8(v.as_ref())?.to_owned())
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
+    type Error = Error;
+
+    fn try_from(v: &str) -> Result<Self, Error> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(VecM(v.into()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(not(feature = "alloc"))]
+impl<const MAX: u32> TryFrom<&'static str> for VecM<u8, MAX> {
+    type Error = Error;
+
+    fn try_from(v: &'static str) -> Result<Self, Error> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(VecM(v.as_bytes()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+impl<'a, const MAX: u32> TryFrom<&'a VecM<u8, MAX>> for &'a str {
+    type Error = Error;
+
+    fn try_from(v: &'a VecM<u8, MAX>) -> Result<Self, Error> {
+        Ok(core::str::from_utf8(v.as_ref())?)
+    }
+}
+
+impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
+    #[cfg(feature = "std")]
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
+        r.with_limited_depth(|r| {
+            let len: u32 = u32::read_xdr(r)?;
+            if len > MAX {
+                return Err(Error::LengthExceedsMax);
+            }
+
+            r.consume_len(len as usize)?;
+            let padding = pad_len(len as usize);
+            r.consume_len(padding)?;
+
+            let mut vec = vec![0u8; len as usize];
+            r.read_exact(&mut vec)?;
+
+            let pad = &mut [0u8; 3][..padding];
+            r.read_exact(pad)?;
+            if pad.iter().any(|b| *b != 0) {
+                return Err(Error::NonZeroPadding);
+            }
+
+            Ok(VecM(vec))
+        })
+    }
+}
+
+impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
+    #[cfg(feature = "std")]
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
+        w.with_limited_depth(|w| {
+            let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+            len.write_xdr(w)?;
+
+            w.consume_len(self.len())?;
+            let padding = pad_len(self.len());
+            w.consume_len(padding)?;
+
+            w.write_all(&self.0)?;
+
+            w.write_all(&[0u8; 3][..padding])?;
+
+            Ok(())
+        })
+    }
+}
+
+impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
+    #[cfg(feature = "std")]
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
+        r.with_limited_depth(|r| {
+            let len = u32::read_xdr(r)?;
+            if len > MAX {
+                return Err(Error::LengthExceedsMax);
+            }
+
+            let mut vec = Vec::new();
+            for _ in 0..len {
+                let t = T::read_xdr(r)?;
+                vec.push(t);
+            }
+
+            Ok(VecM(vec))
+        })
+    }
+}
+
+impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
+    #[cfg(feature = "std")]
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
+        w.with_limited_depth(|w| {
+            let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+            len.write_xdr(w)?;
+
+            for t in &self.0 {
+                t.write_xdr(w)?;
+            }
+
+            Ok(())
+        })
+    }
+}
+
+// BytesM ------------------------------------------------------------------------
+
+#[cfg(feature = "alloc")]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr)
+)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+pub struct BytesM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
+
+#[cfg(not(feature = "alloc"))]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+pub struct BytesM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
+
+impl<const MAX: u32> core::fmt::Display for BytesM<MAX> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        #[cfg(feature = "alloc")]
+        let v = &self.0;
+        #[cfg(not(feature = "alloc"))]
+        let v = self.0;
+        for b in v {
+            write!(f, "{b:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+impl<const MAX: u32> core::fmt::Debug for BytesM<MAX> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        #[cfg(feature = "alloc")]
+        let v = &self.0;
+        #[cfg(not(feature = "alloc"))]
+        let v = self.0;
+        write!(f, "BytesM(")?;
+        for b in v {
+            write!(f, "{b:02x}")?;
+        }
+        write!(f, ")")?;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> core::str::FromStr for BytesM<MAX> {
+    type Err = Error;
+    fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
+        hex::decode(s).map_err(|_| Error::InvalidHex)?.try_into()
+    }
+}
+
+impl<const MAX: u32> Deref for BytesM<MAX> {
+    type Target = Vec<u8>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[cfg(feature = "schemars")]
+impl<const MAX: u32> schemars::JsonSchema for BytesM<MAX> {
+    fn schema_name() -> String {
+        format!("BytesM<{MAX}>")
+    }
+
+    fn is_referenceable() -> bool {
+        false
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        let schema = String::json_schema(gen);
+        if let schemars::schema::Schema::Object(mut schema) = schema {
+            schema.extensions.insert(
+                "contentEncoding".to_owned(),
+                serde_json::Value::String("hex".to_string()),
+            );
+            schema.extensions.insert(
+                "contentMediaType".to_owned(),
+                serde_json::Value::String("application/binary".to_string()),
+            );
+            let string = *schema.string.unwrap_or_default().clone();
+            schema.string = Some(Box::new(schemars::schema::StringValidation {
+                max_length: MAX.checked_mul(2).map(Some).unwrap_or_default(),
+                min_length: None,
+                ..string
+            }));
+            schema.into()
+        } else {
+            schema
+        }
+    }
+}
+
+impl<const MAX: u32> Default for BytesM<MAX> {
+    fn default() -> Self {
+        Self(Vec::default())
+    }
+}
+
+impl<const MAX: u32> BytesM<MAX> {
+    pub const MAX_LEN: usize = { MAX as usize };
+
+    #[must_use]
+    #[allow(clippy::unused_self)]
+    pub fn max_len(&self) -> usize {
+        Self::MAX_LEN
+    }
+
+    #[must_use]
+    pub fn as_vec(&self) -> &Vec<u8> {
+        self.as_ref()
+    }
+}
+
+impl<const MAX: u32> BytesM<MAX> {
+    #[must_use]
+    #[cfg(feature = "alloc")]
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.into()
+    }
+
+    #[must_use]
+    pub fn into_vec(self) -> Vec<u8> {
+        self.into()
+    }
+}
+
+impl<const MAX: u32> BytesM<MAX> {
+    #[cfg(feature = "alloc")]
+    pub fn to_string(&self) -> Result<String, Error> {
+        self.try_into()
+    }
+
+    #[cfg(feature = "alloc")]
+    pub fn into_string(self) -> Result<String, Error> {
+        self.try_into()
+    }
+
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn to_string_lossy(&self) -> String {
+        String::from_utf8_lossy(&self.0).into_owned()
+    }
+
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn into_string_lossy(self) -> String {
+        String::from_utf8_lossy(&self.0).into_owned()
+    }
+}
+
+impl<const MAX: u32> TryFrom<Vec<u8>> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: Vec<u8>) -> Result<Self, Error> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+impl<const MAX: u32> From<BytesM<MAX>> for Vec<u8> {
+    #[must_use]
+    fn from(v: BytesM<MAX>) -> Self {
+        v.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> From<&BytesM<MAX>> for Vec<u8> {
+    #[must_use]
+    fn from(v: &BytesM<MAX>) -> Self {
+        v.0.clone()
+    }
+}
+
+impl<const MAX: u32> AsRef<Vec<u8>> for BytesM<MAX> {
+    #[must_use]
+    fn as_ref(&self) -> &Vec<u8> {
+        &self.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &Vec<u8>) -> Result<Self, Error> {
+        v.as_slice().try_into()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&[u8]> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &[u8]) -> Result<Self, Error> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+impl<const MAX: u32> AsRef<[u8]> for BytesM<MAX> {
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+    #[cfg(not(feature = "alloc"))]
+    #[must_use]
+    fn as_ref(&self) -> &[u8] {
+        self.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: [u8; N]) -> Result<Self, Error> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const N: usize, const MAX: u32> TryFrom<BytesM<MAX>> for [u8; N] {
+    type Error = BytesM<MAX>;
+
+    fn try_from(v: BytesM<MAX>) -> core::result::Result<Self, Self::Error> {
+        let s: [u8; N] = v.0.try_into().map_err(BytesM::<MAX>)?;
+        Ok(s)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &[u8; N]) -> Result<Self, Error> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(not(feature = "alloc"))]
+impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &'static [u8; N]) -> Result<Self, Error> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &String) -> Result<Self, Error> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.as_bytes().to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: String) -> Result<Self, Error> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.into()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
+    type Error = Error;
+
+    fn try_from(v: BytesM<MAX>) -> Result<Self, Error> {
+        Ok(String::from_utf8(v.0)?)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
+    type Error = Error;
+
+    fn try_from(v: &BytesM<MAX>) -> Result<Self, Error> {
+        Ok(core::str::from_utf8(v.as_ref())?.to_owned())
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &str) -> Result<Self, Error> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.into()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(not(feature = "alloc"))]
+impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &'static str) -> Result<Self, Error> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.as_bytes()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
+    type Error = Error;
+
+    fn try_from(v: &'a BytesM<MAX>) -> Result<Self, Error> {
+        Ok(core::str::from_utf8(v.as_ref())?)
+    }
+}
+
+impl<const MAX: u32> ReadXdr for BytesM<MAX> {
+    #[cfg(feature = "std")]
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
+        r.with_limited_depth(|r| {
+            let len: u32 = u32::read_xdr(r)?;
+            if len > MAX {
+                return Err(Error::LengthExceedsMax);
+            }
+
+            r.consume_len(len as usize)?;
+            let padding = pad_len(len as usize);
+            r.consume_len(padding)?;
+
+            let mut vec = vec![0u8; len as usize];
+            r.read_exact(&mut vec)?;
+
+            let pad = &mut [0u8; 3][..padding];
+            r.read_exact(pad)?;
+            if pad.iter().any(|b| *b != 0) {
+                return Err(Error::NonZeroPadding);
+            }
+
+            Ok(BytesM(vec))
+        })
+    }
+}
+
+impl<const MAX: u32> WriteXdr for BytesM<MAX> {
+    #[cfg(feature = "std")]
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
+        w.with_limited_depth(|w| {
+            let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+            len.write_xdr(w)?;
+
+            w.consume_len(self.len())?;
+            let padding = pad_len(self.len());
+            w.consume_len(padding)?;
+
+            w.write_all(&self.0)?;
+
+            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+
+            Ok(())
+        })
+    }
+}
+
+// StringM ------------------------------------------------------------------------
+
+/// A string type that contains arbitrary bytes.
+///
+/// Convertible, fallibly, to/from a Rust UTF-8 String using
+/// [`TryFrom`]/[`TryInto`]/[`StringM::to_utf8_string`].
+///
+/// Convertible, lossyly, to a Rust UTF-8 String using
+/// [`StringM::to_utf8_string_lossy`].
+///
+/// Convertible to/from escaped printable-ASCII using
+/// [`Display`]/[`ToString`]/[`FromStr`].
+
+#[cfg(feature = "alloc")]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr)
+)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
+
+#[cfg(not(feature = "alloc"))]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
+
+impl<const MAX: u32> core::fmt::Display for StringM<MAX> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        #[cfg(feature = "alloc")]
+        let v = &self.0;
+        #[cfg(not(feature = "alloc"))]
+        let v = self.0;
+        for b in escape_bytes::Escape::new(v) {
+            write!(f, "{}", b as char)?;
+        }
+        Ok(())
+    }
+}
+
+impl<const MAX: u32> core::fmt::Debug for StringM<MAX> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        #[cfg(feature = "alloc")]
+        let v = &self.0;
+        #[cfg(not(feature = "alloc"))]
+        let v = self.0;
+        write!(f, "StringM(")?;
+        for b in escape_bytes::Escape::new(v) {
+            write!(f, "{}", b as char)?;
+        }
+        write!(f, ")")?;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> core::str::FromStr for StringM<MAX> {
+    type Err = Error;
+    fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
+        let b = escape_bytes::unescape(s.as_bytes()).map_err(|_| Error::Invalid)?;
+        Ok(Self(b))
+    }
+}
+
+impl<const MAX: u32> Deref for StringM<MAX> {
+    type Target = Vec<u8>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<const MAX: u32> Default for StringM<MAX> {
+    fn default() -> Self {
+        Self(Vec::default())
+    }
+}
+
+#[cfg(feature = "schemars")]
+impl<const MAX: u32> schemars::JsonSchema for StringM<MAX> {
+    fn schema_name() -> String {
+        format!("StringM<{MAX}>")
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        let schema = String::json_schema(gen);
+        if let schemars::schema::Schema::Object(mut schema) = schema {
+            let string = *schema.string.unwrap_or_default().clone();
+            schema.string = Some(Box::new(schemars::schema::StringValidation {
+                max_length: Some(MAX),
+                ..string
+            }));
+            schema.into()
+        } else {
+            schema
+        }
+    }
+}
+
+impl<const MAX: u32> StringM<MAX> {
+    pub const MAX_LEN: usize = { MAX as usize };
+
+    #[must_use]
+    #[allow(clippy::unused_self)]
+    pub fn max_len(&self) -> usize {
+        Self::MAX_LEN
+    }
+
+    #[must_use]
+    pub fn as_vec(&self) -> &Vec<u8> {
+        self.as_ref()
+    }
+}
+
+impl<const MAX: u32> StringM<MAX> {
+    #[must_use]
+    #[cfg(feature = "alloc")]
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.into()
+    }
+
+    #[must_use]
+    pub fn into_vec(self) -> Vec<u8> {
+        self.into()
+    }
+}
+
+impl<const MAX: u32> StringM<MAX> {
+    #[cfg(feature = "alloc")]
+    pub fn to_utf8_string(&self) -> Result<String, Error> {
+        self.try_into()
+    }
+
+    #[cfg(feature = "alloc")]
+    pub fn into_utf8_string(self) -> Result<String, Error> {
+        self.try_into()
+    }
+
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn to_utf8_string_lossy(&self) -> String {
+        String::from_utf8_lossy(&self.0).into_owned()
+    }
+
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn into_utf8_string_lossy(self) -> String {
+        String::from_utf8_lossy(&self.0).into_owned()
+    }
+}
+
+impl<const MAX: u32> TryFrom<Vec<u8>> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: Vec<u8>) -> Result<Self, Error> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+impl<const MAX: u32> From<StringM<MAX>> for Vec<u8> {
+    #[must_use]
+    fn from(v: StringM<MAX>) -> Self {
+        v.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> From<&StringM<MAX>> for Vec<u8> {
+    #[must_use]
+    fn from(v: &StringM<MAX>) -> Self {
+        v.0.clone()
+    }
+}
+
+impl<const MAX: u32> AsRef<Vec<u8>> for StringM<MAX> {
+    #[must_use]
+    fn as_ref(&self) -> &Vec<u8> {
+        &self.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &Vec<u8>) -> Result<Self, Error> {
+        v.as_slice().try_into()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&[u8]> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &[u8]) -> Result<Self, Error> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+impl<const MAX: u32> AsRef<[u8]> for StringM<MAX> {
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+    #[cfg(not(feature = "alloc"))]
+    #[must_use]
+    fn as_ref(&self) -> &[u8] {
+        self.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: [u8; N]) -> Result<Self, Error> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const N: usize, const MAX: u32> TryFrom<StringM<MAX>> for [u8; N] {
+    type Error = StringM<MAX>;
+
+    fn try_from(v: StringM<MAX>) -> core::result::Result<Self, Self::Error> {
+        let s: [u8; N] = v.0.try_into().map_err(StringM::<MAX>)?;
+        Ok(s)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &[u8; N]) -> Result<Self, Error> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(not(feature = "alloc"))]
+impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &'static [u8; N]) -> Result<Self, Error> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &String) -> Result<Self, Error> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.as_bytes().to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: String) -> Result<Self, Error> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.into()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
+    type Error = Error;
+
+    fn try_from(v: StringM<MAX>) -> Result<Self, Error> {
+        Ok(String::from_utf8(v.0)?)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
+    type Error = Error;
+
+    fn try_from(v: &StringM<MAX>) -> Result<Self, Error> {
+        Ok(core::str::from_utf8(v.as_ref())?.to_owned())
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &str) -> Result<Self, Error> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.into()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(not(feature = "alloc"))]
+impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &'static str) -> Result<Self, Error> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.as_bytes()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
+    type Error = Error;
+
+    fn try_from(v: &'a StringM<MAX>) -> Result<Self, Error> {
+        Ok(core::str::from_utf8(v.as_ref())?)
+    }
+}
+
+impl<const MAX: u32> ReadXdr for StringM<MAX> {
+    #[cfg(feature = "std")]
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
+        r.with_limited_depth(|r| {
+            let len: u32 = u32::read_xdr(r)?;
+            if len > MAX {
+                return Err(Error::LengthExceedsMax);
+            }
+
+            r.consume_len(len as usize)?;
+            let padding = pad_len(len as usize);
+            r.consume_len(padding)?;
+
+            let mut vec = vec![0u8; len as usize];
+            r.read_exact(&mut vec)?;
+
+            let pad = &mut [0u8; 3][..padding];
+            r.read_exact(pad)?;
+            if pad.iter().any(|b| *b != 0) {
+                return Err(Error::NonZeroPadding);
+            }
+
+            Ok(StringM(vec))
+        })
+    }
+}
+
+impl<const MAX: u32> WriteXdr for StringM<MAX> {
+    #[cfg(feature = "std")]
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
+        w.with_limited_depth(|w| {
+            let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+            len.write_xdr(w)?;
+
+            w.consume_len(self.len())?;
+            let padding = pad_len(self.len());
+            w.consume_len(padding)?;
+
+            w.write_all(&self.0)?;
+
+            w.write_all(&[0u8; 3][..padding])?;
+
+            Ok(())
+        })
+    }
+}
+
+// Frame ------------------------------------------------------------------------
+
+#[derive(Default, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(
+    all(feature = "serde", feature = "alloc"),
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "snake_case")
+)]
+pub struct Frame<T>(pub T)
+where
+    T: ReadXdr;
+
+#[cfg(feature = "schemars")]
+impl<T: schemars::JsonSchema + ReadXdr> schemars::JsonSchema for Frame<T> {
+    fn schema_name() -> String {
+        format!("Frame<{}>", T::schema_name())
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        T::json_schema(gen)
+    }
+}
+
+impl<T> ReadXdr for Frame<T>
+where
+    T: ReadXdr,
+{
+    #[cfg(feature = "std")]
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
+        // Read the frame header value that contains 1 flag-bit and a 33-bit length.
+        //  - The 1 flag bit is 0 when there are more frames for the same record.
+        //  - The 31-bit length is the length of the bytes within the frame that
+        //  follow the frame header.
+        let header = u32::read_xdr(r)?;
+        // TODO: Use the length and cap the length we'll read from `r`.
+        let last_record = header >> 31 == 1;
+        if last_record {
+            // Read the record in the frame.
+            Ok(Self(T::read_xdr(r)?))
+        } else {
+            // TODO: Support reading those additional frames for the same
+            // record.
+            Err(Error::Unsupported)
+        }
+    }
+}
+
+/// Forwards read operations to the wrapped object, skipping over any
+/// whitespace.
+#[cfg(feature = "std")]
+pub struct SkipWhitespace<R: Read> {
+    pub inner: R,
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> SkipWhitespace<R> {
+    pub fn new(inner: R) -> Self {
+        SkipWhitespace { inner }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for SkipWhitespace<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.inner.read(buf)?;
+
+        let mut written = 0;
+        for read in 0..n {
+            if !buf[read].is_ascii_whitespace() {
+                buf[written] = buf[read];
+                written += 1;
+            }
+        }
+
+        Ok(written)
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test_skip_whitespace {
+    use super::*;
+
+    #[test]
+    fn test() {
+        struct Test {
+            input: &'static [u8],
+            output: &'static [u8],
+        }
+        let tests = [
+            Test {
+                input: b"",
+                output: b"",
+            },
+            Test {
+                input: b" \n\t\r",
+                output: b"",
+            },
+            Test {
+                input: b"a c",
+                output: b"ac",
+            },
+            Test {
+                input: b"ab cd",
+                output: b"abcd",
+            },
+            Test {
+                input: b" ab \n cd ",
+                output: b"abcd",
+            },
+        ];
+        for (i, t) in tests.iter().enumerate() {
+            let mut skip = SkipWhitespace::new(t.input);
+            let mut output = Vec::new();
+            skip.read_to_end(&mut output).unwrap();
+            assert_eq!(output, t.output, "#{i}");
+        }
+    }
+}
+
+// NumberOrString ---------------------------------------------------------------
+
+/// NumberOrString is a serde_as serializer/deserializer.
+///
+/// It deserializers any integer that fits into a 64-bit value into an i64 or u64 field from either
+/// a JSON Number or JSON String value.
+///
+/// It serializes always to a string.
+///
+/// It has a JsonSchema implementation that only advertises that the allowed format is a String.
+/// This is because the type is intended to soften the changing of fields from JSON Number to JSON
+/// String by permitting deserialization, but discourage new uses of JSON Number.
+#[cfg(feature = "serde")]
+struct NumberOrString;
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<i64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum I64OrString<'a> {
+            Str(&'a str),
+            String(String),
+            I64(i64),
+        }
+        match I64OrString::deserialize(deserializer)? {
+            I64OrString::Str(s) => s.parse().map_err(serde::de::Error::custom),
+            I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            I64OrString::I64(v) => Ok(v),
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<u64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum U64OrString<'a> {
+            Str(&'a str),
+            String(String),
+            U64(u64),
+        }
+        match U64OrString::deserialize(deserializer)? {
+            U64OrString::Str(s) => s.parse().map_err(serde::de::Error::custom),
+            U64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            U64OrString::U64(v) => Ok(v),
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<i64> for NumberOrString {
+    fn serialize_as<S>(source: &i64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_str(source)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<u64> for NumberOrString {
+    fn serialize_as<S>(source: &u64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_str(source)
+    }
+}
+
+#[cfg(feature = "schemars")]
+impl<T> serde_with::schemars_0_8::JsonSchemaAs<T> for NumberOrString {
+    fn schema_name() -> String {
+        <String as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        <String as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <String as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <String as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+// Tests ------------------------------------------------------------------------
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use std::io::Cursor;
+
+    use super::*;
+
+    #[test]
+    pub fn vec_u8_read_without_padding() {
+        let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
+        let v = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::none())).unwrap();
+        assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
+    }
+
+    #[test]
+    pub fn vec_u8_read_with_padding() {
+        let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
+        let v = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::none())).unwrap();
+        assert_eq!(v.to_vec(), vec![2]);
+    }
+
+    #[test]
+    pub fn vec_u8_read_with_insufficient_padding() {
+        let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
+        let res = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::none()));
+        match res {
+            Err(Error::Io(_)) => (),
+            _ => panic!("expected IO error got {res:?}"),
+        }
+    }
+
+    #[test]
+    pub fn vec_u8_read_with_non_zero_padding() {
+        let buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
+        let res = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::none()));
+        match res {
+            Err(Error::NonZeroPadding) => (),
+            _ => panic!("expected NonZeroPadding got {res:?}"),
+        }
+    }
+
+    #[test]
+    pub fn vec_u8_write_without_padding() {
+        let mut buf = vec![];
+        let v: VecM<u8, 8> = vec![2, 2, 2, 2].try_into().unwrap();
+
+        v.write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::none()))
+            .unwrap();
+        assert_eq!(buf, vec![0, 0, 0, 4, 2, 2, 2, 2]);
+    }
+
+    #[test]
+    pub fn vec_u8_write_with_padding() {
+        let mut buf = vec![];
+        let v: VecM<u8, 8> = vec![2].try_into().unwrap();
+        v.write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::none()))
+            .unwrap();
+        assert_eq!(buf, vec![0, 0, 0, 1, 2, 0, 0, 0]);
+    }
+
+    #[test]
+    pub fn arr_u8_read_without_padding() {
+        let buf = Cursor::new(vec![2, 2, 2, 2]);
+        let v = <[u8; 4]>::read_xdr(&mut Limited::new(buf, Limits::none())).unwrap();
+        assert_eq!(v, [2, 2, 2, 2]);
+    }
+
+    #[test]
+    pub fn arr_u8_read_with_padding() {
+        let buf = Cursor::new(vec![2, 0, 0, 0]);
+        let v = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::none())).unwrap();
+        assert_eq!(v, [2]);
+    }
+
+    #[test]
+    pub fn arr_u8_read_with_insufficient_padding() {
+        let buf = Cursor::new(vec![2, 0, 0]);
+        let res = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::none()));
+        match res {
+            Err(Error::Io(_)) => (),
+            _ => panic!("expected IO error got {res:?}"),
+        }
+    }
+
+    #[test]
+    pub fn arr_u8_read_with_non_zero_padding() {
+        let buf = Cursor::new(vec![2, 3, 0, 0]);
+        let res = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::none()));
+        match res {
+            Err(Error::NonZeroPadding) => (),
+            _ => panic!("expected NonZeroPadding got {res:?}"),
+        }
+    }
+
+    #[test]
+    pub fn arr_u8_write_without_padding() {
+        let mut buf = vec![];
+        [2u8, 2, 2, 2]
+            .write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::none()))
+            .unwrap();
+        assert_eq!(buf, vec![2, 2, 2, 2]);
+    }
+
+    #[test]
+    pub fn arr_u8_write_with_padding() {
+        let mut buf = vec![];
+        [2u8]
+            .write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::none()))
+            .unwrap();
+        assert_eq!(buf, vec![2, 0, 0, 0]);
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::*;
+
+    #[test]
+    fn into_option_none() {
+        let v: VecM<u32, 1> = vec![].try_into().unwrap();
+        assert_eq!(v.into_option(), None);
+    }
+
+    #[test]
+    fn into_option_some() {
+        let v: VecM<_, 1> = vec![1].try_into().unwrap();
+        assert_eq!(v.into_option(), Some(1));
+    }
+
+    #[test]
+    fn to_option_none() {
+        let v: VecM<u32, 1> = vec![].try_into().unwrap();
+        assert_eq!(v.to_option(), None);
+    }
+
+    #[test]
+    fn to_option_some() {
+        let v: VecM<_, 1> = vec![1].try_into().unwrap();
+        assert_eq!(v.to_option(), Some(1));
+    }
+
+    #[test]
+    fn depth_limited_read_write_under_the_limit_success() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(Vec::new(), Limits::depth(4));
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::depth(4));
+        let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
+        assert_eq!(a, a_back);
+    }
+
+    #[test]
+    fn write_over_depth_limit_fail() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(Vec::new(), Limits::depth(3));
+        let res = a.write_xdr(&mut buf);
+        match res {
+            Err(Error::DepthLimitExceeded) => (),
+            _ => panic!("expected DepthLimitExceeded got {res:?}"),
+        }
+    }
+
+    #[test]
+    fn read_over_depth_limit_fail() {
+        let read_limits = Limits::depth(3);
+        let write_limits = Limits::depth(5);
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(Vec::new(), write_limits);
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), read_limits);
+        let res: Result<Option<Option<Option<u32>>>, _> = ReadXdr::read_xdr(&mut dlr);
+        match res {
+            Err(Error::DepthLimitExceeded) => (),
+            _ => panic!("expected DepthLimitExceeded got {res:?}"),
+        }
+    }
+
+    #[test]
+    fn length_limited_read_write_i32() {
+        // Exact limit, success
+        let v = 123i32;
+        let mut buf = Limited::new(Vec::new(), Limits::len(4));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(4));
+        let v_back: i32 = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        assert_eq!(v, v_back);
+
+        // Over limit, success
+        let v = 123i32;
+        let mut buf = Limited::new(Vec::new(), Limits::len(5));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 1);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(5));
+        let v_back: i32 = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(buf.limits.len, 1);
+        assert_eq!(v, v_back);
+
+        // Write under limit, failure
+        let v = 123i32;
+        let mut buf = Limited::new(Vec::new(), Limits::len(3));
+        assert_eq!(v.write_xdr(&mut buf), Err(Error::LengthLimitExceeded));
+
+        // Read under limit, failure
+        let v = 123i32;
+        let mut buf = Limited::new(Vec::new(), Limits::len(4));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(3));
+        assert_eq!(
+            <i32 as ReadXdr>::read_xdr(&mut lr),
+            Err(Error::LengthLimitExceeded)
+        );
+    }
+
+    #[test]
+    fn length_limited_read_write_u32() {
+        // Exact limit, success
+        let v = 123u32;
+        let mut buf = Limited::new(Vec::new(), Limits::len(4));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(4));
+        let v_back: u32 = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        assert_eq!(v, v_back);
+
+        // Over limit, success
+        let v = 123u32;
+        let mut buf = Limited::new(Vec::new(), Limits::len(5));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 1);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(5));
+        let v_back: u32 = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(buf.limits.len, 1);
+        assert_eq!(v, v_back);
+
+        // Write under limit, failure
+        let v = 123u32;
+        let mut buf = Limited::new(Vec::new(), Limits::len(3));
+        assert_eq!(v.write_xdr(&mut buf), Err(Error::LengthLimitExceeded));
+
+        // Read under limit, failure
+        let v = 123u32;
+        let mut buf = Limited::new(Vec::new(), Limits::len(4));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(3));
+        assert_eq!(
+            <u32 as ReadXdr>::read_xdr(&mut lr),
+            Err(Error::LengthLimitExceeded)
+        );
+    }
+
+    #[test]
+    fn length_limited_read_write_i64() {
+        // Exact limit, success
+        let v = 123i64;
+        let mut buf = Limited::new(Vec::new(), Limits::len(8));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(8));
+        let v_back: i64 = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        assert_eq!(v, v_back);
+
+        // Over limit, success
+        let v = 123i64;
+        let mut buf = Limited::new(Vec::new(), Limits::len(9));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 1);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(9));
+        let v_back: i64 = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(buf.limits.len, 1);
+        assert_eq!(v, v_back);
+
+        // Write under limit, failure
+        let v = 123i64;
+        let mut buf = Limited::new(Vec::new(), Limits::len(7));
+        assert_eq!(v.write_xdr(&mut buf), Err(Error::LengthLimitExceeded));
+
+        // Read under limit, failure
+        let v = 123i64;
+        let mut buf = Limited::new(Vec::new(), Limits::len(8));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(7));
+        assert_eq!(
+            <i64 as ReadXdr>::read_xdr(&mut lr),
+            Err(Error::LengthLimitExceeded)
+        );
+    }
+
+    #[test]
+    fn length_limited_read_write_u64() {
+        // Exact limit, success
+        let v = 123u64;
+        let mut buf = Limited::new(Vec::new(), Limits::len(8));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(8));
+        let v_back: u64 = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        assert_eq!(v, v_back);
+
+        // Over limit, success
+        let v = 123u64;
+        let mut buf = Limited::new(Vec::new(), Limits::len(9));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 1);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(9));
+        let v_back: u64 = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(buf.limits.len, 1);
+        assert_eq!(v, v_back);
+
+        // Write under limit, failure
+        let v = 123u64;
+        let mut buf = Limited::new(Vec::new(), Limits::len(7));
+        assert_eq!(v.write_xdr(&mut buf), Err(Error::LengthLimitExceeded));
+
+        // Read under limit, failure
+        let v = 123u64;
+        let mut buf = Limited::new(Vec::new(), Limits::len(8));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(7));
+        assert_eq!(
+            <u64 as ReadXdr>::read_xdr(&mut lr),
+            Err(Error::LengthLimitExceeded)
+        );
+    }
+
+    #[test]
+    fn length_limited_read_write_bool() {
+        // Exact limit, success
+        let v = true;
+        let mut buf = Limited::new(Vec::new(), Limits::len(4));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(4));
+        let v_back: bool = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        assert_eq!(v, v_back);
+
+        // Over limit, success
+        let v = true;
+        let mut buf = Limited::new(Vec::new(), Limits::len(5));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 1);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(5));
+        let v_back: bool = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(buf.limits.len, 1);
+        assert_eq!(v, v_back);
+
+        // Write under limit, failure
+        let v = true;
+        let mut buf = Limited::new(Vec::new(), Limits::len(3));
+        assert_eq!(v.write_xdr(&mut buf), Err(Error::LengthLimitExceeded));
+
+        // Read under limit, failure
+        let v = true;
+        let mut buf = Limited::new(Vec::new(), Limits::len(4));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(3));
+        assert_eq!(
+            <bool as ReadXdr>::read_xdr(&mut lr),
+            Err(Error::LengthLimitExceeded)
+        );
+    }
+
+    #[test]
+    fn length_limited_read_write_option() {
+        // Exact limit, success
+        let v = Some(true);
+        let mut buf = Limited::new(Vec::new(), Limits::len(8));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(8));
+        let v_back: Option<bool> = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        assert_eq!(v, v_back);
+
+        // Over limit, success
+        let v = Some(true);
+        let mut buf = Limited::new(Vec::new(), Limits::len(9));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 1);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(9));
+        let v_back: Option<bool> = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(buf.limits.len, 1);
+        assert_eq!(v, v_back);
+
+        // Write under limit, failure
+        let v = Some(true);
+        let mut buf = Limited::new(Vec::new(), Limits::len(7));
+        assert_eq!(v.write_xdr(&mut buf), Err(Error::LengthLimitExceeded));
+
+        // Read under limit, failure
+        let v = Some(true);
+        let mut buf = Limited::new(Vec::new(), Limits::len(8));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(7));
+        assert_eq!(
+            <Option<bool> as ReadXdr>::read_xdr(&mut lr),
+            Err(Error::LengthLimitExceeded)
+        );
+    }
+
+    #[test]
+    fn length_limited_read_write_array_u8() {
+        // Exact limit, success
+        let v = [1u8, 2, 3];
+        let mut buf = Limited::new(Vec::new(), Limits::len(4));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(4));
+        let v_back: [u8; 3] = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        assert_eq!(v, v_back);
+
+        // Over limit, success
+        let v = [1u8, 2, 3];
+        let mut buf = Limited::new(Vec::new(), Limits::len(5));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 1);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(5));
+        let v_back: [u8; 3] = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(buf.limits.len, 1);
+        assert_eq!(v, v_back);
+
+        // Write under limit, failure
+        let v = [1u8, 2, 3];
+        let mut buf = Limited::new(Vec::new(), Limits::len(3));
+        assert_eq!(v.write_xdr(&mut buf), Err(Error::LengthLimitExceeded));
+
+        // Read under limit, failure
+        let v = [1u8, 2, 3];
+        let mut buf = Limited::new(Vec::new(), Limits::len(4));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(3));
+        assert_eq!(
+            <[u8; 3] as ReadXdr>::read_xdr(&mut lr),
+            Err(Error::LengthLimitExceeded)
+        );
+    }
+
+    #[test]
+    fn length_limited_read_write_array_type() {
+        // Exact limit, success
+        let v = [true, false, true];
+        let mut buf = Limited::new(Vec::new(), Limits::len(12));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(12));
+        let v_back: [bool; 3] = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        assert_eq!(v, v_back);
+
+        // Over limit, success
+        let v = [true, false, true];
+        let mut buf = Limited::new(Vec::new(), Limits::len(13));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 1);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(13));
+        let v_back: [bool; 3] = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(buf.limits.len, 1);
+        assert_eq!(v, v_back);
+
+        // Write under limit, failure
+        let v = [true, false, true];
+        let mut buf = Limited::new(Vec::new(), Limits::len(11));
+        assert_eq!(v.write_xdr(&mut buf), Err(Error::LengthLimitExceeded));
+
+        // Read under limit, failure
+        let v = [true, false, true];
+        let mut buf = Limited::new(Vec::new(), Limits::len(12));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(11));
+        assert_eq!(
+            <[bool; 3] as ReadXdr>::read_xdr(&mut lr),
+            Err(Error::LengthLimitExceeded)
+        );
+    }
+
+    #[test]
+    fn length_limited_read_write_vec() {
+        // Exact limit, success
+        let v = VecM::<i32, 3>::try_from([1i32, 2, 3]).unwrap();
+        let mut buf = Limited::new(Vec::new(), Limits::len(16));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(16));
+        let v_back: VecM<i32, 3> = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        assert_eq!(v, v_back);
+
+        // Over limit, success
+        let v = VecM::<i32, 3>::try_from([1i32, 2, 3]).unwrap();
+        let mut buf = Limited::new(Vec::new(), Limits::len(17));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 1);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(17));
+        let v_back: VecM<i32, 3> = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(buf.limits.len, 1);
+        assert_eq!(v, v_back);
+
+        // Write under limit, failure
+        let v = VecM::<i32, 3>::try_from([1i32, 2, 3]).unwrap();
+        let mut buf = Limited::new(Vec::new(), Limits::len(15));
+        assert_eq!(v.write_xdr(&mut buf), Err(Error::LengthLimitExceeded));
+
+        // Read under limit, failure
+        let v = VecM::<i32, 3>::try_from([1i32, 2, 3]).unwrap();
+        let mut buf = Limited::new(Vec::new(), Limits::len(16));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(15));
+        assert_eq!(
+            <VecM<i32, 3> as ReadXdr>::read_xdr(&mut lr),
+            Err(Error::LengthLimitExceeded)
+        );
+    }
+
+    #[test]
+    fn length_limited_read_write_bytes() {
+        // Exact limit, success
+        let v = BytesM::<3>::try_from([1u8, 2, 3]).unwrap();
+        let mut buf = Limited::new(Vec::new(), Limits::len(8));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(8));
+        let v_back: BytesM<3> = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        assert_eq!(v, v_back);
+
+        // Over limit, success
+        let v = BytesM::<3>::try_from([1u8, 2, 3]).unwrap();
+        let mut buf = Limited::new(Vec::new(), Limits::len(9));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 1);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(9));
+        let v_back: BytesM<3> = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(buf.limits.len, 1);
+        assert_eq!(v, v_back);
+
+        // Write under limit, failure
+        let v = BytesM::<3>::try_from([1u8, 2, 3]).unwrap();
+        let mut buf = Limited::new(Vec::new(), Limits::len(7));
+        assert_eq!(v.write_xdr(&mut buf), Err(Error::LengthLimitExceeded));
+
+        // Read under limit, failure
+        let v = BytesM::<3>::try_from([1u8, 2, 3]).unwrap();
+        let mut buf = Limited::new(Vec::new(), Limits::len(8));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(7));
+        assert_eq!(
+            <BytesM<3> as ReadXdr>::read_xdr(&mut lr),
+            Err(Error::LengthLimitExceeded)
+        );
+    }
+
+    #[test]
+    fn length_limited_read_write_string() {
+        // Exact limit, success
+        let v = StringM::<3>::try_from("123").unwrap();
+        let mut buf = Limited::new(Vec::new(), Limits::len(8));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(8));
+        let v_back: StringM<3> = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        assert_eq!(v, v_back);
+
+        // Over limit, success
+        let v = StringM::<3>::try_from("123").unwrap();
+        let mut buf = Limited::new(Vec::new(), Limits::len(9));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 1);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(9));
+        let v_back: StringM<3> = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(buf.limits.len, 1);
+        assert_eq!(v, v_back);
+
+        // Write under limit, failure
+        let v = StringM::<3>::try_from("123").unwrap();
+        let mut buf = Limited::new(Vec::new(), Limits::len(7));
+        assert_eq!(v.write_xdr(&mut buf), Err(Error::LengthLimitExceeded));
+
+        // Read under limit, failure
+        let v = StringM::<3>::try_from("123").unwrap();
+        let mut buf = Limited::new(Vec::new(), Limits::len(8));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(7));
+        assert_eq!(
+            <StringM<3> as ReadXdr>::read_xdr(&mut lr),
+            Err(Error::LengthLimitExceeded)
+        );
+    }
+}
+
+#[cfg(all(test, not(feature = "alloc")))]
+mod test {
+    use super::VecM;
+
+    #[test]
+    fn to_option_none() {
+        let v: VecM<u32, 1> = (&[]).try_into().unwrap();
+        assert_eq!(v.to_option(), None);
+    }
+
+    #[test]
+    fn to_option_some() {
+        let v: VecM<_, 1> = (&[1]).try_into().unwrap();
+        assert_eq!(v.to_option(), Some(1));
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod tests_for_number_or_string {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+    use serde_json;
+    use serde_with::serde_as;
+
+    // --- Helper Structs ---
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestI64 {
+        #[serde_as(as = "NumberOrString")]
+        val: i64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestU64 {
+        #[serde_as(as = "NumberOrString")]
+        val: u64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionI64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionU64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<u64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecI64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecU64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<u64>,
+    }
+
+    // Helper Enum for testing field access within variants
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    #[serde(rename_all = "camelCase")] // Added to make JSON keys distinct for variants
+    enum TestEnum {
+        VariantA {
+            #[serde(rename = "numVal")]
+            #[serde_as(as = "NumberOrString")]
+            num_val: i64,
+            #[serde(rename = "otherData")]
+            other_data: String,
+        },
+        VariantB {
+            #[serde_as(as = "NumberOrString")]
+            count: u64,
+        },
+        SimpleVariant,
+    }
+
+    // --- i64 Deserialization Tests ---
+    #[test]
+    fn deserialize_i64_from_json_reader() {
+        let json = r#"{"val": "123"}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_reader::<_, TestI64>(Cursor::new(json)).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_positive() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_negative() {
+        let json = r#"{"val": -456}"#;
+        let expected = TestI64 { val: -456 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_min() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_positive() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestI64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_negative() {
+        let json = r#"{"val": "-101"}"#;
+        let expected = TestI64 { val: -101 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_min() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_minus_zero() {
+        let json = r#"{"val": "-0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_both_whitespace() {
+        let json = r#"{"val": " 123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
+        let json = r#"{"val": "--123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_mixed_prefix() {
+        let json = r#"{"val": "+-123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#; // Not an integer
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_overflow() {
+        let overflow_val = i128::from(i64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_underflow() {
+        let underflow_val = i128::from(i64::MIN) - 1;
+        let json = format!(r#"{{"val": "{underflow_val}"}}"#);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    // -- Additional i64 String Format Tests --
+    #[test]
+    fn deserialize_i64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+                                         // std::primitive::i64.from_str() does not support "0x"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Hex string should fail parsing to i64"
+        );
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+                                         // std::primitive::i64.from_str() does not support "0o"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Octal string should fail parsing to i64"
+        );
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#; // "1000" in scientific
+                                        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Scientific notation string should fail parsing to i64"
+        );
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_invalid_scientific_notation_string() {
+        let json = r#"{"val": "1e"}"#;
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Invalid scientific notation string should fail"
+        );
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        // std::primitive::i64.from_str() does not support underscores
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with underscores should fail parsing to i64"
+        );
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestI64 { val: 123 };
+        // std::primitive::i64.from_str() supports leading zeros
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse"
+        );
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros_negative() {
+        let json = r#"{"val": "-000123"}"#;
+        let expected = TestI64 { val: -123 };
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "Negative string with leading zeros should parse"
+        );
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        // std::primitive::i64.from_str() does not support decimals
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with decimal part should fail parsing to i64"
+        );
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_internal_decimal() {
+        let json = r#"{"val": "12.345"}"#;
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with internal decimal point should fail"
+        );
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        // std::primitive::i64.from_str() does not support commas
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Localized string with commas should fail parsing to i64"
+        );
+    }
+
+    // --- u64 Deserialization Tests ---
+    #[test]
+    fn deserialize_u64_from_json_reader() {
+        let json = r#"{"val": "123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_reader::<_, TestU64>(Cursor::new(json)).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestU64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_negative() {
+        let json = r#"{"val": "-123"}"#; // Negative not allowed for u64 string parse
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_number_negative() {
+        let json = r#"{"val": -1}"#; // Negative not allowed for u64
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_overflow() {
+        let overflow_val = u128::from(u64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
+        assert!(serde_json::from_str::<TestU64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    // -- Additional u64 String Format Tests --
+    #[test]
+    fn deserialize_u64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Hex string should fail parsing to u64"
+        );
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Octal string should fail parsing to u64"
+        );
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#;
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Scientific notation string should fail parsing to u64"
+        );
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with underscores should fail parsing to u64"
+        );
+    }
+
+    #[test]
+    fn deserialize_u64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(
+            serde_json::from_str::<TestU64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse to u64"
+        );
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with decimal part should fail parsing to u64"
+        );
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Localized string with commas should fail parsing to u64"
+        );
+    }
+
+    // --- i64 Serialization Tests ---
+    #[test]
+    fn serialize_i64_positive() {
+        let data = TestI64 { val: 123 };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_negative() {
+        let data = TestI64 { val: -456 };
+        let expected_json = r#"{"val":"-456"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_zero() {
+        let data = TestI64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_max() {
+        let data = TestI64 { val: i64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_min() {
+        let data = TestI64 { val: i64::MIN };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- u64 Serialization Tests ---
+    #[test]
+    fn serialize_u64_positive() {
+        let data = TestU64 { val: 789 };
+        let expected_json = r#"{"val":"789"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_u64_zero() {
+        let data = TestU64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_u64_max() {
+        let data = TestU64 { val: u64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, u64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<i64> Tests ---
+    #[test]
+    fn deserialize_option_i64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionI64 { val: Some(123) };
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn deserialize_option_i64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionI64 { val: Some(456) };
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn deserialize_option_i64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionI64 { val: None };
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_type() {
+        let json = r#"{"val": true}"#;
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_option_i64_some() {
+        let data = TestOptionI64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_i64_none() {
+        let data = TestOptionI64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<u64> Tests ---
+    #[test]
+    fn deserialize_option_u64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionU64 { val: Some(123) };
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn deserialize_option_u64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionU64 { val: Some(456) };
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn deserialize_option_u64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionU64 { val: None };
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn deserialize_option_u64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_option_u64_error_from_negative_string() {
+        let json = r#"{"val": "-1"}"#; // Invalid for u64
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_option_u64_some() {
+        let data = TestOptionU64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_u64_none() {
+        let data = TestOptionU64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<i64> Tests ---
+    #[test]
+    fn deserialize_vec_i64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecI64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", -3, "-4"]}"#;
+        let expected = TestVecI64 {
+            val: vec![1, 2, -3, -4],
+        };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        // The error will point to the specific failing element
+        assert!(err.to_string().contains("invalid digit found in string")); // From parse error
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_type() {
+        let json = r#"{"val": [1, true, 3]}"#;
+        assert!(serde_json::from_str::<TestVecI64>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_vec_i64_empty() {
+        let data = TestVecI64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_i64_with_values() {
+        let data = TestVecI64 {
+            val: vec![1, -2, 0],
+        };
+        let expected_json = r#"{"val":["1","-2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<u64> Tests ---
+    #[test]
+    fn deserialize_vec_u64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecU64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", 3, "4"]}"#;
+        let expected = TestVecU64 {
+            val: vec![1, 2, 3, 4],
+        };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string"));
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_string() {
+        let json = r#"{"val": [1, "-2", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_number() {
+        let json = r#"{"val": [1, -2, 3]}"#;
+        assert!(serde_json::from_str::<TestVecU64>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_vec_u64_empty() {
+        let data = TestVecU64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_u64_with_values() {
+        let data = TestVecU64 { val: vec![1, 2, 0] };
+        let expected_json = r#"{"val":["1","2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Enum with NumberOrString field Tests ---
+    #[test]
+    fn deserialize_enum_variant_a_with_number() {
+        let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
+        let expected = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_a_with_string_number() {
+        let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
+        let expected = TestEnum::VariantA {
+            num_val: -45,
+            other_data: "data".to_string(),
+        };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_number() {
+        let json = r#"{"variantB": {"count": 7890}}"#;
+        let expected = TestEnum::VariantB { count: 7890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_string_number() {
+        let json = r#"{"variantB": {"count": "1234567890"}}"#;
+        let expected = TestEnum::VariantB { count: 1234567890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_a_error_invalid_num_string() {
+        let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
+        assert!(serde_json::from_str::<TestEnum>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_enum_variant_a() {
+        let data = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
+        // Note: num_val will be serialized as a string by NumberOrString
+        let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_enum_variant_b() {
+        let data = TestEnum::VariantB { count: 7890 };
+        let expected_json = r#"{"variantB":{"count":"7890"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+}


### PR DESCRIPTION
### What
  Move the Rust xdrgen generator, currently embedded in xdrgen, into this repository. Use xdrgen the library with the generator located here as a custom generator to generate the Rust code for the XDR.

  ### Why
  The Rust generator is tightly coupled with the code in this repository. It would be pretty painful to use the generator in isolation of this code. The workflow we use when updating the generated code is to change xdrgen then test it with rs-stellar-xdr. The tight coupling makes that pretty awkward.

I think looking forward it's more ideal that generators live near the SDKs they generate code for. Maybe one day the Rust generator becomes so unstable we aren't changing it anymore, and then it could move back into xdrgen as a built-in generator. But at the moment this move will make iterating on rs-stellar-xdr much more convenient and faster.

The change bringing the generator into this repository creates new opportunities. We could rewrite some of the generator to share common types between curr and next, which would probably make the stellar-xdr crate smaller / faster to build and easier to use. But this PR focused just on moving the generator over. Improvements can follow separately.

### Merging

Dependent on:
- https://github.com/stellar/xdrgen/pull/220

Related:
- https://github.com/stellar/stellar-protocol/discussions/1738
- https://github.com/stellar/xdrgen/pull/220
- https://github.com/stellar/xdrgen/pull/221
