### PR TITLE
generator-definitions-json: make --feature always filter

### DIFF
--- a/xdr-definitions-json/xdr.json
+++ b/xdr-definitions-json/xdr.json
@@ -6807,10 +6807,6 @@
         {
           "name": "ENVELOPE_TYPE_SOROBAN_AUTHORIZATION",
           "value": 9
-        },
-        {
-          "name": "ENVELOPE_TYPE_SOROBAN_AUTHORIZATION_WITH_ADDRESS",
-          "value": 10
         }
       ]
     },
@@ -12306,65 +12302,6 @@
       ]
     },
     {
-      "kind": "struct",
-      "name": "SorobanDelegateSignature",
-      "fixed_size": null,
-      "source": "struct SorobanDelegateSignature {\n    SCAddress address;\n    SCVal signature;\n    SorobanDelegateSignature nestedDelegates<>;\n};",
-      "file_index": 11,
-      "fields": [
-        {
-          "name": "address",
-          "type": {
-            "kind": "ref",
-            "name": "SCAddress"
-          }
-        },
-        {
-          "name": "signature",
-          "type": {
-            "kind": "ref",
-            "name": "SCVal"
-          }
-        },
-        {
-          "name": "nestedDelegates",
-          "type": {
-            "kind": "var_array",
-            "element": {
-              "kind": "ref",
-              "name": "SorobanDelegateSignature"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "kind": "struct",
-      "name": "SorobanAddressCredentialsWithDelegates",
-      "fixed_size": null,
-      "source": "struct SorobanAddressCredentialsWithDelegates\n{\n    SorobanAddressCredentials addressCredentials;\n    SorobanDelegateSignature delegates<>;\n};",
-      "file_index": 11,
-      "fields": [
-        {
-          "name": "addressCredentials",
-          "type": {
-            "kind": "ref",
-            "name": "SorobanAddressCredentials"
-          }
-        },
-        {
-          "name": "delegates",
-          "type": {
-            "kind": "var_array",
-            "element": {
-              "kind": "ref",
-              "name": "SorobanDelegateSignature"
-            }
-          }
-        }
-      ]
-    },
-    {
       "kind": "enum",
       "name": "SorobanCredentialsType",
       "source": "enum SorobanCredentialsType\n{\n    SOROBAN_CREDENTIALS_SOURCE_ACCOUNT = 0,\n    SOROBAN_CREDENTIALS_ADDRESS = 1\n#ifdef CAP_0071\n    ,\n    SOROBAN_CREDENTIALS_ADDRESS_WITH_DELEGATES = 2\n#endif\n};",
@@ -12378,10 +12315,6 @@
         {
           "name": "SOROBAN_CREDENTIALS_ADDRESS",
           "value": 1
-        },
-        {
-          "name": "SOROBAN_CREDENTIALS_ADDRESS_WITH_DELEGATES",
-          "value": 2
         }
       ]
     },
@@ -12419,19 +12352,6 @@
           "type": {
             "kind": "ref",
             "name": "SorobanAddressCredentials"
-          }
-        },
-        {
-          "cases": [
-            {
-              "value": 2,
-              "name": "SOROBAN_CREDENTIALS_ADDRESS_WITH_DELEGATES"
-            }
-          ],
-          "name": "addressWithDelegates",
-          "type": {
-            "kind": "ref",
-            "name": "SorobanAddressCredentialsWithDelegates"
           }
         }
       ]
@@ -13057,50 +12977,6 @@
       ]
     },
     {
-      "kind": "struct",
-      "name": "HashIDPreimageSorobanAuthorizationWithAddress",
-      "fixed_size": null,
-      "source": "struct\n    {\n        Hash networkID;\n        int64 nonce;\n        uint32 signatureExpirationLedger;\n        SCAddress address;\n        SorobanAuthorizedInvocation invocation;\n    }",
-      "file_index": 11,
-      "fields": [
-        {
-          "name": "networkID",
-          "type": {
-            "kind": "ref",
-            "name": "Hash"
-          }
-        },
-        {
-          "name": "nonce",
-          "type": {
-            "kind": "ref",
-            "name": "int64"
-          }
-        },
-        {
-          "name": "signatureExpirationLedger",
-          "type": {
-            "kind": "ref",
-            "name": "uint32"
-          }
-        },
-        {
-          "name": "address",
-          "type": {
-            "kind": "ref",
-            "name": "SCAddress"
-          }
-        },
-        {
-          "name": "invocation",
-          "type": {
-            "kind": "ref",
-            "name": "SorobanAuthorizedInvocation"
-          }
-        }
-      ]
-    },
-    {
       "kind": "union",
       "name": "HashIDPreimage",
       "fixed_size": null,
@@ -13164,19 +13040,6 @@
           "type": {
             "kind": "ref",
             "name": "HashIDPreimageSorobanAuthorization"
-          }
-        },
-        {
-          "cases": [
-            {
-              "value": 10,
-              "name": "ENVELOPE_TYPE_SOROBAN_AUTHORIZATION_WITH_ADDRESS"
-            }
-          ],
-          "name": "sorobanAuthorizationWithAddress",
-          "type": {
-            "kind": "ref",
-            "name": "HashIDPreimageSorobanAuthorizationWithAddress"
           }
         }
       ]
@@ -18394,22 +18257,6 @@
           "type": {
             "kind": "ref",
             "name": "Hash"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "struct",
-      "name": "TestNextType",
-      "fixed_size": 4,
-      "source": "struct TestNextType\n{\n    int32 value;\n};",
-      "file_index": 12,
-      "fields": [
-        {
-          "name": "value",
-          "type": {
-            "kind": "ref",
-            "name": "int32"
           }
         }
       ]

--- a/xdr-generator-rust/generator-definitions-json/src/main.rs
+++ b/xdr-generator-rust/generator-definitions-json/src/main.rs
@@ -24,9 +24,14 @@ struct Args {
     #[arg(short, long, required = true)]
     output: PathBuf,
 
-    /// Features to enable for cfg resolution.
-    /// When specified, cfg expressions are evaluated and filtered before emission.
-    /// Without this flag, all definitions are included with cfg annotations intact.
+    /// Feature set for cfg resolution. Items whose cfg evaluates to true
+    /// under this feature set are kept; others are dropped. Accepts
+    /// comma-separated values or may be repeated (e.g. --feature curr,next
+    /// or --feature curr --feature next).
+    ///
+    /// By default the feature set is empty: items gated on any feature are
+    /// dropped (`not(feature = "X")` still evaluates to true with an empty
+    /// set and is kept).
     #[arg(long, value_delimiter = ',')]
     feature: Vec<String>,
 }
@@ -51,13 +56,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Parse the XDR files
     let mut spec = xdr_parser::parser::parse_files(&file_refs)?;
 
-    let resolved_features: Vec<String> = args.feature.iter()
-        .map(|f| f.to_lowercase())
-        .collect();
-    if !resolved_features.is_empty() {
-        let features: HashSet<String> = resolved_features.iter().cloned().collect();
-        filter_spec(&mut spec, &features);
-    }
+    let features: HashSet<String> = args.feature.iter().map(|f| f.to_lowercase()).collect();
+    let mut resolved_features: Vec<String> = features.iter().cloned().collect();
+    resolved_features.sort();
+    filter_spec(&mut spec, &features);
 
     let output = ir::build(&spec, resolved_features);
     let json = serde_json::to_string_pretty(&output)?;
@@ -72,7 +74,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 /// Filter an XDR spec in-place: remove definitions and sub-elements whose cfg
-/// evaluates to false, then clear all remaining cfg annotations.
+/// evaluates to false under the given feature set, then clear all remaining
+/// cfg annotations.
 fn filter_spec(spec: &mut XdrSpec, features: &HashSet<String>) {
     filter_definitions(&mut spec.definitions, features);
     for ns in &mut spec.namespaces {

--- a/xdr-generator-rust/generator-definitions-json/src/tests/cfg_filter.rs
+++ b/xdr-generator-rust/generator-definitions-json/src/tests/cfg_filter.rs
@@ -3,7 +3,7 @@ use xdr_parser::ast::{CfgExpr, Definition, XdrSpec};
 
 use crate::filter_spec;
 
-fn features(names: &[&str]) -> HashSet<String> {
+fn feature_set(names: &[&str]) -> HashSet<String> {
     names.iter().map(|s| s.to_lowercase()).collect()
 }
 
@@ -18,26 +18,26 @@ fn parse(input: &str) -> XdrSpec {
 #[test]
 fn test_evaluate_cfg_feature_present() {
     let expr = CfgExpr::Feature("NEXT".to_string());
-    assert!(expr.evaluate(&features(&["next"])));
+    assert!(expr.evaluate(&feature_set(&["next"])));
 }
 
 #[test]
 fn test_evaluate_cfg_feature_absent() {
     let expr = CfgExpr::Feature("NEXT".to_string());
-    assert!(!expr.evaluate(&features(&["other"])));
+    assert!(!expr.evaluate(&feature_set(&["other"])));
 }
 
 #[test]
 fn test_evaluate_cfg_feature_case_insensitive() {
     let expr = CfgExpr::Feature("Next".to_string());
-    assert!(expr.evaluate(&features(&["NEXT"])));
+    assert!(expr.evaluate(&feature_set(&["NEXT"])));
 }
 
 #[test]
 fn test_evaluate_cfg_not() {
     let expr = CfgExpr::Not(Box::new(CfgExpr::Feature("NEXT".to_string())));
-    assert!(expr.evaluate(&features(&["other"])));
-    assert!(!expr.evaluate(&features(&["next"])));
+    assert!(expr.evaluate(&feature_set(&["other"])));
+    assert!(!expr.evaluate(&feature_set(&["next"])));
 }
 
 #[test]
@@ -46,15 +46,15 @@ fn test_evaluate_cfg_all() {
         CfgExpr::Feature("A".to_string()),
         CfgExpr::Feature("B".to_string()),
     ]);
-    assert!(expr.evaluate(&features(&["a", "b"])));
-    assert!(!expr.evaluate(&features(&["a"])));
-    assert!(!expr.evaluate(&features(&["b"])));
+    assert!(expr.evaluate(&feature_set(&["a", "b"])));
+    assert!(!expr.evaluate(&feature_set(&["a"])));
+    assert!(!expr.evaluate(&feature_set(&["b"])));
 }
 
 #[test]
 fn test_evaluate_cfg_empty_features() {
     let expr = CfgExpr::Feature("X".to_string());
-    assert!(!expr.evaluate(&features(&[])));
+    assert!(!expr.evaluate(&feature_set(&[])));
 }
 
 // =============================================================================
@@ -77,8 +77,47 @@ fn test_def_cfg_evaluates_correctly() {
     "#,
     );
     let cfg = spec.definitions[0].cfg().unwrap();
-    assert!(cfg.evaluate(&features(&["next"])));
-    assert!(!cfg.evaluate(&features(&["other"])));
+    assert!(cfg.evaluate(&feature_set(&["next"])));
+    assert!(!cfg.evaluate(&feature_set(&["other"])));
+}
+
+// =============================================================================
+// filter_spec — default (empty feature set drops all ifdef'd definitions)
+// =============================================================================
+
+#[test]
+fn test_filter_spec_default_drops_all_gated_definitions() {
+    let mut spec = parse(
+        r#"
+        struct Always { int x; };
+        #ifdef NEXT
+        struct OnlyNext { int y; };
+        #endif
+    "#,
+    );
+    filter_spec(&mut spec, &feature_set(&[]));
+    let names: Vec<&str> = spec.definitions.iter().map(|d| d.name()).collect();
+    assert_eq!(names, vec!["Always"]);
+}
+
+#[test]
+fn test_filter_spec_default_drops_gated_union_arms() {
+    let mut spec = parse(
+        r#"
+        union U switch (int v) {
+            case 0: int a;
+            #ifdef NEXT
+            case 1: int b;
+            #endif
+        };
+    "#,
+    );
+    filter_spec(&mut spec, &feature_set(&[]));
+    let u = match &spec.definitions[0] {
+        Definition::Union(u) => u,
+        _ => panic!("expected Union"),
+    };
+    assert_eq!(u.arms.len(), 1);
 }
 
 // =============================================================================
@@ -95,7 +134,7 @@ fn test_filter_spec_removes_gated_definitions() {
         #endif
     "#,
     );
-    filter_spec(&mut spec, &features(&["other"]));
+    filter_spec(&mut spec, &feature_set(&["other"]));
     let names: Vec<&str> = spec.definitions.iter().map(|d| d.name()).collect();
     assert_eq!(names, vec!["Always"]);
 }
@@ -110,7 +149,7 @@ fn test_filter_spec_keeps_matching_definitions() {
         #endif
     "#,
     );
-    filter_spec(&mut spec, &features(&["next"]));
+    filter_spec(&mut spec, &feature_set(&["next"]));
     let names: Vec<&str> = spec.definitions.iter().map(|d| d.name()).collect();
     assert_eq!(names, vec!["Always", "OnlyNext"]);
 }
@@ -124,7 +163,7 @@ fn test_filter_spec_clears_cfg_on_surviving_definitions() {
         #endif
     "#,
     );
-    filter_spec(&mut spec, &features(&["next"]));
+    filter_spec(&mut spec, &feature_set(&["next"]));
     assert!(spec.definitions[0].cfg().is_none());
 }
 
@@ -154,7 +193,7 @@ fn test_filter_spec_removes_gated_union_arms() {
         };
     "#,
     );
-    filter_spec(&mut spec, &features(&["other"]));
+    filter_spec(&mut spec, &feature_set(&["other"]));
     let u = match &spec.definitions[1] {
         Definition::Union(u) => u,
         _ => panic!("expected Union"),
@@ -183,7 +222,7 @@ fn test_filter_spec_keeps_matching_union_arms() {
         };
     "#,
     );
-    filter_spec(&mut spec, &features(&["next"]));
+    filter_spec(&mut spec, &feature_set(&["next"]));
     let u = match &spec.definitions[1] {
         Definition::Union(u) => u,
         _ => panic!("expected Union"),
@@ -210,7 +249,7 @@ fn test_filter_spec_removes_gated_enum_members() {
         };
     "#,
     );
-    filter_spec(&mut spec, &features(&["other"]));
+    filter_spec(&mut spec, &feature_set(&["other"]));
     let e = match &spec.definitions[0] {
         Definition::Enum(e) => e,
         _ => panic!("expected Enum"),
@@ -235,7 +274,7 @@ fn test_filter_spec_ifdef_else_keeps_correct_branch() {
         #endif
     "#,
     );
-    filter_spec(&mut spec, &features(&["next"]));
+    filter_spec(&mut spec, &feature_set(&["next"]));
     let names: Vec<&str> = spec.definitions.iter().map(|d| d.name()).collect();
     assert_eq!(names, vec!["Foo"]);
     if let Definition::Struct(s) = &spec.definitions[0] {
@@ -256,7 +295,7 @@ fn test_filter_spec_ifdef_else_keeps_else_branch() {
         #endif
     "#,
     );
-    filter_spec(&mut spec, &features(&["other"]));
+    filter_spec(&mut spec, &feature_set(&["other"]));
     let names: Vec<&str> = spec.definitions.iter().map(|d| d.name()).collect();
     assert_eq!(names, vec!["Foo"]);
     if let Definition::Struct(s) = &spec.definitions[0] {


### PR DESCRIPTION
Fixes the `--feature` flag behavior in `generator-definitions-json` — the binary at `xdr-generator-rust/generator-definitions-json/` that parses `.x` files and emits a JSON AST for downstream code generators. It is invoked by the `make xdr-definitions-json` target to produce the committed snapshot at `xdr-definitions-json/xdr.json`.

### Context

Given an `.x` file like:

```c
struct AccountEntry { ... };     // unconditional

#ifdef CAP_0071
struct NewType { ... };          // gated on cap_0071
#endif
```

### Before this PR

| `generator-definitions-json` invocation | `AccountEntry` | `NewType` |
|-----------------------------------------|----------------|-----------|
| (no flag)                               | kept           | **kept**  |
| `--feature cap_0071`                    | kept           | kept      |

There was no way to get `AccountEntry` *without* `NewType` — no way to express a baseline schema that excludes speculative CAP-gated fields.

### After this PR

| `generator-definitions-json` invocation | `AccountEntry` | `NewType`    |
|-----------------------------------------|----------------|--------------|
| (no flag)                               | kept           | **dropped**  |
| `--feature cap_0071`                    | kept           | kept         |

No flag now means "empty feature set" — `#ifdef X` definitions drop because `X` isn't in the set, unconditional definitions stay. `--feature X,Y` opts into specific CAPs.

### Snapshot

The committed `xdr-definitions-json/xdr.json` regenerates to baseline (no speculative CAPs). This matches `xdr-json/`, which is generated with Cargo's default features and also excludes them.
