### PR TITLE
Patch in stellar-strkey from git main (0.0.17)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes-lit"
 version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,6 +374,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -378,6 +393,17 @@ name = "hashbrown"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+
+[[package]]
+name = "heapless"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ba4bd83f9415b58b4ed8dc5714c76e626a105be4646c02630ad730ad3b5aa4"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+ "zeroize",
+]
 
 [[package]]
 name = "heck"
@@ -714,13 +740,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "stellar-strkey"
-version = "0.0.13"
+name = "stable_deref_trait"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee1832fb50c651ad10f734aaf5d31ca5acdfb197a6ecda64d93fcdb8885af913"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stellar-strkey"
+version = "0.0.17"
+source = "git+https://github.com/stellar/rs-stellar-strkey?rev=d16561c672b950d7af05939817df19f3a1f63299#d16561c672b950d7af05939817df19f3a1f63299"
 dependencies = [
  "crate-git-revision",
  "data-encoding",
+ "heapless",
+ "zeroize",
 ]
 
 [[package]]
@@ -975,6 +1008,26 @@ name = "zerocopy-derive"
 version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ crate-git-revision = "0.0.6"
 
 [dependencies]
 cfg_eval = { version = "0.1.2", optional = true }
-stellar-strkey = { version = "0.0.13", optional = true }
+stellar-strkey = { version = "0.0.17", optional = true }
 base64 = { version = "0.22.1", optional = true }
 serde = { version = "1.0.139", features = ["derive"], optional = true }
 serde_with = { version = "3.12.0", features = ["schemars_0_8"], optional = true }
@@ -67,3 +67,6 @@ cli = ["std", "type_enum", "base64", "serde", "serde_json", "schemars", "arbitra
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docs"]
+
+[patch.crates-io]
+stellar-strkey = { git = "https://github.com/stellar/rs-stellar-strkey", rev = "d16561c672b950d7af05939817df19f3a1f63299" }

--- a/src/str.rs
+++ b/src/str.rs
@@ -160,8 +160,7 @@ impl core::str::FromStr for MuxedAccount {
                 ed25519: Uint256(ed25519),
                 id,
             })),
-            stellar_strkey::Strkey::PrivateKeyEd25519(_)
-            | stellar_strkey::Strkey::PreAuthTx(_)
+            stellar_strkey::Strkey::PreAuthTx(_)
             | stellar_strkey::Strkey::HashX(_)
             | stellar_strkey::Strkey::SignedPayloadEd25519(_)
             | stellar_strkey::Strkey::Contract(_)
@@ -204,10 +203,8 @@ impl core::fmt::Display for SignerKeyEd25519SignedPayload {
             ed25519: Uint256(ed25519),
             payload,
         } = self;
-        let k = stellar_strkey::ed25519::SignedPayload {
-            ed25519: *ed25519,
-            payload: payload.into(),
-        };
+        let k = stellar_strkey::ed25519::SignedPayload::new(*ed25519, payload.as_slice())
+            .map_err(|_| core::fmt::Error)?;
         let s = k.to_string();
         f.write_str(&s)?;
         Ok(())
@@ -217,11 +214,10 @@ impl core::fmt::Display for SignerKeyEd25519SignedPayload {
 impl core::str::FromStr for SignerKeyEd25519SignedPayload {
     type Err = Error;
     fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
-        let stellar_strkey::ed25519::SignedPayload { ed25519, payload } =
-            stellar_strkey::ed25519::SignedPayload::from_str(s)?;
+        let signed_payload = stellar_strkey::ed25519::SignedPayload::from_str(s)?;
         Ok(SignerKeyEd25519SignedPayload {
-            ed25519: Uint256(ed25519),
-            payload: payload.try_into()?,
+            ed25519: Uint256(*signed_payload.ed25519()),
+            payload: signed_payload.payload().try_into()?,
         })
     }
 }
@@ -240,16 +236,15 @@ impl core::str::FromStr for SignerKey {
             stellar_strkey::Strkey::HashX(stellar_strkey::HashX(h)) => {
                 Ok(SignerKey::HashX(Uint256(h)))
             }
-            stellar_strkey::Strkey::SignedPayloadEd25519(
-                stellar_strkey::ed25519::SignedPayload { ed25519, payload },
-            ) => Ok(SignerKey::Ed25519SignedPayload(
-                SignerKeyEd25519SignedPayload {
-                    ed25519: Uint256(ed25519),
-                    payload: payload.try_into()?,
-                },
-            )),
-            stellar_strkey::Strkey::PrivateKeyEd25519(_)
-            | stellar_strkey::Strkey::Contract(_)
+            stellar_strkey::Strkey::SignedPayloadEd25519(signed_payload) => {
+                Ok(SignerKey::Ed25519SignedPayload(
+                    SignerKeyEd25519SignedPayload {
+                        ed25519: Uint256(*signed_payload.ed25519()),
+                        payload: signed_payload.payload().try_into()?,
+                    },
+                ))
+            }
+            stellar_strkey::Strkey::Contract(_)
             | stellar_strkey::Strkey::MuxedAccountEd25519(_)
             | stellar_strkey::Strkey::LiquidityPool(_)
             | stellar_strkey::Strkey::ClaimableBalance(_) => Err(Error::Invalid),
@@ -332,8 +327,7 @@ impl core::str::FromStr for ScAddress {
             )) => Ok(ScAddress::ClaimableBalance(
                 ClaimableBalanceId::ClaimableBalanceIdTypeV0(Hash(claimable_balance)),
             )),
-            stellar_strkey::Strkey::PrivateKeyEd25519(_)
-            | stellar_strkey::Strkey::PreAuthTx(_)
+            stellar_strkey::Strkey::PreAuthTx(_)
             | stellar_strkey::Strkey::HashX(_)
             | stellar_strkey::Strkey::SignedPayloadEd25519(_) => Err(Error::Invalid),
         }


### PR DESCRIPTION
Patches `stellar-strkey` to its latest git `main` commit so we can validate it before releasing the new `stellar-strkey`.

## Changes

**`Cargo.toml`**
- Add `[patch.crates-io]` pointing `stellar-strkey` at git `main` rev `d16561c672b950d7af05939817df19f3a1f63299`.
- Bump the version requirement `0.0.13` → `0.0.17` (required, since `main` is at `0.0.17` and `0.0.x` releases are semver-incompatible, so the patch wouldn't otherwise apply).

**`src/str.rs`** — adapt to breaking API changes on `main`:
1. `Strkey::PrivateKeyEd25519` was removed (private keys are no longer routed through the general `Strkey` enum). Dropped that variant from the three match arms that treated it as invalid — behavior is unchanged since `S…` strkeys are now rejected earlier by the decoder itself.
2. `ed25519::SignedPayload` fields are now private and `payload` changed from `Vec<u8>` to `heapless::Vec<u8, 64>`. Switched to the new public API: construct via `SignedPayload::new(ed25519, payload)` and read via the `.ed25519()` / `.payload()` accessors.

The `From<stellar_strkey::DecodeError>` impl still compiles despite the new structured `DecodeError` variants, since it ignores the inner value.

## Verification
- `cargo build --features alloc` ✅
- `cargo build --all-features` ✅
- `cargo test --all-features` ✅ — all pass, 0 failures. `tests/str.rs` (50 tests) directly exercises every touched path: signed-payload encode/decode, signer keys, muxed accounts, SC addresses.
- `cargo clippy --all-features` exits 0 (the remaining warnings are pre-existing `derivable_impls` in `src/cli/*`, unrelated to this change).

## Note
This is a temporary validation patch. Once the new `stellar-strkey` is published to crates.io, the `[patch.crates-io]` block should be removed (keeping the `0.0.17` version bump).

https://claude.ai/code/session_012stz989VHZBKY3qM9xtzAy