### PR TITLE
Update stellar-strkey to 0.0.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -758,9 +758,8 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stellar-strkey"
-version = "0.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0247b168bdee20244445e3d9cdea697dde6211e88742dd04acfd1b498661e936"
+version = "0.0.18"
+source = "git+https://github.com/stellar/rs-stellar-strkey?rev=73bf43778a4acad5e7b3589f54a5ec3607c4b7b1#73bf43778a4acad5e7b3589f54a5ec3607c4b7b1"
 dependencies = [
  "crate-git-revision 0.0.9",
  "data-encoding",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes-lit"
 version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -183,6 +189,17 @@ name = "crate-git-revision"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c521bf1f43d31ed2f73441775ed31935d77901cb3451e44b38a1c1612fcbaf98"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
+name = "crate-git-revision"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54851b5b3f24621804b1cded2820975623c205e3055d2d44031cdb1237339ac8"
 dependencies = [
  "serde",
  "serde_derive",
@@ -368,6 +385,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -378,6 +404,17 @@ name = "hashbrown"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+
+[[package]]
+name = "heapless"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ba4bd83f9415b58b4ed8dc5714c76e626a105be4646c02630ad730ad3b5aa4"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+ "zeroize",
+]
 
 [[package]]
 name = "heck"
@@ -714,13 +751,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "stellar-strkey"
-version = "0.0.13"
+name = "stable_deref_trait"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee1832fb50c651ad10f734aaf5d31ca5acdfb197a6ecda64d93fcdb8885af913"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stellar-strkey"
+version = "0.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0247b168bdee20244445e3d9cdea697dde6211e88742dd04acfd1b498661e936"
 dependencies = [
- "crate-git-revision",
+ "crate-git-revision 0.0.9",
  "data-encoding",
+ "heapless",
+ "zeroize",
 ]
 
 [[package]]
@@ -732,7 +777,7 @@ dependencies = [
  "bytes-lit",
  "cfg_eval",
  "clap",
- "crate-git-revision",
+ "crate-git-revision 0.0.6",
  "escape-bytes",
  "ethnum",
  "hex",
@@ -975,6 +1020,26 @@ name = "zerocopy-derive"
 version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -759,7 +759,8 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "stellar-strkey"
 version = "0.0.18"
-source = "git+https://github.com/stellar/rs-stellar-strkey?rev=73bf43778a4acad5e7b3589f54a5ec3607c4b7b1#73bf43778a4acad5e7b3589f54a5ec3607c4b7b1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f34ff61c0ca6f1c2b4169e8d1633417bd9225f58b6175e4e317204565d16277"
 dependencies = [
  "crate-git-revision 0.0.9",
  "data-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Stellar Development Foundation <info@stellar.org>"]
 license = "Apache-2.0"
 version = "27.0.0"
 edition = "2021"
-rust-version = "1.84.0"
+rust-version = "1.87.0"
 
 [[bin]]
 name = "stellar-xdr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ crate-git-revision = "0.0.6"
 
 [dependencies]
 cfg_eval = { version = "0.1.2", optional = true }
-stellar-strkey = { version = "0.0.17", optional = true }
+stellar-strkey = { version = "0.0.18", optional = true }
 base64 = { version = "0.22.1", optional = true }
 serde = { version = "1.0.139", features = ["derive"], optional = true }
 serde_with = { version = "3.12.0", features = ["schemars_0_8"], optional = true }
@@ -66,3 +66,9 @@ cli = ["std", "type_enum", "base64", "serde", "serde_json", "schemars", "arbitra
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docs"]
+
+# Temporary: stellar-strkey 0.0.18 is not yet published to crates.io. Point at
+# the release/v0.0.18 branch so this PR can be validated against the actual
+# 0.0.18 code ahead of the release. Remove once 0.0.18 is published.
+[patch.crates-io]
+stellar-strkey = { git = "https://github.com/stellar/rs-stellar-strkey", rev = "73bf43778a4acad5e7b3589f54a5ec3607c4b7b1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ crate-git-revision = "0.0.6"
 
 [dependencies]
 cfg_eval = { version = "0.1.2", optional = true }
-stellar-strkey = { version = "0.0.13", optional = true }
+stellar-strkey = { version = "0.0.17", optional = true }
 base64 = { version = "0.22.1", optional = true }
 serde = { version = "1.0.139", features = ["derive"], optional = true }
 serde_with = { version = "3.12.0", features = ["schemars_0_8"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,9 +66,3 @@ cli = ["std", "type_enum", "base64", "serde", "serde_json", "schemars", "arbitra
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docs"]
-
-# Temporary: stellar-strkey 0.0.18 is not yet published to crates.io. Point at
-# the release/v0.0.18 branch so this PR can be validated against the actual
-# 0.0.18 code ahead of the release. Remove once 0.0.18 is published.
-[patch.crates-io]
-stellar-strkey = { git = "https://github.com/stellar/rs-stellar-strkey", rev = "73bf43778a4acad5e7b3589f54a5ec3607c4b7b1" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,6 @@
 #![allow(clippy::tabs_in_doc_comments)]
 #![allow(clippy::doc_markdown)]
 #![allow(clippy::doc_lazy_continuation)]
-// Pedantic lints raised by the newer clippy that ships with the bumped MSRV,
-// firing on the auto-generated code.
 #![allow(clippy::unnecessary_semicolon)]
 #![allow(clippy::non_std_lazy_statics)]
 #![allow(unused_attributes)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,10 @@
 #![allow(clippy::tabs_in_doc_comments)]
 #![allow(clippy::doc_markdown)]
 #![allow(clippy::doc_lazy_continuation)]
+// Pedantic lints raised by the newer clippy that ships with the bumped MSRV,
+// firing on the auto-generated code.
+#![allow(clippy::unnecessary_semicolon)]
+#![allow(clippy::non_std_lazy_statics)]
 #![allow(unused_attributes)]
 
 //! Library and CLI containing types and functionality for working with Stellar

--- a/src/str.rs
+++ b/src/str.rs
@@ -160,8 +160,7 @@ impl core::str::FromStr for MuxedAccount {
                 ed25519: Uint256(ed25519),
                 id,
             })),
-            stellar_strkey::Strkey::PrivateKeyEd25519(_)
-            | stellar_strkey::Strkey::PreAuthTx(_)
+            stellar_strkey::Strkey::PreAuthTx(_)
             | stellar_strkey::Strkey::HashX(_)
             | stellar_strkey::Strkey::SignedPayloadEd25519(_)
             | stellar_strkey::Strkey::Contract(_)
@@ -204,10 +203,8 @@ impl core::fmt::Display for SignerKeyEd25519SignedPayload {
             ed25519: Uint256(ed25519),
             payload,
         } = self;
-        let k = stellar_strkey::ed25519::SignedPayload {
-            ed25519: *ed25519,
-            payload: payload.into(),
-        };
+        let k = stellar_strkey::ed25519::SignedPayload::new(*ed25519, payload.as_ref())
+            .map_err(|_| core::fmt::Error)?;
         let s = k.to_string();
         f.write_str(&s)?;
         Ok(())
@@ -217,11 +214,10 @@ impl core::fmt::Display for SignerKeyEd25519SignedPayload {
 impl core::str::FromStr for SignerKeyEd25519SignedPayload {
     type Err = Error;
     fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
-        let stellar_strkey::ed25519::SignedPayload { ed25519, payload } =
-            stellar_strkey::ed25519::SignedPayload::from_str(s)?;
+        let sp = stellar_strkey::ed25519::SignedPayload::from_str(s)?;
         Ok(SignerKeyEd25519SignedPayload {
-            ed25519: Uint256(ed25519),
-            payload: payload.try_into()?,
+            ed25519: Uint256(*sp.ed25519()),
+            payload: sp.payload().try_into()?,
         })
     }
 }
@@ -240,16 +236,13 @@ impl core::str::FromStr for SignerKey {
             stellar_strkey::Strkey::HashX(stellar_strkey::HashX(h)) => {
                 Ok(SignerKey::HashX(Uint256(h)))
             }
-            stellar_strkey::Strkey::SignedPayloadEd25519(
-                stellar_strkey::ed25519::SignedPayload { ed25519, payload },
-            ) => Ok(SignerKey::Ed25519SignedPayload(
-                SignerKeyEd25519SignedPayload {
-                    ed25519: Uint256(ed25519),
-                    payload: payload.try_into()?,
-                },
-            )),
-            stellar_strkey::Strkey::PrivateKeyEd25519(_)
-            | stellar_strkey::Strkey::Contract(_)
+            stellar_strkey::Strkey::SignedPayloadEd25519(sp) => Ok(
+                SignerKey::Ed25519SignedPayload(SignerKeyEd25519SignedPayload {
+                    ed25519: Uint256(*sp.ed25519()),
+                    payload: sp.payload().try_into()?,
+                }),
+            ),
+            stellar_strkey::Strkey::Contract(_)
             | stellar_strkey::Strkey::MuxedAccountEd25519(_)
             | stellar_strkey::Strkey::LiquidityPool(_)
             | stellar_strkey::Strkey::ClaimableBalance(_) => Err(Error::Invalid),
@@ -332,8 +325,7 @@ impl core::str::FromStr for ScAddress {
             )) => Ok(ScAddress::ClaimableBalance(
                 ClaimableBalanceId::ClaimableBalanceIdTypeV0(Hash(claimable_balance)),
             )),
-            stellar_strkey::Strkey::PrivateKeyEd25519(_)
-            | stellar_strkey::Strkey::PreAuthTx(_)
+            stellar_strkey::Strkey::PreAuthTx(_)
             | stellar_strkey::Strkey::HashX(_)
             | stellar_strkey::Strkey::SignedPayloadEd25519(_) => Err(Error::Invalid),
         }


### PR DESCRIPTION
### What

Bump the `stellar-strkey` dependency from 0.0.13 to 0.0.18 and adapt the hand-written strkey usage in `src/str.rs` to the 0.0.17+ API.

### Why

0.0.18 is the stellar-strkey release line for protocol 28. The upgrade requires a few source changes because the API differs from 0.0.13: the `Strkey::PrivateKeyEd25519` variant was removed, and `ed25519::SignedPayload` now has private fields exposed via `new(ed25519, payload)`, `ed25519()`, and `payload()` accessors instead of public struct fields. `src/str.rs` was updated to construct and read `SignedPayload` through these accessors and to drop the removed `PrivateKeyEd25519` match arms. The lockfile was updated to pin 0.0.18.

This supersedes the earlier 0.0.17 bump: 0.0.17 contained a CLI bug (`Decoded<Strkey>` rejected owned JSON keys, breaking `strkey encode`), fixed in 0.0.18 by stellar/rs-stellar-strkey#125.

### Known limitations

N/A

---

## Protocol 28 coordination

⚠️ This change targets versions of software that will ship for **Protocol 28**, and should **not** be merged unless this repository is ready to accept Protocol 28 changes.

This is one of a coordinated set of PRs bumping `stellar-strkey` to **0.0.18** across the Protocol 28 component stack. It is preferred that all Protocol 28 releases of these components depend on the **same** version of `stellar-strkey`:

- stellar/rs-stellar-xdr#547
- stellar/rs-soroban-env#1694
- stellar/rs-soroban-sdk#1913
- stellar/rs-stellar-rpc-client#99
- stellar/stellar-cli#2614

`stellar-strkey` 0.0.18 raises the minimum supported Rust version to 1.87 and updates/adds transitive dependencies (`heapless` 0.9, `zeroize`), so MSRV and supply-chain policy (cargo-deny / cackle) updates may be required in some repositories before CI is green.