### PR TITLE
Avoid large usage of stack memory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ serde_json = { version = "1.0.89", optional = true }
 thiserror = { version = "1.0.37", optional = true }
 schemars = { version = "0.8.16", optional = true }
 ethnum = { version = "1.5.0", optional = true }
-rand = { version = "0.9.0", optional = true }
+rand = { version = "0.9.0", optional = true, features = ["os_rng", "std_rng"] }
 sha2 = { version = "0.10.9", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Avoids allocating `Arbitrary`-related memory from the stack. `1024 * 10` (`10240`) usually isn't a problem in modern `x86_64` systems so let me know if this change is desired.