### PR TITLE
Print enabled xdr features in CLI version output

### DIFF
--- a/src/cli/version.rs
+++ b/src/cli/version.rs
@@ -9,6 +9,13 @@ pub struct Cmd;
 impl Cmd {
     pub fn run() {
         let v = VERSION;
-        println!("stellar-xdr {} ({})\nxdr: {}", v.pkg, v.rev, v.xdr);
+        let features = match v.features {
+            [] => "<none>".to_string(),
+            fs => fs.join(", "),
+        };
+        println!(
+            "stellar-xdr {} ({})\nxdr: {}\nfeatures: {}",
+            v.pkg, v.rev, v.xdr, features,
+        );
     }
 }


### PR DESCRIPTION
### What
Extend `stellar-xdr version` to print the list of enabled XDR feature flags alongside the xdr version, falling back to `<none>` when none are enabled.

### Why
The active feature set determines which XDR variants the binary supports, so surfacing it in `version` will make troubleshooting and bug reports more helpful.

Close #533