### PR TITLE
Change doc_auto_cfg feature to doc_cfg

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![forbid(unsafe_code)]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(docs, feature(doc_auto_cfg))]
+#![cfg_attr(docs, feature(doc_cfg))]
 // TODO: Remove these clippy doc comment allows after improving the
 // auto-generated docs.
 #![allow(clippy::tabs_in_doc_comments)]


### PR DESCRIPTION
### What
  Change the feature flag from `doc_auto_cfg` to `doc_cfg` in the library configuration attributes.

  ### Why

The `doc_auto_cfg` and `doc_cfg_hide` were combined into `doc_cfg`.

  The `doc_cfg` feature is now the feature name for documenting feature-gated items in Rust documentation. It was changed in the last couple weeks in Rust nightly. 

The fact that the functionality under `doc_cfg_hide` is now enabled and wasn't before has no consequence. We don't use the `#[doc(cfg_hide(...))]` feature which is the feature it provides.


Close https://github.com/stellar/rs-stellar-xdr/issues/476

Related https://github.com/rust-lang/rust/issues/43781

Related https://github.com/rust-lang/rust/commit/c0ee51f07d271f7cf3227c60a2c59aa18c959192