### PR TITLE
Fix ResetRead panic on partial cache overlap

### DIFF
--- a/src/cli/guess.rs
+++ b/src/cli/guess.rs
@@ -258,7 +258,9 @@ mod test {
     #[test]
     fn test_reset_read_partial_cache_overlap() -> Result<(), Box<dyn error::Error>> {
         // 12 bytes with distinct values to verify read ordering.
-        let source: Vec<u8> = vec![0x00, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
+        let source: Vec<u8> = vec![
+            0x00, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+        ];
         let reader = Cursor::new(source);
         let mut rr = ResetRead::new(reader);
 


### PR DESCRIPTION
### What
Change `self.read.read(buf)` to `self.read.read(&mut buf[n..])` so the underlying reader writes into the unfilled remainder of the buffer rather than from the start. Add a regression test covering reads that span the cached and uncached boundary.

### Why
When a read partially hit the cache and then read from the underlying reader into the full buffer, `buf[n..n + read_n]` could exceed the buffer length, panicking with "range end index out of range". This caused `stellar-xdr guess --input single` to panic on valid inputs.

Close #501