### PR TITLE
Make cfg_eval dep optional, gate behind serde feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ doctest = false
 crate-git-revision = "0.0.6"
 
 [dependencies]
-cfg_eval = { version = "0.1.2" }
+cfg_eval = { version = "0.1.2", optional = true }
 stellar-strkey = { version = "0.0.13", optional = true }
 base64 = { version = "0.22.1", optional = true }
 serde = { version = "1.0.139", features = ["derive"], optional = true }
@@ -49,7 +49,7 @@ test_feature = []
 
 # Features dependent on optional dependencies.
 base64 = ["std", "dep:base64"]
-serde = ["alloc", "dep:serde", "dep:serde_with", "hex/serde"]
+serde = ["alloc", "dep:serde", "dep:serde_with", "hex/serde", "dep:cfg_eval"]
 serde_json = ["std", "serde", "dep:serde_json"]
 schemars = ["alloc", "serde", "serde_json", "dep:schemars"]
 arbitrary = ["std", "dep:arbitrary"]

--- a/src/generated/account_entry.rs
+++ b/src/generated/account_entry.rs
@@ -36,7 +36,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/account_entry_ext.rs
+++ b/src/generated/account_entry_ext.rs
@@ -14,7 +14,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant i32
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/account_entry_extension_v1.rs
+++ b/src/generated/account_entry_extension_v1.rs
@@ -21,7 +21,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/account_entry_extension_v1_ext.rs
+++ b/src/generated/account_entry_extension_v1_ext.rs
@@ -14,7 +14,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant i32
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/account_entry_extension_v2.rs
+++ b/src/generated/account_entry_extension_v2.rs
@@ -23,7 +23,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/account_entry_extension_v2_ext.rs
+++ b/src/generated/account_entry_extension_v2_ext.rs
@@ -14,7 +14,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant i32
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/account_entry_extension_v3.rs
+++ b/src/generated/account_entry_extension_v3.rs
@@ -20,7 +20,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/account_id.rs
+++ b/src/generated/account_id.rs
@@ -7,7 +7,7 @@ use super::*;
 /// typedef PublicKey AccountID;
 /// ```
 ///
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]

--- a/src/generated/account_merge_result.rs
+++ b/src/generated/account_merge_result.rs
@@ -20,7 +20,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant AccountMergeResultCode
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/allow_trust_op.rs
+++ b/src/generated/allow_trust_op.rs
@@ -16,7 +16,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/allow_trust_result.rs
+++ b/src/generated/allow_trust_result.rs
@@ -19,7 +19,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant AllowTrustResultCode
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/alpha_num12.rs
+++ b/src/generated/alpha_num12.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/alpha_num4.rs
+++ b/src/generated/alpha_num4.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/asset.rs
+++ b/src/generated/asset.rs
@@ -20,7 +20,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant AssetType
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/asset_code.rs
+++ b/src/generated/asset_code.rs
@@ -17,7 +17,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant AssetType
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/asset_code12.rs
+++ b/src/generated/asset_code12.rs
@@ -7,7 +7,7 @@ use super::*;
 /// typedef opaque AssetCode12[12];
 /// ```
 ///
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]

--- a/src/generated/asset_code4.rs
+++ b/src/generated/asset_code4.rs
@@ -7,7 +7,7 @@ use super::*;
 /// typedef opaque AssetCode4[4];
 /// ```
 ///
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]

--- a/src/generated/auth.rs
+++ b/src/generated/auth.rs
@@ -12,7 +12,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/auth_cert.rs
+++ b/src/generated/auth_cert.rs
@@ -14,7 +14,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/authenticated_message.rs
+++ b/src/generated/authenticated_message.rs
@@ -17,7 +17,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant u32
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/authenticated_message_v0.rs
+++ b/src/generated/authenticated_message_v0.rs
@@ -14,7 +14,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/begin_sponsoring_future_reserves_op.rs
+++ b/src/generated/begin_sponsoring_future_reserves_op.rs
@@ -12,7 +12,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/begin_sponsoring_future_reserves_result.rs
+++ b/src/generated/begin_sponsoring_future_reserves_result.rs
@@ -17,7 +17,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant BeginSponsoringFutureReservesResultCode
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/bucket_entry.rs
+++ b/src/generated/bucket_entry.rs
@@ -18,7 +18,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant BucketEntryType
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/bucket_metadata.rs
+++ b/src/generated/bucket_metadata.rs
@@ -23,7 +23,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/bucket_metadata_ext.rs
+++ b/src/generated/bucket_metadata_ext.rs
@@ -14,7 +14,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant i32
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/bump_sequence_op.rs
+++ b/src/generated/bump_sequence_op.rs
@@ -12,7 +12,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/bump_sequence_result.rs
+++ b/src/generated/bump_sequence_result.rs
@@ -14,7 +14,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant BumpSequenceResultCode
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/change_trust_asset.rs
+++ b/src/generated/change_trust_asset.rs
@@ -23,7 +23,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant AssetType
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/change_trust_op.rs
+++ b/src/generated/change_trust_op.rs
@@ -15,7 +15,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/change_trust_result.rs
+++ b/src/generated/change_trust_result.rs
@@ -21,7 +21,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant ChangeTrustResultCode
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/claim_atom.rs
+++ b/src/generated/claim_atom.rs
@@ -16,7 +16,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant ClaimAtomType
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/claim_claimable_balance_op.rs
+++ b/src/generated/claim_claimable_balance_op.rs
@@ -12,7 +12,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/claim_claimable_balance_result.rs
+++ b/src/generated/claim_claimable_balance_result.rs
@@ -19,7 +19,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant ClaimClaimableBalanceResultCode
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/claim_liquidity_atom.rs
+++ b/src/generated/claim_liquidity_atom.rs
@@ -20,7 +20,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/claim_offer_atom.rs
+++ b/src/generated/claim_offer_atom.rs
@@ -22,7 +22,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/claim_offer_atom_v0.rs
+++ b/src/generated/claim_offer_atom_v0.rs
@@ -22,7 +22,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/claim_predicate.rs
+++ b/src/generated/claim_predicate.rs
@@ -23,7 +23,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant ClaimPredicateType
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/claimable_balance_entry.rs
+++ b/src/generated/claimable_balance_entry.rs
@@ -32,7 +32,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/claimable_balance_entry_ext.rs
+++ b/src/generated/claimable_balance_entry_ext.rs
@@ -14,7 +14,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant i32
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/claimable_balance_entry_extension_v1.rs
+++ b/src/generated/claimable_balance_entry_extension_v1.rs
@@ -19,7 +19,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/claimable_balance_entry_extension_v1_ext.rs
+++ b/src/generated/claimable_balance_entry_extension_v1_ext.rs
@@ -12,7 +12,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant i32
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/claimable_balance_id.rs
+++ b/src/generated/claimable_balance_id.rs
@@ -12,7 +12,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant ClaimableBalanceIdType
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/claimant.rs
+++ b/src/generated/claimant.rs
@@ -16,7 +16,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant ClaimantType
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/claimant_v0.rs
+++ b/src/generated/claimant_v0.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/clawback_claimable_balance_op.rs
+++ b/src/generated/clawback_claimable_balance_op.rs
@@ -12,7 +12,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/clawback_claimable_balance_result.rs
+++ b/src/generated/clawback_claimable_balance_result.rs
@@ -17,7 +17,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant ClawbackClaimableBalanceResultCode
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/clawback_op.rs
+++ b/src/generated/clawback_op.rs
@@ -14,7 +14,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/clawback_result.rs
+++ b/src/generated/clawback_result.rs
@@ -17,7 +17,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant ClawbackResultCode
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/config_setting_contract_bandwidth_v0.rs
+++ b/src/generated/config_setting_contract_bandwidth_v0.rs
@@ -18,7 +18,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/config_setting_contract_compute_v0.rs
+++ b/src/generated/config_setting_contract_compute_v0.rs
@@ -21,7 +21,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/config_setting_contract_events_v0.rs
+++ b/src/generated/config_setting_contract_events_v0.rs
@@ -15,7 +15,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/config_setting_contract_execution_lanes_v0.rs
+++ b/src/generated/config_setting_contract_execution_lanes_v0.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/config_setting_contract_historical_data_v0.rs
+++ b/src/generated/config_setting_contract_historical_data_v0.rs
@@ -12,7 +12,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/config_setting_contract_ledger_cost_ext_v0.rs
+++ b/src/generated/config_setting_contract_ledger_cost_ext_v0.rs
@@ -17,7 +17,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/config_setting_contract_ledger_cost_v0.rs
+++ b/src/generated/config_setting_contract_ledger_cost_v0.rs
@@ -43,7 +43,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/config_setting_contract_parallel_compute_v0.rs
+++ b/src/generated/config_setting_contract_parallel_compute_v0.rs
@@ -16,7 +16,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/config_setting_entry.rs
+++ b/src/generated/config_setting_entry.rs
@@ -52,7 +52,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant ConfigSettingId
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/config_setting_scp_timing.rs
+++ b/src/generated/config_setting_scp_timing.rs
@@ -15,7 +15,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/config_upgrade_set.rs
+++ b/src/generated/config_upgrade_set.rs
@@ -11,7 +11,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/config_upgrade_set_key.rs
+++ b/src/generated/config_upgrade_set_key.rs
@@ -12,7 +12,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/contract_code_cost_inputs.rs
+++ b/src/generated/contract_code_cost_inputs.rs
@@ -21,7 +21,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/contract_code_entry.rs
+++ b/src/generated/contract_code_entry.rs
@@ -24,7 +24,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/contract_code_entry_ext.rs
+++ b/src/generated/contract_code_entry_ext.rs
@@ -18,7 +18,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant i32
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/contract_code_entry_v1.rs
+++ b/src/generated/contract_code_entry_v1.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/contract_cost_param_entry.rs
+++ b/src/generated/contract_cost_param_entry.rs
@@ -15,7 +15,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/contract_cost_params.rs
+++ b/src/generated/contract_cost_params.rs
@@ -7,7 +7,7 @@ use super::*;
 /// typedef ContractCostParamEntry ContractCostParams<CONTRACT_COST_COUNT_LIMIT>;
 /// ```
 ///
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Default, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/contract_data_entry.rs
+++ b/src/generated/contract_data_entry.rs
@@ -16,7 +16,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/contract_event.rs
+++ b/src/generated/contract_event.rs
@@ -28,7 +28,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/contract_event_body.rs
+++ b/src/generated/contract_event_body.rs
@@ -16,7 +16,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant i32
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/contract_event_v0.rs
+++ b/src/generated/contract_event_v0.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/contract_executable.rs
+++ b/src/generated/contract_executable.rs
@@ -14,7 +14,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant ContractExecutableType
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/contract_id.rs
+++ b/src/generated/contract_id.rs
@@ -7,7 +7,7 @@ use super::*;
 /// typedef Hash ContractID;
 /// ```
 ///
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]

--- a/src/generated/contract_id_preimage.rs
+++ b/src/generated/contract_id_preimage.rs
@@ -18,7 +18,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant ContractIdPreimageType
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/contract_id_preimage_from_address.rs
+++ b/src/generated/contract_id_preimage_from_address.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/create_account_op.rs
+++ b/src/generated/create_account_op.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/create_account_result.rs
+++ b/src/generated/create_account_result.rs
@@ -17,7 +17,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant CreateAccountResultCode
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/create_claimable_balance_op.rs
+++ b/src/generated/create_claimable_balance_op.rs
@@ -14,7 +14,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/create_claimable_balance_result.rs
+++ b/src/generated/create_claimable_balance_result.rs
@@ -19,7 +19,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant CreateClaimableBalanceResultCode
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/create_contract_args.rs
+++ b/src/generated/create_contract_args.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/create_contract_args_v2.rs
+++ b/src/generated/create_contract_args_v2.rs
@@ -15,7 +15,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/create_passive_sell_offer_op.rs
+++ b/src/generated/create_passive_sell_offer_op.rs
@@ -15,7 +15,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/curve25519_public.rs
+++ b/src/generated/curve25519_public.rs
@@ -12,7 +12,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/curve25519_secret.rs
+++ b/src/generated/curve25519_secret.rs
@@ -12,7 +12,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/data_entry.rs
+++ b/src/generated/data_entry.rs
@@ -22,7 +22,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/data_entry_ext.rs
+++ b/src/generated/data_entry_ext.rs
@@ -12,7 +12,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant i32
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/data_value.rs
+++ b/src/generated/data_value.rs
@@ -7,7 +7,7 @@ use super::*;
 /// typedef opaque DataValue<64>;
 /// ```
 ///
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Default, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/decorated_signature.rs
+++ b/src/generated/decorated_signature.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/dependent_tx_cluster.rs
+++ b/src/generated/dependent_tx_cluster.rs
@@ -7,7 +7,7 @@ use super::*;
 /// typedef TransactionEnvelope DependentTxCluster<>;
 /// ```
 ///
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Default, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/diagnostic_event.rs
+++ b/src/generated/diagnostic_event.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/dont_have.rs
+++ b/src/generated/dont_have.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/duration.rs
+++ b/src/generated/duration.rs
@@ -7,7 +7,7 @@ use super::*;
 /// typedef uint64 Duration;
 /// ```
 ///
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]

--- a/src/generated/encoded_ledger_key.rs
+++ b/src/generated/encoded_ledger_key.rs
@@ -7,7 +7,7 @@ use super::*;
 /// typedef opaque EncodedLedgerKey<>;
 /// ```
 ///
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Default, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/encrypted_body.rs
+++ b/src/generated/encrypted_body.rs
@@ -7,7 +7,7 @@ use super::*;
 /// typedef opaque EncryptedBody<64000>;
 /// ```
 ///
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Default, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/end_sponsoring_future_reserves_result.rs
+++ b/src/generated/end_sponsoring_future_reserves_result.rs
@@ -15,7 +15,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant EndSponsoringFutureReservesResultCode
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/eviction_iterator.rs
+++ b/src/generated/eviction_iterator.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/extend_footprint_ttl_op.rs
+++ b/src/generated/extend_footprint_ttl_op.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/extend_footprint_ttl_result.rs
+++ b/src/generated/extend_footprint_ttl_result.rs
@@ -16,7 +16,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant ExtendFootprintTtlResultCode
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/extension_point.rs
+++ b/src/generated/extension_point.rs
@@ -12,7 +12,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant i32
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/fee_bump_transaction.rs
+++ b/src/generated/fee_bump_transaction.rs
@@ -25,7 +25,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/fee_bump_transaction_envelope.rs
+++ b/src/generated/fee_bump_transaction_envelope.rs
@@ -15,7 +15,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/fee_bump_transaction_ext.rs
+++ b/src/generated/fee_bump_transaction_ext.rs
@@ -12,7 +12,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant i32
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/fee_bump_transaction_inner_tx.rs
+++ b/src/generated/fee_bump_transaction_inner_tx.rs
@@ -12,7 +12,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant EnvelopeType
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/flood_advert.rs
+++ b/src/generated/flood_advert.rs
@@ -12,7 +12,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/flood_demand.rs
+++ b/src/generated/flood_demand.rs
@@ -12,7 +12,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/freeze_bypass_txs.rs
+++ b/src/generated/freeze_bypass_txs.rs
@@ -11,7 +11,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/freeze_bypass_txs_delta.rs
+++ b/src/generated/freeze_bypass_txs_delta.rs
@@ -12,7 +12,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/frozen_ledger_keys.rs
+++ b/src/generated/frozen_ledger_keys.rs
@@ -11,7 +11,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/frozen_ledger_keys_delta.rs
+++ b/src/generated/frozen_ledger_keys_delta.rs
@@ -12,7 +12,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/generalized_transaction_set.rs
+++ b/src/generated/generalized_transaction_set.rs
@@ -13,7 +13,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant i32
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/hash.rs
+++ b/src/generated/hash.rs
@@ -7,7 +7,7 @@ use super::*;
 /// typedef opaque Hash[32];
 /// ```
 ///
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]

--- a/src/generated/hash_id_preimage.rs
+++ b/src/generated/hash_id_preimage.rs
@@ -40,7 +40,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant EnvelopeType
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/hash_id_preimage_contract_id.rs
+++ b/src/generated/hash_id_preimage_contract_id.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/hash_id_preimage_operation_id.rs
+++ b/src/generated/hash_id_preimage_operation_id.rs
@@ -14,7 +14,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/hash_id_preimage_revoke_id.rs
+++ b/src/generated/hash_id_preimage_revoke_id.rs
@@ -16,7 +16,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/hash_id_preimage_soroban_authorization.rs
+++ b/src/generated/hash_id_preimage_soroban_authorization.rs
@@ -15,7 +15,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/hello.rs
+++ b/src/generated/hello.rs
@@ -20,7 +20,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/hmac_sha256_key.rs
+++ b/src/generated/hmac_sha256_key.rs
@@ -12,7 +12,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/hmac_sha256_mac.rs
+++ b/src/generated/hmac_sha256_mac.rs
@@ -12,7 +12,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/host_function.rs
+++ b/src/generated/host_function.rs
@@ -18,7 +18,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant HostFunctionType
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/hot_archive_bucket_entry.rs
+++ b/src/generated/hot_archive_bucket_entry.rs
@@ -17,7 +17,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant HotArchiveBucketEntryType
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/inflation_payout.rs
+++ b/src/generated/inflation_payout.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/inflation_result.rs
+++ b/src/generated/inflation_result.rs
@@ -14,7 +14,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant InflationResultCode
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/inner_transaction_result.rs
+++ b/src/generated/inner_transaction_result.rs
@@ -48,7 +48,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/inner_transaction_result_ext.rs
+++ b/src/generated/inner_transaction_result_ext.rs
@@ -12,7 +12,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant i32
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/inner_transaction_result_pair.rs
+++ b/src/generated/inner_transaction_result_pair.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/inner_transaction_result_result.rs
+++ b/src/generated/inner_transaction_result_result.rs
@@ -32,7 +32,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant TransactionResultCode
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/int128_parts.rs
+++ b/src/generated/int128_parts.rs
@@ -12,7 +12,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/int256_parts.rs
+++ b/src/generated/int256_parts.rs
@@ -14,7 +14,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/invoke_contract_args.rs
+++ b/src/generated/invoke_contract_args.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/invoke_host_function_op.rs
+++ b/src/generated/invoke_host_function_op.rs
@@ -15,7 +15,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/invoke_host_function_result.rs
+++ b/src/generated/invoke_host_function_result.rs
@@ -18,7 +18,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant InvokeHostFunctionResultCode
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/invoke_host_function_success_pre_image.rs
+++ b/src/generated/invoke_host_function_success_pre_image.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/ledger_bounds.rs
+++ b/src/generated/ledger_bounds.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/ledger_close_meta.rs
+++ b/src/generated/ledger_close_meta.rs
@@ -16,7 +16,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant i32
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/ledger_close_meta_batch.rs
+++ b/src/generated/ledger_close_meta_batch.rs
@@ -19,7 +19,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/ledger_close_meta_ext.rs
+++ b/src/generated/ledger_close_meta_ext.rs
@@ -14,7 +14,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant i32
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/ledger_close_meta_ext_v1.rs
+++ b/src/generated/ledger_close_meta_ext_v1.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/ledger_close_meta_v0.rs
+++ b/src/generated/ledger_close_meta_v0.rs
@@ -25,7 +25,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/ledger_close_meta_v1.rs
+++ b/src/generated/ledger_close_meta_v1.rs
@@ -37,7 +37,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/ledger_close_meta_v2.rs
+++ b/src/generated/ledger_close_meta_v2.rs
@@ -34,7 +34,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/ledger_close_value_signature.rs
+++ b/src/generated/ledger_close_value_signature.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/ledger_entry.rs
+++ b/src/generated/ledger_entry.rs
@@ -47,7 +47,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/ledger_entry_change.rs
+++ b/src/generated/ledger_entry_change.rs
@@ -20,7 +20,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant LedgerEntryChangeType
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/ledger_entry_changes.rs
+++ b/src/generated/ledger_entry_changes.rs
@@ -7,7 +7,7 @@ use super::*;
 /// typedef LedgerEntryChange LedgerEntryChanges<>;
 /// ```
 ///
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Default, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/ledger_entry_data.rs
+++ b/src/generated/ledger_entry_data.rs
@@ -30,7 +30,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant LedgerEntryType
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/ledger_entry_ext.rs
+++ b/src/generated/ledger_entry_ext.rs
@@ -14,7 +14,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant i32
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/ledger_entry_extension_v1.rs
+++ b/src/generated/ledger_entry_extension_v1.rs
@@ -19,7 +19,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/ledger_entry_extension_v1_ext.rs
+++ b/src/generated/ledger_entry_extension_v1_ext.rs
@@ -12,7 +12,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant i32
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/ledger_footprint.rs
+++ b/src/generated/ledger_footprint.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/ledger_header.rs
+++ b/src/generated/ledger_header.rs
@@ -47,7 +47,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/ledger_header_ext.rs
+++ b/src/generated/ledger_header_ext.rs
@@ -14,7 +14,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant i32
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/ledger_header_extension_v1.rs
+++ b/src/generated/ledger_header_extension_v1.rs
@@ -19,7 +19,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/ledger_header_extension_v1_ext.rs
+++ b/src/generated/ledger_header_extension_v1_ext.rs
@@ -12,7 +12,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant i32
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/ledger_header_history_entry.rs
+++ b/src/generated/ledger_header_history_entry.rs
@@ -21,7 +21,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/ledger_header_history_entry_ext.rs
+++ b/src/generated/ledger_header_history_entry_ext.rs
@@ -12,7 +12,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant i32
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/ledger_key.rs
+++ b/src/generated/ledger_key.rs
@@ -71,7 +71,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant LedgerEntryType
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/ledger_key_account.rs
+++ b/src/generated/ledger_key_account.rs
@@ -12,7 +12,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/ledger_key_claimable_balance.rs
+++ b/src/generated/ledger_key_claimable_balance.rs
@@ -12,7 +12,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/ledger_key_config_setting.rs
+++ b/src/generated/ledger_key_config_setting.rs
@@ -12,7 +12,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/ledger_key_contract_code.rs
+++ b/src/generated/ledger_key_contract_code.rs
@@ -12,7 +12,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/ledger_key_contract_data.rs
+++ b/src/generated/ledger_key_contract_data.rs
@@ -14,7 +14,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/ledger_key_data.rs
+++ b/src/generated/ledger_key_data.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/ledger_key_liquidity_pool.rs
+++ b/src/generated/ledger_key_liquidity_pool.rs
@@ -12,7 +12,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/ledger_key_offer.rs
+++ b/src/generated/ledger_key_offer.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/ledger_key_trust_line.rs
+++ b/src/generated/ledger_key_trust_line.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/ledger_key_ttl.rs
+++ b/src/generated/ledger_key_ttl.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/ledger_scp_messages.rs
+++ b/src/generated/ledger_scp_messages.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/ledger_upgrade.rs
+++ b/src/generated/ledger_upgrade.rs
@@ -27,7 +27,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant LedgerUpgradeType
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/liabilities.rs
+++ b/src/generated/liabilities.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/liquidity_pool_constant_product_parameters.rs
+++ b/src/generated/liquidity_pool_constant_product_parameters.rs
@@ -14,7 +14,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/liquidity_pool_deposit_op.rs
+++ b/src/generated/liquidity_pool_deposit_op.rs
@@ -16,7 +16,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/liquidity_pool_deposit_result.rs
+++ b/src/generated/liquidity_pool_deposit_result.rs
@@ -21,7 +21,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant LiquidityPoolDepositResultCode
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/liquidity_pool_entry.rs
+++ b/src/generated/liquidity_pool_entry.rs
@@ -28,7 +28,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/liquidity_pool_entry_body.rs
+++ b/src/generated/liquidity_pool_entry_body.rs
@@ -21,7 +21,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant LiquidityPoolType
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/liquidity_pool_entry_constant_product.rs
+++ b/src/generated/liquidity_pool_entry_constant_product.rs
@@ -18,7 +18,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/liquidity_pool_parameters.rs
+++ b/src/generated/liquidity_pool_parameters.rs
@@ -12,7 +12,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant LiquidityPoolType
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/liquidity_pool_withdraw_op.rs
+++ b/src/generated/liquidity_pool_withdraw_op.rs
@@ -15,7 +15,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/liquidity_pool_withdraw_result.rs
+++ b/src/generated/liquidity_pool_withdraw_result.rs
@@ -19,7 +19,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant LiquidityPoolWithdrawResultCode
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/manage_buy_offer_op.rs
+++ b/src/generated/manage_buy_offer_op.rs
@@ -19,7 +19,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/manage_buy_offer_result.rs
+++ b/src/generated/manage_buy_offer_result.rs
@@ -25,7 +25,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant ManageBuyOfferResultCode
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/manage_data_op.rs
+++ b/src/generated/manage_data_op.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/manage_data_result.rs
+++ b/src/generated/manage_data_result.rs
@@ -17,7 +17,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant ManageDataResultCode
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/manage_offer_success_result.rs
+++ b/src/generated/manage_offer_success_result.rs
@@ -23,7 +23,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/manage_offer_success_result_offer.rs
+++ b/src/generated/manage_offer_success_result_offer.rs
@@ -15,7 +15,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant ManageOfferEffect
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/manage_sell_offer_op.rs
+++ b/src/generated/manage_sell_offer_op.rs
@@ -18,7 +18,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/manage_sell_offer_result.rs
+++ b/src/generated/manage_sell_offer_result.rs
@@ -25,7 +25,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant ManageSellOfferResultCode
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/memo.rs
+++ b/src/generated/memo.rs
@@ -20,7 +20,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant MemoType
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/muxed_account.rs
+++ b/src/generated/muxed_account.rs
@@ -18,7 +18,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant CryptoKeyType
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/muxed_account_med25519.rs
+++ b/src/generated/muxed_account_med25519.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/muxed_ed25519_account.rs
+++ b/src/generated/muxed_ed25519_account.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/node_id.rs
+++ b/src/generated/node_id.rs
@@ -7,7 +7,7 @@ use super::*;
 /// typedef PublicKey NodeID;
 /// ```
 ///
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]

--- a/src/generated/offer_entry.rs
+++ b/src/generated/offer_entry.rs
@@ -32,7 +32,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/offer_entry_ext.rs
+++ b/src/generated/offer_entry_ext.rs
@@ -12,7 +12,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant i32
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/operation.rs
+++ b/src/generated/operation.rs
@@ -74,7 +74,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/operation_body.rs
+++ b/src/generated/operation_body.rs
@@ -64,7 +64,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant OperationType
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/operation_meta.rs
+++ b/src/generated/operation_meta.rs
@@ -12,7 +12,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/operation_meta_v2.rs
+++ b/src/generated/operation_meta_v2.rs
@@ -16,7 +16,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/operation_result.rs
+++ b/src/generated/operation_result.rs
@@ -76,7 +76,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant OperationResultCode
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/operation_result_tr.rs
+++ b/src/generated/operation_result_tr.rs
@@ -64,7 +64,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant OperationType
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/parallel_tx_execution_stage.rs
+++ b/src/generated/parallel_tx_execution_stage.rs
@@ -7,7 +7,7 @@ use super::*;
 /// typedef DependentTxCluster ParallelTxExecutionStage<>;
 /// ```
 ///
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Default, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/parallel_txs_component.rs
+++ b/src/generated/parallel_txs_component.rs
@@ -16,7 +16,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/path_payment_strict_receive_op.rs
+++ b/src/generated/path_payment_strict_receive_op.rs
@@ -21,7 +21,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/path_payment_strict_receive_result.rs
+++ b/src/generated/path_payment_strict_receive_result.rs
@@ -32,7 +32,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant PathPaymentStrictReceiveResultCode
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/path_payment_strict_receive_result_success.rs
+++ b/src/generated/path_payment_strict_receive_result_success.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/path_payment_strict_send_op.rs
+++ b/src/generated/path_payment_strict_send_op.rs
@@ -21,7 +21,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/path_payment_strict_send_result.rs
+++ b/src/generated/path_payment_strict_send_result.rs
@@ -31,7 +31,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant PathPaymentStrictSendResultCode
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/path_payment_strict_send_result_success.rs
+++ b/src/generated/path_payment_strict_send_result_success.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/payment_op.rs
+++ b/src/generated/payment_op.rs
@@ -14,7 +14,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/payment_result.rs
+++ b/src/generated/payment_result.rs
@@ -22,7 +22,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant PaymentResultCode
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/peer_address.rs
+++ b/src/generated/peer_address.rs
@@ -21,7 +21,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/peer_address_ip.rs
+++ b/src/generated/peer_address_ip.rs
@@ -14,7 +14,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant IpAddrType
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/peer_stats.rs
+++ b/src/generated/peer_stats.rs
@@ -28,7 +28,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/persisted_scp_state.rs
+++ b/src/generated/persisted_scp_state.rs
@@ -14,7 +14,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant i32
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/persisted_scp_state_v0.rs
+++ b/src/generated/persisted_scp_state_v0.rs
@@ -14,7 +14,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/persisted_scp_state_v1.rs
+++ b/src/generated/persisted_scp_state_v1.rs
@@ -14,7 +14,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/pool_id.rs
+++ b/src/generated/pool_id.rs
@@ -7,7 +7,7 @@ use super::*;
 /// typedef Hash PoolID;
 /// ```
 ///
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]

--- a/src/generated/preconditions.rs
+++ b/src/generated/preconditions.rs
@@ -16,7 +16,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant PreconditionType
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/preconditions_v2.rs
+++ b/src/generated/preconditions_v2.rs
@@ -40,7 +40,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/price.rs
+++ b/src/generated/price.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/public_key.rs
+++ b/src/generated/public_key.rs
@@ -12,7 +12,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant PublicKeyType
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/restore_footprint_op.rs
+++ b/src/generated/restore_footprint_op.rs
@@ -12,7 +12,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/restore_footprint_result.rs
+++ b/src/generated/restore_footprint_result.rs
@@ -16,7 +16,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant RestoreFootprintResultCode
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/revoke_sponsorship_op.rs
+++ b/src/generated/revoke_sponsorship_op.rs
@@ -18,7 +18,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant RevokeSponsorshipType
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/revoke_sponsorship_op_signer.rs
+++ b/src/generated/revoke_sponsorship_op_signer.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/revoke_sponsorship_result.rs
+++ b/src/generated/revoke_sponsorship_result.rs
@@ -18,7 +18,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant RevokeSponsorshipResultCode
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/s_error.rs
+++ b/src/generated/s_error.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/sc_address.rs
+++ b/src/generated/sc_address.rs
@@ -20,7 +20,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant ScAddressType
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/sc_bytes.rs
+++ b/src/generated/sc_bytes.rs
@@ -7,7 +7,7 @@ use super::*;
 /// typedef opaque SCBytes<>;
 /// ```
 ///
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Default, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/sc_contract_instance.rs
+++ b/src/generated/sc_contract_instance.rs
@@ -12,7 +12,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/sc_env_meta_entry.rs
+++ b/src/generated/sc_env_meta_entry.rs
@@ -15,7 +15,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant ScEnvMetaKind
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/sc_env_meta_entry_interface_version.rs
+++ b/src/generated/sc_env_meta_entry_interface_version.rs
@@ -12,7 +12,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/sc_error.rs
+++ b/src/generated/sc_error.rs
@@ -22,7 +22,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant ScErrorType
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/sc_map.rs
+++ b/src/generated/sc_map.rs
@@ -7,7 +7,7 @@ use super::*;
 /// typedef SCMapEntry SCMap<>;
 /// ```
 ///
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Default, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/sc_map_entry.rs
+++ b/src/generated/sc_map_entry.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/sc_meta_entry.rs
+++ b/src/generated/sc_meta_entry.rs
@@ -12,7 +12,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant ScMetaKind
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/sc_meta_v0.rs
+++ b/src/generated/sc_meta_v0.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/sc_nonce_key.rs
+++ b/src/generated/sc_nonce_key.rs
@@ -11,7 +11,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/sc_spec_entry.rs
+++ b/src/generated/sc_spec_entry.rs
@@ -22,7 +22,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant ScSpecEntryKind
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/sc_spec_event_param_v0.rs
+++ b/src/generated/sc_spec_event_param_v0.rs
@@ -15,7 +15,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/sc_spec_event_v0.rs
+++ b/src/generated/sc_spec_event_v0.rs
@@ -17,7 +17,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/sc_spec_function_input_v0.rs
+++ b/src/generated/sc_spec_function_input_v0.rs
@@ -14,7 +14,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/sc_spec_function_v0.rs
+++ b/src/generated/sc_spec_function_v0.rs
@@ -15,7 +15,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/sc_spec_type_bytes_n.rs
+++ b/src/generated/sc_spec_type_bytes_n.rs
@@ -12,7 +12,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/sc_spec_type_def.rs
+++ b/src/generated/sc_spec_type_def.rs
@@ -44,7 +44,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant ScSpecType
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/sc_spec_type_map.rs
+++ b/src/generated/sc_spec_type_map.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/sc_spec_type_option.rs
+++ b/src/generated/sc_spec_type_option.rs
@@ -12,7 +12,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/sc_spec_type_result.rs
+++ b/src/generated/sc_spec_type_result.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/sc_spec_type_tuple.rs
+++ b/src/generated/sc_spec_type_tuple.rs
@@ -12,7 +12,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/sc_spec_type_udt.rs
+++ b/src/generated/sc_spec_type_udt.rs
@@ -12,7 +12,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/sc_spec_type_vec.rs
+++ b/src/generated/sc_spec_type_vec.rs
@@ -12,7 +12,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/sc_spec_udt_enum_case_v0.rs
+++ b/src/generated/sc_spec_udt_enum_case_v0.rs
@@ -14,7 +14,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/sc_spec_udt_enum_v0.rs
+++ b/src/generated/sc_spec_udt_enum_v0.rs
@@ -15,7 +15,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/sc_spec_udt_error_enum_case_v0.rs
+++ b/src/generated/sc_spec_udt_error_enum_case_v0.rs
@@ -14,7 +14,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/sc_spec_udt_error_enum_v0.rs
+++ b/src/generated/sc_spec_udt_error_enum_v0.rs
@@ -15,7 +15,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/sc_spec_udt_struct_field_v0.rs
+++ b/src/generated/sc_spec_udt_struct_field_v0.rs
@@ -14,7 +14,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/sc_spec_udt_struct_v0.rs
+++ b/src/generated/sc_spec_udt_struct_v0.rs
@@ -15,7 +15,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/sc_spec_udt_union_case_tuple_v0.rs
+++ b/src/generated/sc_spec_udt_union_case_tuple_v0.rs
@@ -14,7 +14,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/sc_spec_udt_union_case_v0.rs
+++ b/src/generated/sc_spec_udt_union_case_v0.rs
@@ -14,7 +14,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant ScSpecUdtUnionCaseV0Kind
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/sc_spec_udt_union_case_void_v0.rs
+++ b/src/generated/sc_spec_udt_union_case_void_v0.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/sc_spec_udt_union_v0.rs
+++ b/src/generated/sc_spec_udt_union_v0.rs
@@ -15,7 +15,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/sc_string.rs
+++ b/src/generated/sc_string.rs
@@ -7,7 +7,7 @@ use super::*;
 /// typedef string SCString<>;
 /// ```
 ///
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Default, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/sc_symbol.rs
+++ b/src/generated/sc_symbol.rs
@@ -7,7 +7,7 @@ use super::*;
 /// typedef string SCSymbol<SCSYMBOL_LIMIT>;
 /// ```
 ///
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Default, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/sc_val.rs
+++ b/src/generated/sc_val.rs
@@ -67,7 +67,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant ScValType
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/sc_vec.rs
+++ b/src/generated/sc_vec.rs
@@ -7,7 +7,7 @@ use super::*;
 /// typedef SCVal SCVec<>;
 /// ```
 ///
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Default, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/scp_ballot.rs
+++ b/src/generated/scp_ballot.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/scp_envelope.rs
+++ b/src/generated/scp_envelope.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/scp_history_entry.rs
+++ b/src/generated/scp_history_entry.rs
@@ -12,7 +12,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant i32
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/scp_history_entry_v0.rs
+++ b/src/generated/scp_history_entry_v0.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/scp_nomination.rs
+++ b/src/generated/scp_nomination.rs
@@ -14,7 +14,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/scp_quorum_set.rs
+++ b/src/generated/scp_quorum_set.rs
@@ -14,7 +14,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/scp_statement.rs
+++ b/src/generated/scp_statement.rs
@@ -46,7 +46,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/scp_statement_confirm.rs
+++ b/src/generated/scp_statement_confirm.rs
@@ -16,7 +16,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/scp_statement_externalize.rs
+++ b/src/generated/scp_statement_externalize.rs
@@ -14,7 +14,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/scp_statement_pledges.rs
+++ b/src/generated/scp_statement_pledges.rs
@@ -38,7 +38,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant ScpStatementType
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/scp_statement_prepare.rs
+++ b/src/generated/scp_statement_prepare.rs
@@ -17,7 +17,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/send_more.rs
+++ b/src/generated/send_more.rs
@@ -12,7 +12,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/send_more_extended.rs
+++ b/src/generated/send_more_extended.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/sequence_number.rs
+++ b/src/generated/sequence_number.rs
@@ -7,7 +7,7 @@ use super::*;
 /// typedef int64 SequenceNumber;
 /// ```
 ///
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]

--- a/src/generated/serialized_binary_fuse_filter.rs
+++ b/src/generated/serialized_binary_fuse_filter.rs
@@ -26,7 +26,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/set_options_op.rs
+++ b/src/generated/set_options_op.rs
@@ -27,7 +27,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/set_options_result.rs
+++ b/src/generated/set_options_result.rs
@@ -23,7 +23,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant SetOptionsResultCode
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/set_trust_line_flags_op.rs
+++ b/src/generated/set_trust_line_flags_op.rs
@@ -16,7 +16,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/set_trust_line_flags_result.rs
+++ b/src/generated/set_trust_line_flags_result.rs
@@ -18,7 +18,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant SetTrustLineFlagsResultCode
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/short_hash_seed.rs
+++ b/src/generated/short_hash_seed.rs
@@ -12,7 +12,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/signature.rs
+++ b/src/generated/signature.rs
@@ -7,7 +7,7 @@ use super::*;
 /// typedef opaque Signature<64>;
 /// ```
 ///
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Default, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/signature_hint.rs
+++ b/src/generated/signature_hint.rs
@@ -7,7 +7,7 @@ use super::*;
 /// typedef opaque SignatureHint[4];
 /// ```
 ///
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]

--- a/src/generated/signed_time_sliced_survey_request_message.rs
+++ b/src/generated/signed_time_sliced_survey_request_message.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/signed_time_sliced_survey_response_message.rs
+++ b/src/generated/signed_time_sliced_survey_response_message.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/signed_time_sliced_survey_start_collecting_message.rs
+++ b/src/generated/signed_time_sliced_survey_start_collecting_message.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/signed_time_sliced_survey_stop_collecting_message.rs
+++ b/src/generated/signed_time_sliced_survey_stop_collecting_message.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/signer.rs
+++ b/src/generated/signer.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/signer_key.rs
+++ b/src/generated/signer_key.rs
@@ -26,7 +26,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant SignerKeyType
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/signer_key_ed25519_signed_payload.rs
+++ b/src/generated/signer_key_ed25519_signed_payload.rs
@@ -15,7 +15,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/simple_payment_result.rs
+++ b/src/generated/simple_payment_result.rs
@@ -14,7 +14,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/soroban_address_credentials.rs
+++ b/src/generated/soroban_address_credentials.rs
@@ -15,7 +15,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/soroban_authorization_entries.rs
+++ b/src/generated/soroban_authorization_entries.rs
@@ -7,7 +7,7 @@ use super::*;
 /// typedef SorobanAuthorizationEntry SorobanAuthorizationEntries<>;
 /// ```
 ///
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Default, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/soroban_authorization_entry.rs
+++ b/src/generated/soroban_authorization_entry.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/soroban_authorized_function.rs
+++ b/src/generated/soroban_authorized_function.rs
@@ -24,7 +24,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant SorobanAuthorizedFunctionType
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/soroban_authorized_invocation.rs
+++ b/src/generated/soroban_authorized_invocation.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/soroban_credentials.rs
+++ b/src/generated/soroban_credentials.rs
@@ -14,7 +14,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant SorobanCredentialsType
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/soroban_resources.rs
+++ b/src/generated/soroban_resources.rs
@@ -20,7 +20,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/soroban_resources_ext_v0.rs
+++ b/src/generated/soroban_resources_ext_v0.rs
@@ -15,7 +15,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/soroban_transaction_data.rs
+++ b/src/generated/soroban_transaction_data.rs
@@ -29,7 +29,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/soroban_transaction_data_ext.rs
+++ b/src/generated/soroban_transaction_data_ext.rs
@@ -14,7 +14,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant i32
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/soroban_transaction_meta.rs
+++ b/src/generated/soroban_transaction_meta.rs
@@ -21,7 +21,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/soroban_transaction_meta_ext.rs
+++ b/src/generated/soroban_transaction_meta_ext.rs
@@ -14,7 +14,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant i32
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/soroban_transaction_meta_ext_v1.rs
+++ b/src/generated/soroban_transaction_meta_ext_v1.rs
@@ -41,7 +41,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/soroban_transaction_meta_v2.rs
+++ b/src/generated/soroban_transaction_meta_v2.rs
@@ -14,7 +14,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/sponsorship_descriptor.rs
+++ b/src/generated/sponsorship_descriptor.rs
@@ -7,7 +7,7 @@ use super::*;
 /// typedef AccountID* SponsorshipDescriptor;
 /// ```
 ///
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]

--- a/src/generated/state_archival_settings.rs
+++ b/src/generated/state_archival_settings.rs
@@ -32,7 +32,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/stellar_message.rs
+++ b/src/generated/stellar_message.rs
@@ -63,7 +63,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant MessageType
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/stellar_value.rs
+++ b/src/generated/stellar_value.rs
@@ -30,7 +30,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/stellar_value_ext.rs
+++ b/src/generated/stellar_value_ext.rs
@@ -14,7 +14,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant StellarValueType
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/stored_debug_transaction_set.rs
+++ b/src/generated/stored_debug_transaction_set.rs
@@ -14,7 +14,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/stored_transaction_set.rs
+++ b/src/generated/stored_transaction_set.rs
@@ -14,7 +14,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant i32
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/string32.rs
+++ b/src/generated/string32.rs
@@ -7,7 +7,7 @@ use super::*;
 /// typedef string string32<32>;
 /// ```
 ///
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Default, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/string64.rs
+++ b/src/generated/string64.rs
@@ -7,7 +7,7 @@ use super::*;
 /// typedef string string64<64>;
 /// ```
 ///
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Default, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/survey_request_message.rs
+++ b/src/generated/survey_request_message.rs
@@ -16,7 +16,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/survey_response_body.rs
+++ b/src/generated/survey_response_body.rs
@@ -12,7 +12,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant SurveyMessageResponseType
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/survey_response_message.rs
+++ b/src/generated/survey_response_message.rs
@@ -16,7 +16,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/test_next_type.rs
+++ b/src/generated/test_next_type.rs
@@ -13,7 +13,7 @@ use super::*;
 #[cfg(feature = "test_feature")]
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/thresholds.rs
+++ b/src/generated/thresholds.rs
@@ -7,7 +7,7 @@ use super::*;
 /// typedef opaque Thresholds[4];
 /// ```
 ///
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]

--- a/src/generated/time_bounds.rs
+++ b/src/generated/time_bounds.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/time_point.rs
+++ b/src/generated/time_point.rs
@@ -7,7 +7,7 @@ use super::*;
 /// typedef uint64 TimePoint;
 /// ```
 ///
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]

--- a/src/generated/time_sliced_node_data.rs
+++ b/src/generated/time_sliced_node_data.rs
@@ -27,7 +27,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/time_sliced_peer_data.rs
+++ b/src/generated/time_sliced_peer_data.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/time_sliced_peer_data_list.rs
+++ b/src/generated/time_sliced_peer_data_list.rs
@@ -7,7 +7,7 @@ use super::*;
 /// typedef TimeSlicedPeerData TimeSlicedPeerDataList<25>;
 /// ```
 ///
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Default, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/time_sliced_survey_request_message.rs
+++ b/src/generated/time_sliced_survey_request_message.rs
@@ -15,7 +15,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/time_sliced_survey_response_message.rs
+++ b/src/generated/time_sliced_survey_response_message.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/time_sliced_survey_start_collecting_message.rs
+++ b/src/generated/time_sliced_survey_start_collecting_message.rs
@@ -14,7 +14,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/time_sliced_survey_stop_collecting_message.rs
+++ b/src/generated/time_sliced_survey_stop_collecting_message.rs
@@ -14,7 +14,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/topology_response_body_v2.rs
+++ b/src/generated/topology_response_body_v2.rs
@@ -14,7 +14,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/transaction.rs
+++ b/src/generated/transaction.rs
@@ -35,7 +35,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/transaction_envelope.rs
+++ b/src/generated/transaction_envelope.rs
@@ -16,7 +16,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant EnvelopeType
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/transaction_event.rs
+++ b/src/generated/transaction_event.rs
@@ -12,7 +12,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/transaction_ext.rs
+++ b/src/generated/transaction_ext.rs
@@ -14,7 +14,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant i32
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/transaction_history_entry.rs
+++ b/src/generated/transaction_history_entry.rs
@@ -23,7 +23,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/transaction_history_entry_ext.rs
+++ b/src/generated/transaction_history_entry_ext.rs
@@ -14,7 +14,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant i32
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/transaction_history_result_entry.rs
+++ b/src/generated/transaction_history_result_entry.rs
@@ -21,7 +21,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/transaction_history_result_entry_ext.rs
+++ b/src/generated/transaction_history_result_entry_ext.rs
@@ -12,7 +12,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant i32
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/transaction_meta.rs
+++ b/src/generated/transaction_meta.rs
@@ -20,7 +20,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant i32
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/transaction_meta_v1.rs
+++ b/src/generated/transaction_meta_v1.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/transaction_meta_v2.rs
+++ b/src/generated/transaction_meta_v2.rs
@@ -16,7 +16,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/transaction_meta_v3.rs
+++ b/src/generated/transaction_meta_v3.rs
@@ -20,7 +20,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/transaction_meta_v4.rs
+++ b/src/generated/transaction_meta_v4.rs
@@ -23,7 +23,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/transaction_phase.rs
+++ b/src/generated/transaction_phase.rs
@@ -14,7 +14,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant i32
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/transaction_result.rs
+++ b/src/generated/transaction_result.rs
@@ -49,7 +49,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/transaction_result_ext.rs
+++ b/src/generated/transaction_result_ext.rs
@@ -12,7 +12,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant i32
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/transaction_result_meta.rs
+++ b/src/generated/transaction_result_meta.rs
@@ -14,7 +14,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/transaction_result_meta_v1.rs
+++ b/src/generated/transaction_result_meta_v1.rs
@@ -18,7 +18,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/transaction_result_pair.rs
+++ b/src/generated/transaction_result_pair.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/transaction_result_result.rs
+++ b/src/generated/transaction_result_result.rs
@@ -34,7 +34,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant TransactionResultCode
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/transaction_result_set.rs
+++ b/src/generated/transaction_result_set.rs
@@ -12,7 +12,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/transaction_set.rs
+++ b/src/generated/transaction_set.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/transaction_set_v1.rs
+++ b/src/generated/transaction_set_v1.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/transaction_signature_payload.rs
+++ b/src/generated/transaction_signature_payload.rs
@@ -21,7 +21,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/transaction_signature_payload_tagged_transaction.rs
+++ b/src/generated/transaction_signature_payload_tagged_transaction.rs
@@ -15,7 +15,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant EnvelopeType
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/transaction_v0.rs
+++ b/src/generated/transaction_v0.rs
@@ -23,7 +23,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/transaction_v0_envelope.rs
+++ b/src/generated/transaction_v0_envelope.rs
@@ -15,7 +15,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/transaction_v0_ext.rs
+++ b/src/generated/transaction_v0_ext.rs
@@ -12,7 +12,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant i32
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/transaction_v1_envelope.rs
+++ b/src/generated/transaction_v1_envelope.rs
@@ -15,7 +15,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/trust_line_asset.rs
+++ b/src/generated/trust_line_asset.rs
@@ -23,7 +23,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant AssetType
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/trust_line_entry.rs
+++ b/src/generated/trust_line_entry.rs
@@ -40,7 +40,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/trust_line_entry_ext.rs
+++ b/src/generated/trust_line_entry_ext.rs
@@ -26,7 +26,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant i32
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/trust_line_entry_extension_v2.rs
+++ b/src/generated/trust_line_entry_extension_v2.rs
@@ -19,7 +19,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/trust_line_entry_extension_v2_ext.rs
+++ b/src/generated/trust_line_entry_extension_v2_ext.rs
@@ -12,7 +12,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant i32
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/trust_line_entry_v1.rs
+++ b/src/generated/trust_line_entry_v1.rs
@@ -21,7 +21,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/trust_line_entry_v1_ext.rs
+++ b/src/generated/trust_line_entry_v1_ext.rs
@@ -14,7 +14,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant i32
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/ttl_entry.rs
+++ b/src/generated/ttl_entry.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/tx_advert_vector.rs
+++ b/src/generated/tx_advert_vector.rs
@@ -7,7 +7,7 @@ use super::*;
 /// typedef Hash TxAdvertVector<TX_ADVERT_VECTOR_MAX_SIZE>;
 /// ```
 ///
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Default, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/tx_demand_vector.rs
+++ b/src/generated/tx_demand_vector.rs
@@ -7,7 +7,7 @@ use super::*;
 /// typedef Hash TxDemandVector<TX_DEMAND_VECTOR_MAX_SIZE>;
 /// ```
 ///
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Default, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/tx_set_component.rs
+++ b/src/generated/tx_set_component.rs
@@ -16,7 +16,7 @@ use super::*;
 /// ```
 ///
 // union with discriminant TxSetComponentType
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/tx_set_component_txs_maybe_discounted_fee.rs
+++ b/src/generated/tx_set_component_txs_maybe_discounted_fee.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/u_int128_parts.rs
+++ b/src/generated/u_int128_parts.rs
@@ -12,7 +12,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/u_int256_parts.rs
+++ b/src/generated/u_int256_parts.rs
@@ -14,7 +14,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/uint256.rs
+++ b/src/generated/uint256.rs
@@ -7,7 +7,7 @@ use super::*;
 /// typedef opaque uint256[32];
 /// ```
 ///
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]

--- a/src/generated/upgrade_entry_meta.rs
+++ b/src/generated/upgrade_entry_meta.rs
@@ -13,7 +13,7 @@ use super::*;
 ///
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/src/generated/upgrade_type.rs
+++ b/src/generated/upgrade_type.rs
@@ -7,7 +7,7 @@ use super::*;
 /// typedef opaque UpgradeType<128>;
 /// ```
 ///
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Default, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/src/generated/value.rs
+++ b/src/generated/value.rs
@@ -7,7 +7,7 @@ use super::*;
 /// typedef opaque Value<>;
 /// ```
 ///
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Default, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(

--- a/xdr-generator-rust/generator/src/tests/generator.rs
+++ b/xdr-generator-rust/generator/src/tests/generator.rs
@@ -37,7 +37,7 @@ fn test_ifdef_generates_cfg_on_struct() {
         r#"#[cfg(feature = "feature_x")]
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
@@ -76,7 +76,7 @@ fn test_ifdef_else_generates_both_cfgs() {
         r#"#[cfg(feature = "feature_x")]
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
@@ -92,7 +92,7 @@ pub struct Foo {"#,
         r#"#[cfg(not(feature = "feature_x"))]
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
@@ -121,7 +121,7 @@ fn test_ifdef_same_name_both_branches() {
         r#"#[cfg(feature = "feature_x")]
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),
@@ -139,7 +139,7 @@ pub struct Foo {
         r#"#[cfg(not(feature = "feature_x"))]
 #[cfg_attr(feature = "alloc", derive(Default))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(
     all(feature = "serde", feature = "alloc"),

--- a/xdr-generator-rust/generator/templates/struct.rs.jinja
+++ b/xdr-generator-rust/generator/templates/struct.rs.jinja
@@ -6,7 +6,7 @@
 #[cfg_attr(feature = "alloc", derive(Default))]
 {%- endif %}
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 {%- if s.is_custom_str %}
 #[cfg_attr(

--- a/xdr-generator-rust/generator/templates/typedef_newtype.rs.jinja
+++ b/xdr-generator-rust/generator/templates/typedef_newtype.rs.jinja
@@ -2,7 +2,7 @@
 {%- if let Some(cfg) = t.cfg %}
 #[cfg({{ cfg }})]
 {%- endif %}
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 {%- if t.has_default && !t.is_var_array %}
 #[cfg_attr(feature = "alloc", derive(Default))]
 {%- endif %}

--- a/xdr-generator-rust/generator/templates/union.rs.jinja
+++ b/xdr-generator-rust/generator/templates/union.rs.jinja
@@ -3,7 +3,7 @@
 {%- if let Some(cfg) = u.cfg %}
 #[cfg({{ cfg }})]
 {%- endif %}
-#[cfg_eval::cfg_eval]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 {%- if u.is_custom_str %}


### PR DESCRIPTION
### What
Make `cfg_eval` an optional dependency, pulled in only when the `serde` feature is enabled. Replace the unconditional `#[cfg_eval::cfg_eval]` attribute on all generated XDR types with `#[cfg_attr(feature = "serde", cfg_eval::cfg_eval)]`.

### Why
`cfg_eval` is only required to expand `#[cfg_attr(feature = "serde", ...)]` attributes used inside structs and enums that have `derive` attributes on them. Requiring it unconditionally adds a dependency on crates that don't use serde.