### PR TITLE
Document version support policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,20 @@ using the Rust XDR generator in `xdr-generator-rust/`.
 
 [stellar/stellar-xdr]: https://github.com/stellar/stellar-xdr
 
+## Support
+
+Bug and security fixes are provided for:
+
+- The latest major version.
+- The latest major version in use by the Stellar network's current protocol.
+
+In practice that means only the latest major version, or, if the latest major
+version has not yet been adopted by the Stellar network, the major version
+prior.
+
+All other major versions are unsupported and do not receive bug or security
+fixes.
+
 ## Usage
 
 ### Library

--- a/README.md
+++ b/README.md
@@ -10,17 +10,9 @@ using the Rust XDR generator in `xdr-generator-rust/`.
 
 ## Support
 
-Bug and security fixes are provided for:
-
-- The latest major version.
-- The latest major version in use by the Stellar network's current protocol.
-
-In practice that means only the latest major version, or, if the latest major
-version has not yet been adopted by the Stellar network, the major version
-prior.
-
-All other major versions are unsupported and do not receive bug or security
-fixes.
+The most recent stellar-xdr major release is supported with critical security fixes.
+Critical security issues may be backported to earlier versions if practical, but not guaranteed.
+General bugs are only fixed on, and new features are only added to, the latest major release.
 
 ## Usage
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,20 @@
 //!
 //! [stellar/stellar-xdr]: https://github.com/stellar/stellar-xdr
 //!
+//! ## Support
+//!
+//! Bug and security fixes are provided for:
+//!
+//! - The latest major version.
+//! - The latest major version in use by the Stellar network's current protocol.
+//!
+//! In practice that means only the latest major version, or, if the latest major
+//! version has not yet been adopted by the Stellar network, the major version
+//! prior.
+//!
+//! All other major versions are unsupported and do not receive bug or security
+//! fixes.
+//!
 //! ## Usage
 //!
 //! ### Library

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //!
 //! ## Support
 //!
-//! The two most recent stellar-xdr major releases are supported with critical security fixes.
+//! The most recent stellar-xdr major release is supported with critical security fixes.
 //! Critical security issues may be backported to earlier versions if practical, but not guaranteed.
 //! General bugs are only fixed on, and new features are only added to, the latest major release.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,17 +18,9 @@
 //!
 //! ## Support
 //!
-//! Bug and security fixes are provided for:
-//!
-//! - The latest major version.
-//! - The latest major version in use by the Stellar network's current protocol.
-//!
-//! In practice that means only the latest major version, or, if the latest major
-//! version has not yet been adopted by the Stellar network, the major version
-//! prior.
-//!
-//! All other major versions are unsupported and do not receive bug or security
-//! fixes.
+//! The two most recent stellar-xdr major releases are supported with critical security fixes.
+//! Critical security issues may be backported to earlier versions if practical, but not guaranteed.
+//! General bugs are only fixed on, and new features are only added to, the latest major release.
 //!
 //! ## Usage
 //!


### PR DESCRIPTION
### What
Add a Support section to the README and crate-level docs stating that bug and security fixes are provided only for the latest major version.

### Why
Set explicit expectations about which major versions receive backports, prompted by user questions (e.g. issue #529) about whether older release branches still receive security fixes.

Close #529