### PR TITLE
Update crate-git-revision to 0.0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,6 +190,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "crate-git-revision"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54851b5b3f24621804b1cded2820975623c205e3055d2d44031cdb1237339ac8"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -719,7 +730,7 @@ version = "0.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee1832fb50c651ad10f734aaf5d31ca5acdfb197a6ecda64d93fcdb8885af913"
 dependencies = [
- "crate-git-revision",
+ "crate-git-revision 0.0.6",
  "data-encoding",
 ]
 
@@ -732,7 +743,7 @@ dependencies = [
  "bytes-lit",
  "cfg_eval",
  "clap",
- "crate-git-revision",
+ "crate-git-revision 0.0.9",
  "escape-bytes",
  "ethnum",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ required-features = ["cli"]
 doctest = false
 
 [build-dependencies]
-crate-git-revision = "0.0.6"
+crate-git-revision = "0.0.9"
 
 [dependencies]
 cfg_eval = { version = "0.1.2", optional = true }


### PR DESCRIPTION
### What

Bump the `crate-git-revision` build dependency from 0.0.6 to 0.0.9.

### Why

Keeps the build-time git revision tooling current with upstream releases. The transitive `crate-git-revision` requirement from `stellar-strkey` still resolves to 0.0.6, so the lockfile now carries both versions side by side until that dependency is updated upstream.

### Known limitations

N/A