### PR TITLE
chore: update stellar-strkey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -715,9 +715,9 @@ dependencies = [
 
 [[package]]
 name = "stellar-strkey"
-version = "0.0.13"
+version = "0.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee1832fb50c651ad10f734aaf5d31ca5acdfb197a6ecda64d93fcdb8885af913"
+checksum = "97e1a364048067bfcd24e6f1a93bba43eeb79c16b854596c841c3e8bab0bfa0c"
 dependencies = [
  "crate-git-revision",
  "data-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ crate-git-revision = "0.0.6"
 
 [dependencies]
 cfg_eval = { version = "0.1.2" }
-stellar-strkey = { version = "0.0.13", optional = true }
+stellar-strkey = { version = "0.0.15", optional = true }
 base64 = { version = "0.22.1", optional = true }
 serde = { version = "1.0.139", features = ["derive"], optional = true }
 serde_with = { version = "3.12.0", features = ["schemars_0_8"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ crate-git-revision = "0.0.6"
 
 [dependencies]
 cfg_eval = { version = "0.1.2" }
-stellar-strkey = { version = "0.0.15", optional = true }
+stellar-strkey = { version = "0.0.16", optional = true }
 base64 = { version = "0.22.1", optional = true }
 serde = { version = "1.0.139", features = ["derive"], optional = true }
 serde_with = { version = "3.12.0", features = ["schemars_0_8"], optional = true }


### PR DESCRIPTION
### What

Update the `stellar-strkey` package

### Why

So it can be updated in the soroban-sdk without an old version also being included

### Known limitations

None
