### PR TITLE
Update stellar-strkey to 0.0.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes-lit"
 version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,6 +374,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -378,6 +393,16 @@ name = "hashbrown"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "heck"
@@ -714,13 +739,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "stellar-strkey"
-version = "0.0.13"
+name = "stable_deref_trait"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee1832fb50c651ad10f734aaf5d31ca5acdfb197a6ecda64d93fcdb8885af913"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stellar-strkey"
+version = "0.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "084afcb0d458c3d5d5baa2d294b18f881e62cc258ef539d8fdf68be7dbe45520"
 dependencies = [
  "crate-git-revision",
  "data-encoding",
+ "heapless",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ crate-git-revision = "0.0.6"
 
 [dependencies]
 cfg_eval = { version = "0.1.2", optional = true }
-stellar-strkey = { version = "0.0.13", optional = true }
+stellar-strkey = { version = "0.0.16", optional = true }
 base64 = { version = "0.22.1", optional = true }
 serde = { version = "1.0.139", features = ["derive"], optional = true }
 serde_with = { version = "3.12.0", features = ["schemars_0_8"], optional = true }

--- a/src/str.rs
+++ b/src/str.rs
@@ -206,7 +206,10 @@ impl core::fmt::Display for SignerKeyEd25519SignedPayload {
         } = self;
         let k = stellar_strkey::ed25519::SignedPayload {
             ed25519: *ed25519,
-            payload: payload.into(),
+            payload: payload
+                .as_slice()
+                .try_into()
+                .map_err(|_| core::fmt::Error)?,
         };
         let s = k.to_string();
         f.write_str(&s)?;
@@ -221,7 +224,7 @@ impl core::str::FromStr for SignerKeyEd25519SignedPayload {
             stellar_strkey::ed25519::SignedPayload::from_str(s)?;
         Ok(SignerKeyEd25519SignedPayload {
             ed25519: Uint256(ed25519),
-            payload: payload.try_into()?,
+            payload: payload.as_slice().try_into()?,
         })
     }
 }
@@ -245,7 +248,7 @@ impl core::str::FromStr for SignerKey {
             ) => Ok(SignerKey::Ed25519SignedPayload(
                 SignerKeyEd25519SignedPayload {
                     ed25519: Uint256(ed25519),
-                    payload: payload.try_into()?,
+                    payload: payload.as_slice().try_into()?,
                 },
             )),
             stellar_strkey::Strkey::PrivateKeyEd25519(_)

--- a/src/str.rs
+++ b/src/str.rs
@@ -209,7 +209,7 @@ impl core::fmt::Display for SignerKeyEd25519SignedPayload {
             payload: payload
                 .as_slice()
                 .try_into()
-                .map_err(|_| core::fmt::Error)?,
+                .map_err(|()| core::fmt::Error)?,
         };
         let s = k.to_string();
         f.write_str(&s)?;


### PR DESCRIPTION
> ⚠️ This change targets versions of software that will ship for **protocol 28**. Do not merge if this repository is not yet ready to accept v28 changes.

### What

Bump the optional `stellar-strkey` dependency from 0.0.13 to 0.0.16, updating Cargo.lock to match.

### Why

The 0.0.16 release of stellar-strkey is part of the software set shipping for Stellar protocol 28, and rs-stellar-xdr needs to track it so downstream consumers building for v28 resolve a consistent, current strkey implementation.

### Known limitations

N/A