### PR TITLE
Fix doc comment on type for schema subcommand

### DIFF
--- a/src/cli/types/schema.rs
+++ b/src/cli/types/schema.rs
@@ -13,7 +13,7 @@ pub enum Error {
 #[derive(Args, Debug, Clone)]
 #[command()]
 pub struct Cmd {
-    /// XDR type to decode
+    /// XDR type to generate schema for
     #[arg(long)]
     pub r#type: String,
 


### PR DESCRIPTION
The current documentation for the schema subcommand is a little misleading: `--type <TYPE>` is documented as "XDR type to decode." This just updates it to say "XDR type to generate schema for," instead.

```
$ stellar-xdr types schema --help
Usage: stellar-xdr types schema [OPTIONS] --type <TYPE>

Options:
      --type <TYPE>      XDR type to decode
      --output <OUTPUT>  [default: json-schema-draft201909] [possible values: json-schema-draft201909]
  -h, --help             Print help
```