### PR TITLE
Update dependency `ethnum` to `1.5.3`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,9 +335,9 @@ checksum = "2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2"
 
 [[package]]
 name = "ethnum"
-version = "1.5.1"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0939f82868b77ef93ce3c3c3daf2b3c526b456741da5a1a4559e590965b6026b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "fnv"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ clap = { version = "4.2.4", default-features = false, features = ["std", "derive
 serde_json = { version = "1.0.89", optional = true }
 thiserror = { version = "1.0.37", optional = true }
 schemars = { version = "0.8.16", optional = true }
-ethnum = { version = "1.5.0", optional = true }
+ethnum = { version = "1.5.3", optional = true }
 rand = { version = "0.9.0", optional = true }
 sha2 = { version = "0.10.9", optional = true }
 


### PR DESCRIPTION
### What

Update dependency `ethnum` to `1.5.3`

### Why

This includes a fix for new compiler errors introduce in nightly-2026-04-18. https://github.com/nlordell/ethnum-rs/pull/58

### Known limitations

None
