### PR TITLE
Emit unescaped JSON key for `type` fields

### DIFF
--- a/src/generated/contract_event.rs
+++ b/src/generated/contract_event.rs
@@ -40,8 +40,12 @@ use super::*;
 pub struct ContractEvent {
     pub ext: ExtensionPoint,
     pub contract_id: Option<ContractId>,
-    #[cfg_attr(all(feature = "serde", feature = "alloc"), serde(alias = "type_"))]
-    pub r#type: ContractEventType,
+    #[cfg_attr(
+        all(feature = "serde", feature = "alloc"),
+        serde(rename = "type", alias = "type_")
+    )]
+    #[cfg_attr(feature = "schemars", schemars(rename = "type"))]
+    pub type_: ContractEventType,
     pub body: ContractEventBody,
 }
 
@@ -52,7 +56,7 @@ impl ReadXdr for ContractEvent {
             Ok(Self {
                 ext: ExtensionPoint::read_xdr(r)?,
                 contract_id: Option::<ContractId>::read_xdr(r)?,
-                r#type: ContractEventType::read_xdr(r)?,
+                type_: ContractEventType::read_xdr(r)?,
                 body: ContractEventBody::read_xdr(r)?,
             })
         })
@@ -65,7 +69,7 @@ impl WriteXdr for ContractEvent {
         w.with_limited_depth(|w| {
             self.ext.write_xdr(w)?;
             self.contract_id.write_xdr(w)?;
-            self.r#type.write_xdr(w)?;
+            self.type_.write_xdr(w)?;
             self.body.write_xdr(w)?;
             Ok(())
         })

--- a/src/generated/contract_event.rs
+++ b/src/generated/contract_event.rs
@@ -40,12 +40,8 @@ use super::*;
 pub struct ContractEvent {
     pub ext: ExtensionPoint,
     pub contract_id: Option<ContractId>,
-    #[cfg_attr(
-        all(feature = "serde", feature = "alloc"),
-        serde(rename = "type", alias = "type_")
-    )]
-    #[cfg_attr(feature = "schemars", schemars(rename = "type"))]
-    pub type_: ContractEventType,
+    #[cfg_attr(all(feature = "serde", feature = "alloc"), serde(alias = "type_"))]
+    pub r#type: ContractEventType,
     pub body: ContractEventBody,
 }
 
@@ -56,7 +52,7 @@ impl ReadXdr for ContractEvent {
             Ok(Self {
                 ext: ExtensionPoint::read_xdr(r)?,
                 contract_id: Option::<ContractId>::read_xdr(r)?,
-                type_: ContractEventType::read_xdr(r)?,
+                r#type: ContractEventType::read_xdr(r)?,
                 body: ContractEventBody::read_xdr(r)?,
             })
         })
@@ -69,7 +65,7 @@ impl WriteXdr for ContractEvent {
         w.with_limited_depth(|w| {
             self.ext.write_xdr(w)?;
             self.contract_id.write_xdr(w)?;
-            self.type_.write_xdr(w)?;
+            self.r#type.write_xdr(w)?;
             self.body.write_xdr(w)?;
             Ok(())
         })

--- a/src/generated/contract_event.rs
+++ b/src/generated/contract_event.rs
@@ -40,6 +40,11 @@ use super::*;
 pub struct ContractEvent {
     pub ext: ExtensionPoint,
     pub contract_id: Option<ContractId>,
+    #[cfg_attr(
+        all(feature = "serde", feature = "alloc"),
+        serde(rename = "type", alias = "type_")
+    )]
+    #[cfg_attr(feature = "schemars", schemars(rename = "type"))]
     pub type_: ContractEventType,
     pub body: ContractEventBody,
 }

--- a/src/generated/dont_have.rs
+++ b/src/generated/dont_have.rs
@@ -23,6 +23,11 @@ use super::*;
 )]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct DontHave {
+    #[cfg_attr(
+        all(feature = "serde", feature = "alloc"),
+        serde(rename = "type", alias = "type_")
+    )]
+    #[cfg_attr(feature = "schemars", schemars(rename = "type"))]
     pub type_: MessageType,
     pub req_hash: Uint256,
 }

--- a/src/generated/dont_have.rs
+++ b/src/generated/dont_have.rs
@@ -23,8 +23,12 @@ use super::*;
 )]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct DontHave {
-    #[cfg_attr(all(feature = "serde", feature = "alloc"), serde(alias = "type_"))]
-    pub r#type: MessageType,
+    #[cfg_attr(
+        all(feature = "serde", feature = "alloc"),
+        serde(rename = "type", alias = "type_")
+    )]
+    #[cfg_attr(feature = "schemars", schemars(rename = "type"))]
+    pub type_: MessageType,
     pub req_hash: Uint256,
 }
 
@@ -33,7 +37,7 @@ impl ReadXdr for DontHave {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             Ok(Self {
-                r#type: MessageType::read_xdr(r)?,
+                type_: MessageType::read_xdr(r)?,
                 req_hash: Uint256::read_xdr(r)?,
             })
         })
@@ -44,7 +48,7 @@ impl WriteXdr for DontHave {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
-            self.r#type.write_xdr(w)?;
+            self.type_.write_xdr(w)?;
             self.req_hash.write_xdr(w)?;
             Ok(())
         })

--- a/src/generated/dont_have.rs
+++ b/src/generated/dont_have.rs
@@ -23,12 +23,8 @@ use super::*;
 )]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct DontHave {
-    #[cfg_attr(
-        all(feature = "serde", feature = "alloc"),
-        serde(rename = "type", alias = "type_")
-    )]
-    #[cfg_attr(feature = "schemars", schemars(rename = "type"))]
-    pub type_: MessageType,
+    #[cfg_attr(all(feature = "serde", feature = "alloc"), serde(alias = "type_"))]
+    pub r#type: MessageType,
     pub req_hash: Uint256,
 }
 
@@ -37,7 +33,7 @@ impl ReadXdr for DontHave {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             Ok(Self {
-                type_: MessageType::read_xdr(r)?,
+                r#type: MessageType::read_xdr(r)?,
                 req_hash: Uint256::read_xdr(r)?,
             })
         })
@@ -48,7 +44,7 @@ impl WriteXdr for DontHave {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
-            self.type_.write_xdr(w)?;
+            self.r#type.write_xdr(w)?;
             self.req_hash.write_xdr(w)?;
             Ok(())
         })

--- a/src/generated/sc_spec_event_param_v0.rs
+++ b/src/generated/sc_spec_event_param_v0.rs
@@ -27,12 +27,8 @@ use super::*;
 pub struct ScSpecEventParamV0 {
     pub doc: StringM<1024>,
     pub name: StringM<30>,
-    #[cfg_attr(
-        all(feature = "serde", feature = "alloc"),
-        serde(rename = "type", alias = "type_")
-    )]
-    #[cfg_attr(feature = "schemars", schemars(rename = "type"))]
-    pub type_: ScSpecTypeDef,
+    #[cfg_attr(all(feature = "serde", feature = "alloc"), serde(alias = "type_"))]
+    pub r#type: ScSpecTypeDef,
     pub location: ScSpecEventParamLocationV0,
 }
 
@@ -43,7 +39,7 @@ impl ReadXdr for ScSpecEventParamV0 {
             Ok(Self {
                 doc: StringM::<1024>::read_xdr(r)?,
                 name: StringM::<30>::read_xdr(r)?,
-                type_: ScSpecTypeDef::read_xdr(r)?,
+                r#type: ScSpecTypeDef::read_xdr(r)?,
                 location: ScSpecEventParamLocationV0::read_xdr(r)?,
             })
         })
@@ -56,7 +52,7 @@ impl WriteXdr for ScSpecEventParamV0 {
         w.with_limited_depth(|w| {
             self.doc.write_xdr(w)?;
             self.name.write_xdr(w)?;
-            self.type_.write_xdr(w)?;
+            self.r#type.write_xdr(w)?;
             self.location.write_xdr(w)?;
             Ok(())
         })

--- a/src/generated/sc_spec_event_param_v0.rs
+++ b/src/generated/sc_spec_event_param_v0.rs
@@ -27,8 +27,12 @@ use super::*;
 pub struct ScSpecEventParamV0 {
     pub doc: StringM<1024>,
     pub name: StringM<30>,
-    #[cfg_attr(all(feature = "serde", feature = "alloc"), serde(alias = "type_"))]
-    pub r#type: ScSpecTypeDef,
+    #[cfg_attr(
+        all(feature = "serde", feature = "alloc"),
+        serde(rename = "type", alias = "type_")
+    )]
+    #[cfg_attr(feature = "schemars", schemars(rename = "type"))]
+    pub type_: ScSpecTypeDef,
     pub location: ScSpecEventParamLocationV0,
 }
 
@@ -39,7 +43,7 @@ impl ReadXdr for ScSpecEventParamV0 {
             Ok(Self {
                 doc: StringM::<1024>::read_xdr(r)?,
                 name: StringM::<30>::read_xdr(r)?,
-                r#type: ScSpecTypeDef::read_xdr(r)?,
+                type_: ScSpecTypeDef::read_xdr(r)?,
                 location: ScSpecEventParamLocationV0::read_xdr(r)?,
             })
         })
@@ -52,7 +56,7 @@ impl WriteXdr for ScSpecEventParamV0 {
         w.with_limited_depth(|w| {
             self.doc.write_xdr(w)?;
             self.name.write_xdr(w)?;
-            self.r#type.write_xdr(w)?;
+            self.type_.write_xdr(w)?;
             self.location.write_xdr(w)?;
             Ok(())
         })

--- a/src/generated/sc_spec_event_param_v0.rs
+++ b/src/generated/sc_spec_event_param_v0.rs
@@ -27,6 +27,11 @@ use super::*;
 pub struct ScSpecEventParamV0 {
     pub doc: StringM<1024>,
     pub name: StringM<30>,
+    #[cfg_attr(
+        all(feature = "serde", feature = "alloc"),
+        serde(rename = "type", alias = "type_")
+    )]
+    #[cfg_attr(feature = "schemars", schemars(rename = "type"))]
     pub type_: ScSpecTypeDef,
     pub location: ScSpecEventParamLocationV0,
 }

--- a/src/generated/sc_spec_function_input_v0.rs
+++ b/src/generated/sc_spec_function_input_v0.rs
@@ -26,6 +26,11 @@ use super::*;
 pub struct ScSpecFunctionInputV0 {
     pub doc: StringM<1024>,
     pub name: StringM<30>,
+    #[cfg_attr(
+        all(feature = "serde", feature = "alloc"),
+        serde(rename = "type", alias = "type_")
+    )]
+    #[cfg_attr(feature = "schemars", schemars(rename = "type"))]
     pub type_: ScSpecTypeDef,
 }
 

--- a/src/generated/sc_spec_function_input_v0.rs
+++ b/src/generated/sc_spec_function_input_v0.rs
@@ -26,12 +26,8 @@ use super::*;
 pub struct ScSpecFunctionInputV0 {
     pub doc: StringM<1024>,
     pub name: StringM<30>,
-    #[cfg_attr(
-        all(feature = "serde", feature = "alloc"),
-        serde(rename = "type", alias = "type_")
-    )]
-    #[cfg_attr(feature = "schemars", schemars(rename = "type"))]
-    pub type_: ScSpecTypeDef,
+    #[cfg_attr(all(feature = "serde", feature = "alloc"), serde(alias = "type_"))]
+    pub r#type: ScSpecTypeDef,
 }
 
 impl ReadXdr for ScSpecFunctionInputV0 {
@@ -41,7 +37,7 @@ impl ReadXdr for ScSpecFunctionInputV0 {
             Ok(Self {
                 doc: StringM::<1024>::read_xdr(r)?,
                 name: StringM::<30>::read_xdr(r)?,
-                type_: ScSpecTypeDef::read_xdr(r)?,
+                r#type: ScSpecTypeDef::read_xdr(r)?,
             })
         })
     }
@@ -53,7 +49,7 @@ impl WriteXdr for ScSpecFunctionInputV0 {
         w.with_limited_depth(|w| {
             self.doc.write_xdr(w)?;
             self.name.write_xdr(w)?;
-            self.type_.write_xdr(w)?;
+            self.r#type.write_xdr(w)?;
             Ok(())
         })
     }

--- a/src/generated/sc_spec_function_input_v0.rs
+++ b/src/generated/sc_spec_function_input_v0.rs
@@ -26,8 +26,12 @@ use super::*;
 pub struct ScSpecFunctionInputV0 {
     pub doc: StringM<1024>,
     pub name: StringM<30>,
-    #[cfg_attr(all(feature = "serde", feature = "alloc"), serde(alias = "type_"))]
-    pub r#type: ScSpecTypeDef,
+    #[cfg_attr(
+        all(feature = "serde", feature = "alloc"),
+        serde(rename = "type", alias = "type_")
+    )]
+    #[cfg_attr(feature = "schemars", schemars(rename = "type"))]
+    pub type_: ScSpecTypeDef,
 }
 
 impl ReadXdr for ScSpecFunctionInputV0 {
@@ -37,7 +41,7 @@ impl ReadXdr for ScSpecFunctionInputV0 {
             Ok(Self {
                 doc: StringM::<1024>::read_xdr(r)?,
                 name: StringM::<30>::read_xdr(r)?,
-                r#type: ScSpecTypeDef::read_xdr(r)?,
+                type_: ScSpecTypeDef::read_xdr(r)?,
             })
         })
     }
@@ -49,7 +53,7 @@ impl WriteXdr for ScSpecFunctionInputV0 {
         w.with_limited_depth(|w| {
             self.doc.write_xdr(w)?;
             self.name.write_xdr(w)?;
-            self.r#type.write_xdr(w)?;
+            self.type_.write_xdr(w)?;
             Ok(())
         })
     }

--- a/src/generated/sc_spec_udt_struct_field_v0.rs
+++ b/src/generated/sc_spec_udt_struct_field_v0.rs
@@ -26,8 +26,12 @@ use super::*;
 pub struct ScSpecUdtStructFieldV0 {
     pub doc: StringM<1024>,
     pub name: StringM<30>,
-    #[cfg_attr(all(feature = "serde", feature = "alloc"), serde(alias = "type_"))]
-    pub r#type: ScSpecTypeDef,
+    #[cfg_attr(
+        all(feature = "serde", feature = "alloc"),
+        serde(rename = "type", alias = "type_")
+    )]
+    #[cfg_attr(feature = "schemars", schemars(rename = "type"))]
+    pub type_: ScSpecTypeDef,
 }
 
 impl ReadXdr for ScSpecUdtStructFieldV0 {
@@ -37,7 +41,7 @@ impl ReadXdr for ScSpecUdtStructFieldV0 {
             Ok(Self {
                 doc: StringM::<1024>::read_xdr(r)?,
                 name: StringM::<30>::read_xdr(r)?,
-                r#type: ScSpecTypeDef::read_xdr(r)?,
+                type_: ScSpecTypeDef::read_xdr(r)?,
             })
         })
     }
@@ -49,7 +53,7 @@ impl WriteXdr for ScSpecUdtStructFieldV0 {
         w.with_limited_depth(|w| {
             self.doc.write_xdr(w)?;
             self.name.write_xdr(w)?;
-            self.r#type.write_xdr(w)?;
+            self.type_.write_xdr(w)?;
             Ok(())
         })
     }

--- a/src/generated/sc_spec_udt_struct_field_v0.rs
+++ b/src/generated/sc_spec_udt_struct_field_v0.rs
@@ -26,6 +26,11 @@ use super::*;
 pub struct ScSpecUdtStructFieldV0 {
     pub doc: StringM<1024>,
     pub name: StringM<30>,
+    #[cfg_attr(
+        all(feature = "serde", feature = "alloc"),
+        serde(rename = "type", alias = "type_")
+    )]
+    #[cfg_attr(feature = "schemars", schemars(rename = "type"))]
     pub type_: ScSpecTypeDef,
 }
 

--- a/src/generated/sc_spec_udt_struct_field_v0.rs
+++ b/src/generated/sc_spec_udt_struct_field_v0.rs
@@ -26,12 +26,8 @@ use super::*;
 pub struct ScSpecUdtStructFieldV0 {
     pub doc: StringM<1024>,
     pub name: StringM<30>,
-    #[cfg_attr(
-        all(feature = "serde", feature = "alloc"),
-        serde(rename = "type", alias = "type_")
-    )]
-    #[cfg_attr(feature = "schemars", schemars(rename = "type"))]
-    pub type_: ScSpecTypeDef,
+    #[cfg_attr(all(feature = "serde", feature = "alloc"), serde(alias = "type_"))]
+    pub r#type: ScSpecTypeDef,
 }
 
 impl ReadXdr for ScSpecUdtStructFieldV0 {
@@ -41,7 +37,7 @@ impl ReadXdr for ScSpecUdtStructFieldV0 {
             Ok(Self {
                 doc: StringM::<1024>::read_xdr(r)?,
                 name: StringM::<30>::read_xdr(r)?,
-                type_: ScSpecTypeDef::read_xdr(r)?,
+                r#type: ScSpecTypeDef::read_xdr(r)?,
             })
         })
     }
@@ -53,7 +49,7 @@ impl WriteXdr for ScSpecUdtStructFieldV0 {
         w.with_limited_depth(|w| {
             self.doc.write_xdr(w)?;
             self.name.write_xdr(w)?;
-            self.type_.write_xdr(w)?;
+            self.r#type.write_xdr(w)?;
             Ok(())
         })
     }

--- a/src/generated/sc_spec_udt_union_case_tuple_v0.rs
+++ b/src/generated/sc_spec_udt_union_case_tuple_v0.rs
@@ -26,12 +26,8 @@ use super::*;
 pub struct ScSpecUdtUnionCaseTupleV0 {
     pub doc: StringM<1024>,
     pub name: StringM<60>,
-    #[cfg_attr(
-        all(feature = "serde", feature = "alloc"),
-        serde(rename = "type", alias = "type_")
-    )]
-    #[cfg_attr(feature = "schemars", schemars(rename = "type"))]
-    pub type_: VecM<ScSpecTypeDef>,
+    #[cfg_attr(all(feature = "serde", feature = "alloc"), serde(alias = "type_"))]
+    pub r#type: VecM<ScSpecTypeDef>,
 }
 
 impl ReadXdr for ScSpecUdtUnionCaseTupleV0 {
@@ -41,7 +37,7 @@ impl ReadXdr for ScSpecUdtUnionCaseTupleV0 {
             Ok(Self {
                 doc: StringM::<1024>::read_xdr(r)?,
                 name: StringM::<60>::read_xdr(r)?,
-                type_: VecM::<ScSpecTypeDef>::read_xdr(r)?,
+                r#type: VecM::<ScSpecTypeDef>::read_xdr(r)?,
             })
         })
     }
@@ -53,7 +49,7 @@ impl WriteXdr for ScSpecUdtUnionCaseTupleV0 {
         w.with_limited_depth(|w| {
             self.doc.write_xdr(w)?;
             self.name.write_xdr(w)?;
-            self.type_.write_xdr(w)?;
+            self.r#type.write_xdr(w)?;
             Ok(())
         })
     }

--- a/src/generated/sc_spec_udt_union_case_tuple_v0.rs
+++ b/src/generated/sc_spec_udt_union_case_tuple_v0.rs
@@ -26,6 +26,11 @@ use super::*;
 pub struct ScSpecUdtUnionCaseTupleV0 {
     pub doc: StringM<1024>,
     pub name: StringM<60>,
+    #[cfg_attr(
+        all(feature = "serde", feature = "alloc"),
+        serde(rename = "type", alias = "type_")
+    )]
+    #[cfg_attr(feature = "schemars", schemars(rename = "type"))]
     pub type_: VecM<ScSpecTypeDef>,
 }
 

--- a/src/generated/sc_spec_udt_union_case_tuple_v0.rs
+++ b/src/generated/sc_spec_udt_union_case_tuple_v0.rs
@@ -26,8 +26,12 @@ use super::*;
 pub struct ScSpecUdtUnionCaseTupleV0 {
     pub doc: StringM<1024>,
     pub name: StringM<60>,
-    #[cfg_attr(all(feature = "serde", feature = "alloc"), serde(alias = "type_"))]
-    pub r#type: VecM<ScSpecTypeDef>,
+    #[cfg_attr(
+        all(feature = "serde", feature = "alloc"),
+        serde(rename = "type", alias = "type_")
+    )]
+    #[cfg_attr(feature = "schemars", schemars(rename = "type"))]
+    pub type_: VecM<ScSpecTypeDef>,
 }
 
 impl ReadXdr for ScSpecUdtUnionCaseTupleV0 {
@@ -37,7 +41,7 @@ impl ReadXdr for ScSpecUdtUnionCaseTupleV0 {
             Ok(Self {
                 doc: StringM::<1024>::read_xdr(r)?,
                 name: StringM::<60>::read_xdr(r)?,
-                r#type: VecM::<ScSpecTypeDef>::read_xdr(r)?,
+                type_: VecM::<ScSpecTypeDef>::read_xdr(r)?,
             })
         })
     }
@@ -49,7 +53,7 @@ impl WriteXdr for ScSpecUdtUnionCaseTupleV0 {
         w.with_limited_depth(|w| {
             self.doc.write_xdr(w)?;
             self.name.write_xdr(w)?;
-            self.r#type.write_xdr(w)?;
+            self.type_.write_xdr(w)?;
             Ok(())
         })
     }

--- a/src/generated/serialized_binary_fuse_filter.rs
+++ b/src/generated/serialized_binary_fuse_filter.rs
@@ -36,12 +36,8 @@ use super::*;
 )]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct SerializedBinaryFuseFilter {
-    #[cfg_attr(
-        all(feature = "serde", feature = "alloc"),
-        serde(rename = "type", alias = "type_")
-    )]
-    #[cfg_attr(feature = "schemars", schemars(rename = "type"))]
-    pub type_: BinaryFuseFilterType,
+    #[cfg_attr(all(feature = "serde", feature = "alloc"), serde(alias = "type_"))]
+    pub r#type: BinaryFuseFilterType,
     pub input_hash_seed: ShortHashSeed,
     pub filter_seed: ShortHashSeed,
     pub segment_length: u32,
@@ -57,7 +53,7 @@ impl ReadXdr for SerializedBinaryFuseFilter {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             Ok(Self {
-                type_: BinaryFuseFilterType::read_xdr(r)?,
+                r#type: BinaryFuseFilterType::read_xdr(r)?,
                 input_hash_seed: ShortHashSeed::read_xdr(r)?,
                 filter_seed: ShortHashSeed::read_xdr(r)?,
                 segment_length: u32::read_xdr(r)?,
@@ -75,7 +71,7 @@ impl WriteXdr for SerializedBinaryFuseFilter {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
-            self.type_.write_xdr(w)?;
+            self.r#type.write_xdr(w)?;
             self.input_hash_seed.write_xdr(w)?;
             self.filter_seed.write_xdr(w)?;
             self.segment_length.write_xdr(w)?;

--- a/src/generated/serialized_binary_fuse_filter.rs
+++ b/src/generated/serialized_binary_fuse_filter.rs
@@ -36,8 +36,12 @@ use super::*;
 )]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct SerializedBinaryFuseFilter {
-    #[cfg_attr(all(feature = "serde", feature = "alloc"), serde(alias = "type_"))]
-    pub r#type: BinaryFuseFilterType,
+    #[cfg_attr(
+        all(feature = "serde", feature = "alloc"),
+        serde(rename = "type", alias = "type_")
+    )]
+    #[cfg_attr(feature = "schemars", schemars(rename = "type"))]
+    pub type_: BinaryFuseFilterType,
     pub input_hash_seed: ShortHashSeed,
     pub filter_seed: ShortHashSeed,
     pub segment_length: u32,
@@ -53,7 +57,7 @@ impl ReadXdr for SerializedBinaryFuseFilter {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             Ok(Self {
-                r#type: BinaryFuseFilterType::read_xdr(r)?,
+                type_: BinaryFuseFilterType::read_xdr(r)?,
                 input_hash_seed: ShortHashSeed::read_xdr(r)?,
                 filter_seed: ShortHashSeed::read_xdr(r)?,
                 segment_length: u32::read_xdr(r)?,
@@ -71,7 +75,7 @@ impl WriteXdr for SerializedBinaryFuseFilter {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
-            self.r#type.write_xdr(w)?;
+            self.type_.write_xdr(w)?;
             self.input_hash_seed.write_xdr(w)?;
             self.filter_seed.write_xdr(w)?;
             self.segment_length.write_xdr(w)?;

--- a/src/generated/serialized_binary_fuse_filter.rs
+++ b/src/generated/serialized_binary_fuse_filter.rs
@@ -36,6 +36,11 @@ use super::*;
 )]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct SerializedBinaryFuseFilter {
+    #[cfg_attr(
+        all(feature = "serde", feature = "alloc"),
+        serde(rename = "type", alias = "type_")
+    )]
+    #[cfg_attr(feature = "schemars", schemars(rename = "type"))]
     pub type_: BinaryFuseFilterType,
     pub input_hash_seed: ShortHashSeed,
     pub filter_seed: ShortHashSeed,

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -82,7 +82,7 @@ fn test_structs_that_ser_to_string_and_dual_der() -> Result<(), Box<dyn std::err
 #[test]
 fn test_serde_type_field_uses_sep51_json_key() -> Result<(), Box<dyn std::error::Error>> {
     let event = ContractEvent {
-        r#type: ContractEventType::Contract,
+        type_: ContractEventType::Contract,
         ..Default::default()
     };
 

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -2,7 +2,7 @@
 
 use stellar_xdr::{BytesM, Hash, StringM, VecM};
 
-use stellar_xdr::{AccountId, Int128Parts};
+use stellar_xdr::{AccountId, ContractEvent, ContractEventType, Int128Parts};
 
 use std::str::FromStr;
 
@@ -76,5 +76,25 @@ fn test_structs_that_ser_to_string_and_dual_der() -> Result<(), Box<dyn std::err
         serde_json::from_str::<Int128Parts>(r#"{"hi":1,"lo":2}"#)?,
         Int128Parts { hi: 1, lo: 2 },
     );
+    Ok(())
+}
+
+#[test]
+fn test_serde_type_field_uses_unescaped_json_key() -> Result<(), Box<dyn std::error::Error>> {
+    let mut event = ContractEvent::default();
+    event.type_ = ContractEventType::Contract;
+
+    // Serializes with the SEP-51 JSON key `type`, not the escaped Rust name `type_`.
+    let json = serde_json::to_string(&event)?;
+    assert!(json.contains(r#""type":"#), "expected `type` key in {json}");
+    assert!(!json.contains("type_"), "unexpected `type_` key in {json}");
+
+    // Deserializes from the correct SEP-51 key `type`.
+    assert_eq!(serde_json::from_str::<ContractEvent>(&json)?, event);
+
+    // Deserializes from the legacy escaped key `type_` (backward-compat alias).
+    let legacy = json.replace(r#""type":"#, r#""type_":"#);
+    assert_eq!(serde_json::from_str::<ContractEvent>(&legacy)?, event);
+
     Ok(())
 }

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -80,21 +80,21 @@ fn test_structs_that_ser_to_string_and_dual_der() -> Result<(), Box<dyn std::err
 }
 
 #[test]
-fn test_serde_type_field_uses_unescaped_json_key() -> Result<(), Box<dyn std::error::Error>> {
+fn test_serde_type_field_uses_sep51_json_key() -> Result<(), Box<dyn std::error::Error>> {
     let event = ContractEvent {
-        type_: ContractEventType::Contract,
+        r#type: ContractEventType::Contract,
         ..Default::default()
     };
 
-    // Serializes with the SEP-51 JSON key `type`, not the escaped Rust name `type_`.
+    // Serializes with the SEP-51 JSON key `type`, not the previous escaped `type_`.
     let json = serde_json::to_string(&event)?;
     assert!(json.contains(r#""type":"#), "expected `type` key in {json}");
     assert!(!json.contains("type_"), "unexpected `type_` key in {json}");
 
-    // Deserializes from the correct SEP-51 key `type`.
+    // Deserializes from the SEP-51 key `type`.
     assert_eq!(serde_json::from_str::<ContractEvent>(&json)?, event);
 
-    // Deserializes from the legacy escaped key `type_` (backward-compat alias).
+    // The legacy escaped key `type_` is still accepted via a serde alias.
     let legacy = json.replace(r#""type":"#, r#""type_":"#);
     assert_eq!(serde_json::from_str::<ContractEvent>(&legacy)?, event);
 

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -86,17 +86,19 @@ fn test_serde_type_field_uses_sep51_json_key() -> Result<(), Box<dyn std::error:
         ..Default::default()
     };
 
-    // Serializes with the SEP-51 JSON key `type`, not the previous escaped `type_`.
-    let json = serde_json::to_string(&event)?;
-    assert!(json.contains(r#""type":"#), "expected `type` key in {json}");
-    assert!(!json.contains("type_"), "unexpected `type_` key in {json}");
+    // The SEP-51 JSON uses the key `type`, not the previously escaped `type_`.
+    let json = r#"{"ext":"v0","contract_id":null,"type":"contract","body":{"v0":{"topics":[],"data":{"bool":false}}}}"#;
+    // The legacy JSON that older versions of this crate emitted, using `type_`.
+    let legacy_json = r#"{"ext":"v0","contract_id":null,"type_":"contract","body":{"v0":{"topics":[],"data":{"bool":false}}}}"#;
+
+    // Serializes with the SEP-51 key `type`.
+    assert_eq!(serde_json::to_string(&event)?, json);
 
     // Deserializes from the SEP-51 key `type`.
-    assert_eq!(serde_json::from_str::<ContractEvent>(&json)?, event);
+    assert_eq!(serde_json::from_str::<ContractEvent>(json)?, event);
 
     // The legacy escaped key `type_` is still accepted via a serde alias.
-    let legacy = json.replace(r#""type":"#, r#""type_":"#);
-    assert_eq!(serde_json::from_str::<ContractEvent>(&legacy)?, event);
+    assert_eq!(serde_json::from_str::<ContractEvent>(legacy_json)?, event);
 
     Ok(())
 }

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -81,8 +81,10 @@ fn test_structs_that_ser_to_string_and_dual_der() -> Result<(), Box<dyn std::err
 
 #[test]
 fn test_serde_type_field_uses_unescaped_json_key() -> Result<(), Box<dyn std::error::Error>> {
-    let mut event = ContractEvent::default();
-    event.type_ = ContractEventType::Contract;
+    let event = ContractEvent {
+        type_: ContractEventType::Contract,
+        ..Default::default()
+    };
 
     // Serializes with the SEP-51 JSON key `type`, not the escaped Rust name `type_`.
     let json = serde_json::to_string(&event)?;

--- a/xdr-generator-rust/generator/src/generator.rs
+++ b/xdr-generator-rust/generator/src/generator.rs
@@ -8,7 +8,9 @@ use xdr_parser::ast::{
 use xdr_parser::lexer::IntBase;
 use xdr_parser::types::{is_builtin_type, is_fixed_array, is_fixed_opaque, is_var_array, TypeInfo};
 
-use crate::naming::{case_value, field_name, mod_name, source_comment, type_name};
+use crate::naming::{
+    case_value, field_json_rename, field_name, mod_name, source_comment, type_name,
+};
 use crate::options::RustOptions;
 use crate::output::{
     ConstOutput, DefinitionOutput, DefinitionTemplate, EnumOutput, EnumStructMemberOutput,
@@ -424,6 +426,7 @@ impl RustGenerator {
         custom_str: bool,
     ) -> StructMemberOutput {
         let name = field_name(&m.name);
+        let serde_rename = field_json_rename(&m.name);
         let resolved = resolve_type(&m.type_, Some(parent), &self.type_info, custom_str);
 
         StructMemberOutput {
@@ -431,6 +434,7 @@ impl RustGenerator {
             type_ref: resolved.type_ref,
             turbofish_type: resolved.turbofish_type,
             serde_as_type: resolved.serde_as_type,
+            serde_rename,
         }
     }
 

--- a/xdr-generator-rust/generator/src/generator.rs
+++ b/xdr-generator-rust/generator/src/generator.rs
@@ -9,7 +9,7 @@ use xdr_parser::lexer::IntBase;
 use xdr_parser::types::{is_builtin_type, is_fixed_array, is_fixed_opaque, is_var_array, TypeInfo};
 
 use crate::naming::{
-    case_value, field_json_rename, field_name, mod_name, source_comment, type_name,
+    case_value, field_name, field_serde_alias, mod_name, source_comment, type_name,
 };
 use crate::options::RustOptions;
 use crate::output::{
@@ -426,7 +426,7 @@ impl RustGenerator {
         custom_str: bool,
     ) -> StructMemberOutput {
         let name = field_name(&m.name);
-        let serde_rename = field_json_rename(&m.name);
+        let serde_alias = field_serde_alias(&m.name);
         let resolved = resolve_type(&m.type_, Some(parent), &self.type_info, custom_str);
 
         StructMemberOutput {
@@ -434,7 +434,7 @@ impl RustGenerator {
             type_ref: resolved.type_ref,
             turbofish_type: resolved.turbofish_type,
             serde_as_type: resolved.serde_as_type,
-            serde_rename,
+            serde_alias,
         }
     }
 

--- a/xdr-generator-rust/generator/src/generator.rs
+++ b/xdr-generator-rust/generator/src/generator.rs
@@ -9,7 +9,7 @@ use xdr_parser::lexer::IntBase;
 use xdr_parser::types::{is_builtin_type, is_fixed_array, is_fixed_opaque, is_var_array, TypeInfo};
 
 use crate::naming::{
-    case_value, field_name, field_serde_alias, mod_name, source_comment, type_name,
+    case_value, field_json_rename, field_name, mod_name, source_comment, type_name,
 };
 use crate::options::RustOptions;
 use crate::output::{
@@ -426,7 +426,7 @@ impl RustGenerator {
         custom_str: bool,
     ) -> StructMemberOutput {
         let name = field_name(&m.name);
-        let serde_alias = field_serde_alias(&m.name);
+        let serde_rename = field_json_rename(&m.name);
         let resolved = resolve_type(&m.type_, Some(parent), &self.type_info, custom_str);
 
         StructMemberOutput {
@@ -434,7 +434,7 @@ impl RustGenerator {
             type_ref: resolved.type_ref,
             turbofish_type: resolved.turbofish_type,
             serde_as_type: resolved.serde_as_type,
-            serde_alias,
+            serde_rename,
         }
     }
 

--- a/xdr-generator-rust/generator/src/naming.rs
+++ b/xdr-generator-rust/generator/src/naming.rs
@@ -17,18 +17,15 @@ pub(crate) fn field_name(name: &str) -> String {
     escape_field_name(&snake)
 }
 
-/// When a field name is keyword-escaped to a raw identifier (e.g. `type` ->
-/// `r#type`), serde derives the JSON key from the bare keyword (`type`). Prior
-/// versions escaped the field with a trailing underscore (`type_`) and
-/// serialized it as such, so return that legacy key to keep accepting it on
-/// deserialization via `#[serde(alias = ...)]`. Returns `None` when no escaping
-/// occurred.
-pub(crate) fn field_serde_alias(name: &str) -> Option<String> {
+/// If the Rust field name for an XDR field was keyword-escaped away from its
+/// plain snake_case name (e.g. `type` -> `type_`), return the correct JSON key
+/// (the unescaped snake_case name). Returns `None` when no escaping occurred.
+pub(crate) fn field_json_rename(name: &str) -> Option<String> {
     let snake = name.to_snake_case();
-    if escape_field_name(&snake).starts_with("r#") {
-        Some(format!("{snake}_"))
-    } else {
+    if escape_field_name(&snake) == snake {
         None
+    } else {
+        Some(snake)
     }
 }
 
@@ -42,9 +39,7 @@ fn escape_type_name(name: &str) -> String {
 
 fn escape_field_name(name: &str) -> String {
     match name {
-        // Emit the raw identifier so the Rust field is literally named `type`
-        // and serde/schemars derive the JSON key `type` from it directly.
-        "type" => "r#type".to_string(),
+        "type" => "type_".to_string(),
         _ => name.to_string(),
     }
 }

--- a/xdr-generator-rust/generator/src/naming.rs
+++ b/xdr-generator-rust/generator/src/naming.rs
@@ -17,15 +17,18 @@ pub(crate) fn field_name(name: &str) -> String {
     escape_field_name(&snake)
 }
 
-/// If the Rust field name for an XDR field was keyword-escaped away from its
-/// plain snake_case name (e.g. `type` -> `type_`), return the correct JSON key
-/// (the unescaped snake_case name). Returns `None` when no escaping occurred.
-pub(crate) fn field_json_rename(name: &str) -> Option<String> {
+/// When a field name is keyword-escaped to a raw identifier (e.g. `type` ->
+/// `r#type`), serde derives the JSON key from the bare keyword (`type`). Prior
+/// versions escaped the field with a trailing underscore (`type_`) and
+/// serialized it as such, so return that legacy key to keep accepting it on
+/// deserialization via `#[serde(alias = ...)]`. Returns `None` when no escaping
+/// occurred.
+pub(crate) fn field_serde_alias(name: &str) -> Option<String> {
     let snake = name.to_snake_case();
-    if escape_field_name(&snake) == snake {
-        None
+    if escape_field_name(&snake).starts_with("r#") {
+        Some(format!("{snake}_"))
     } else {
-        Some(snake)
+        None
     }
 }
 
@@ -39,7 +42,9 @@ fn escape_type_name(name: &str) -> String {
 
 fn escape_field_name(name: &str) -> String {
     match name {
-        "type" => "type_".to_string(),
+        // Emit the raw identifier so the Rust field is literally named `type`
+        // and serde/schemars derive the JSON key `type` from it directly.
+        "type" => "r#type".to_string(),
         _ => name.to_string(),
     }
 }

--- a/xdr-generator-rust/generator/src/naming.rs
+++ b/xdr-generator-rust/generator/src/naming.rs
@@ -17,6 +17,18 @@ pub(crate) fn field_name(name: &str) -> String {
     escape_field_name(&snake)
 }
 
+/// If the Rust field name for an XDR field was keyword-escaped away from its
+/// plain snake_case name (e.g. `type` -> `type_`), return the correct JSON key
+/// (the unescaped snake_case name). Returns `None` when no escaping occurred.
+pub(crate) fn field_json_rename(name: &str) -> Option<String> {
+    let snake = name.to_snake_case();
+    if escape_field_name(&snake) == snake {
+        None
+    } else {
+        Some(snake)
+    }
+}
+
 fn escape_type_name(name: &str) -> String {
     match name {
         "type" => "type_".to_string(),

--- a/xdr-generator-rust/generator/src/output.rs
+++ b/xdr-generator-rust/generator/src/output.rs
@@ -58,10 +58,9 @@ pub struct StructMemberOutput {
     pub type_ref: String,
     pub turbofish_type: String,
     pub serde_as_type: Option<String>,
-    /// Legacy JSON key to accept on deserialization when the field name was
-    /// keyword-escaped to a raw identifier (e.g. `type_` for `r#type`). `None`
-    /// when the name was not escaped.
-    pub serde_alias: Option<String>,
+    /// The correct SEP-51 JSON key when the Rust field name was keyword-escaped
+    /// (e.g. `type_` -> JSON `type`). `None` when the name was not escaped.
+    pub serde_rename: Option<String>,
 }
 
 pub struct EnumOutput {

--- a/xdr-generator-rust/generator/src/output.rs
+++ b/xdr-generator-rust/generator/src/output.rs
@@ -58,9 +58,10 @@ pub struct StructMemberOutput {
     pub type_ref: String,
     pub turbofish_type: String,
     pub serde_as_type: Option<String>,
-    /// The correct SEP-51 JSON key when the Rust field name was keyword-escaped
-    /// (e.g. `type_` -> JSON `type`). `None` when the name was not escaped.
-    pub serde_rename: Option<String>,
+    /// Legacy JSON key to accept on deserialization when the field name was
+    /// keyword-escaped to a raw identifier (e.g. `type_` for `r#type`). `None`
+    /// when the name was not escaped.
+    pub serde_alias: Option<String>,
 }
 
 pub struct EnumOutput {

--- a/xdr-generator-rust/generator/src/output.rs
+++ b/xdr-generator-rust/generator/src/output.rs
@@ -58,6 +58,9 @@ pub struct StructMemberOutput {
     pub type_ref: String,
     pub turbofish_type: String,
     pub serde_as_type: Option<String>,
+    /// The correct SEP-51 JSON key when the Rust field name was keyword-escaped
+    /// (e.g. `type_` -> JSON `type`). `None` when the name was not escaped.
+    pub serde_rename: Option<String>,
 }
 
 pub struct EnumOutput {

--- a/xdr-generator-rust/generator/src/tests/naming.rs
+++ b/xdr-generator-rust/generator/src/tests/naming.rs
@@ -1,4 +1,4 @@
-use crate::naming::{field_name, field_serde_alias, type_name};
+use crate::naming::{field_json_rename, field_name, type_name};
 
 #[test]
 fn test_type_name_snake_case() {
@@ -53,17 +53,17 @@ fn test_field_name_already_snake_case() {
 
 #[test]
 fn test_field_name_escape_type() {
-    assert_eq!(field_name("type"), "r#type");
+    assert_eq!(field_name("type"), "type_");
 }
 
 #[test]
-fn test_field_serde_alias_type() {
-    assert_eq!(field_serde_alias("type"), Some("type_".to_string()));
+fn test_field_json_rename_type() {
+    assert_eq!(field_json_rename("type"), Some("type".to_string()));
 }
 
 #[test]
-fn test_field_serde_alias_non_keyword() {
-    assert_eq!(field_serde_alias("public_key"), None);
+fn test_field_json_rename_non_keyword() {
+    assert_eq!(field_json_rename("public_key"), None);
 }
 
 #[test]

--- a/xdr-generator-rust/generator/src/tests/naming.rs
+++ b/xdr-generator-rust/generator/src/tests/naming.rs
@@ -1,4 +1,4 @@
-use crate::naming::{field_name, type_name};
+use crate::naming::{field_name, field_serde_alias, type_name};
 
 #[test]
 fn test_type_name_snake_case() {
@@ -53,7 +53,17 @@ fn test_field_name_already_snake_case() {
 
 #[test]
 fn test_field_name_escape_type() {
-    assert_eq!(field_name("type"), "type_");
+    assert_eq!(field_name("type"), "r#type");
+}
+
+#[test]
+fn test_field_serde_alias_type() {
+    assert_eq!(field_serde_alias("type"), Some("type_".to_string()));
+}
+
+#[test]
+fn test_field_serde_alias_non_keyword() {
+    assert_eq!(field_serde_alias("public_key"), None);
 }
 
 #[test]

--- a/xdr-generator-rust/generator/templates/struct.rs.jinja
+++ b/xdr-generator-rust/generator/templates/struct.rs.jinja
@@ -30,11 +30,12 @@ pub struct {{ s.name }} {
         serde_as(as = "{{ serde_as }}")
     )]
 {%- endif %}
-{%- if let Some(alias) = m.serde_alias %}
+{%- if let Some(rename) = m.serde_rename %}
     #[cfg_attr(
         all(feature = "serde", feature = "alloc"),
-        serde(alias = "{{ alias }}")
+        serde(rename = "{{ rename }}", alias = "{{ m.name }}")
     )]
+    #[cfg_attr(feature = "schemars", schemars(rename = "{{ rename }}"))]
 {%- endif %}
     pub {{ m.name }}: {{ m.type_ref }},
 {%- endfor %}

--- a/xdr-generator-rust/generator/templates/struct.rs.jinja
+++ b/xdr-generator-rust/generator/templates/struct.rs.jinja
@@ -30,12 +30,11 @@ pub struct {{ s.name }} {
         serde_as(as = "{{ serde_as }}")
     )]
 {%- endif %}
-{%- if let Some(rename) = m.serde_rename %}
+{%- if let Some(alias) = m.serde_alias %}
     #[cfg_attr(
         all(feature = "serde", feature = "alloc"),
-        serde(rename = "{{ rename }}", alias = "{{ m.name }}")
+        serde(alias = "{{ alias }}")
     )]
-    #[cfg_attr(feature = "schemars", schemars(rename = "{{ rename }}"))]
 {%- endif %}
     pub {{ m.name }}: {{ m.type_ref }},
 {%- endfor %}

--- a/xdr-generator-rust/generator/templates/struct.rs.jinja
+++ b/xdr-generator-rust/generator/templates/struct.rs.jinja
@@ -30,6 +30,13 @@ pub struct {{ s.name }} {
         serde_as(as = "{{ serde_as }}")
     )]
 {%- endif %}
+{%- if let Some(rename) = m.serde_rename %}
+    #[cfg_attr(
+        all(feature = "serde", feature = "alloc"),
+        serde(rename = "{{ rename }}", alias = "{{ m.name }}")
+    )]
+    #[cfg_attr(feature = "schemars", schemars(rename = "{{ rename }}"))]
+{%- endif %}
     pub {{ m.name }}: {{ m.type_ref }},
 {%- endfor %}
 }

--- a/xdr-json/AuthenticatedMessage.json
+++ b/xdr-json/AuthenticatedMessage.json
@@ -689,7 +689,7 @@
       "type": "object",
       "required": [
         "req_hash",
-        "type_"
+        "type"
       ],
       "properties": {
         "req_hash": {
@@ -699,7 +699,7 @@
           "contentEncoding": "hex",
           "contentMediaType": "application/binary"
         },
-        "type_": {
+        "type": {
           "$ref": "#/definitions/MessageType"
         }
       }

--- a/xdr-json/AuthenticatedMessageV0.json
+++ b/xdr-json/AuthenticatedMessageV0.json
@@ -671,7 +671,7 @@
       "type": "object",
       "required": [
         "req_hash",
-        "type_"
+        "type"
       ],
       "properties": {
         "req_hash": {
@@ -681,7 +681,7 @@
           "contentEncoding": "hex",
           "contentMediaType": "application/binary"
         },
-        "type_": {
+        "type": {
           "$ref": "#/definitions/MessageType"
         }
       }

--- a/xdr-json/ContractEvent.json
+++ b/xdr-json/ContractEvent.json
@@ -6,7 +6,7 @@
   "required": [
     "body",
     "ext",
-    "type_"
+    "type"
   ],
   "properties": {
     "$schema": {
@@ -28,7 +28,7 @@
     "ext": {
       "$ref": "#/definitions/ExtensionPoint"
     },
-    "type_": {
+    "type": {
       "$ref": "#/definitions/ContractEventType"
     }
   },

--- a/xdr-json/DiagnosticEvent.json
+++ b/xdr-json/DiagnosticEvent.json
@@ -26,7 +26,7 @@
       "required": [
         "body",
         "ext",
-        "type_"
+        "type"
       ],
       "properties": {
         "body": {
@@ -45,7 +45,7 @@
         "ext": {
           "$ref": "#/definitions/ExtensionPoint"
         },
-        "type_": {
+        "type": {
           "$ref": "#/definitions/ContractEventType"
         }
       }

--- a/xdr-json/DontHave.json
+++ b/xdr-json/DontHave.json
@@ -5,7 +5,7 @@
   "type": "object",
   "required": [
     "req_hash",
-    "type_"
+    "type"
   ],
   "properties": {
     "$schema": {
@@ -18,7 +18,7 @@
       "contentEncoding": "hex",
       "contentMediaType": "application/binary"
     },
-    "type_": {
+    "type": {
       "$ref": "#/definitions/MessageType"
     }
   },

--- a/xdr-json/InvokeHostFunctionSuccessPreImage.json
+++ b/xdr-json/InvokeHostFunctionSuccessPreImage.json
@@ -30,7 +30,7 @@
       "required": [
         "body",
         "ext",
-        "type_"
+        "type"
       ],
       "properties": {
         "body": {
@@ -49,7 +49,7 @@
         "ext": {
           "$ref": "#/definitions/ExtensionPoint"
         },
-        "type_": {
+        "type": {
           "$ref": "#/definitions/ContractEventType"
         }
       }

--- a/xdr-json/LedgerCloseMeta.json
+++ b/xdr-json/LedgerCloseMeta.json
@@ -1659,7 +1659,7 @@
       "required": [
         "body",
         "ext",
-        "type_"
+        "type"
       ],
       "properties": {
         "body": {
@@ -1678,7 +1678,7 @@
         "ext": {
           "$ref": "#/definitions/ExtensionPoint"
         },
-        "type_": {
+        "type": {
           "$ref": "#/definitions/ContractEventType"
         }
       }

--- a/xdr-json/LedgerCloseMetaBatch.json
+++ b/xdr-json/LedgerCloseMetaBatch.json
@@ -1647,7 +1647,7 @@
       "required": [
         "body",
         "ext",
-        "type_"
+        "type"
       ],
       "properties": {
         "body": {
@@ -1666,7 +1666,7 @@
         "ext": {
           "$ref": "#/definitions/ExtensionPoint"
         },
-        "type_": {
+        "type": {
           "$ref": "#/definitions/ContractEventType"
         }
       }

--- a/xdr-json/LedgerCloseMetaV0.json
+++ b/xdr-json/LedgerCloseMetaV0.json
@@ -1659,7 +1659,7 @@
       "required": [
         "body",
         "ext",
-        "type_"
+        "type"
       ],
       "properties": {
         "body": {
@@ -1678,7 +1678,7 @@
         "ext": {
           "$ref": "#/definitions/ExtensionPoint"
         },
-        "type_": {
+        "type": {
           "$ref": "#/definitions/ContractEventType"
         }
       }

--- a/xdr-json/LedgerCloseMetaV1.json
+++ b/xdr-json/LedgerCloseMetaV1.json
@@ -1683,7 +1683,7 @@
       "required": [
         "body",
         "ext",
-        "type_"
+        "type"
       ],
       "properties": {
         "body": {
@@ -1702,7 +1702,7 @@
         "ext": {
           "$ref": "#/definitions/ExtensionPoint"
         },
-        "type_": {
+        "type": {
           "$ref": "#/definitions/ContractEventType"
         }
       }

--- a/xdr-json/LedgerCloseMetaV2.json
+++ b/xdr-json/LedgerCloseMetaV2.json
@@ -1675,7 +1675,7 @@
       "required": [
         "body",
         "ext",
-        "type_"
+        "type"
       ],
       "properties": {
         "body": {
@@ -1694,7 +1694,7 @@
         "ext": {
           "$ref": "#/definitions/ExtensionPoint"
         },
-        "type_": {
+        "type": {
           "$ref": "#/definitions/ContractEventType"
         }
       }

--- a/xdr-json/OperationMetaV2.json
+++ b/xdr-json/OperationMetaV2.json
@@ -1228,7 +1228,7 @@
       "required": [
         "body",
         "ext",
-        "type_"
+        "type"
       ],
       "properties": {
         "body": {
@@ -1247,7 +1247,7 @@
         "ext": {
           "$ref": "#/definitions/ExtensionPoint"
         },
-        "type_": {
+        "type": {
           "$ref": "#/definitions/ContractEventType"
         }
       }

--- a/xdr-json/ScSpecEntry.json
+++ b/xdr-json/ScSpecEntry.json
@@ -101,7 +101,7 @@
         "doc",
         "location",
         "name",
-        "type_"
+        "type"
       ],
       "properties": {
         "doc": {
@@ -113,7 +113,7 @@
         "name": {
           "$ref": "#/definitions/StringM<30>"
         },
-        "type_": {
+        "type": {
           "$ref": "#/definitions/ScSpecTypeDef"
         }
       }
@@ -164,7 +164,7 @@
       "required": [
         "doc",
         "name",
-        "type_"
+        "type"
       ],
       "properties": {
         "doc": {
@@ -173,7 +173,7 @@
         "name": {
           "$ref": "#/definitions/StringM<30>"
         },
-        "type_": {
+        "type": {
           "$ref": "#/definitions/ScSpecTypeDef"
         }
       }
@@ -520,7 +520,7 @@
       "required": [
         "doc",
         "name",
-        "type_"
+        "type"
       ],
       "properties": {
         "doc": {
@@ -529,7 +529,7 @@
         "name": {
           "$ref": "#/definitions/StringM<30>"
         },
-        "type_": {
+        "type": {
           "$ref": "#/definitions/ScSpecTypeDef"
         }
       }
@@ -568,7 +568,7 @@
       "required": [
         "doc",
         "name",
-        "type_"
+        "type"
       ],
       "properties": {
         "doc": {
@@ -577,7 +577,7 @@
         "name": {
           "$ref": "#/definitions/StringM<60>"
         },
-        "type_": {
+        "type": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/ScSpecTypeDef"

--- a/xdr-json/ScSpecEventParamV0.json
+++ b/xdr-json/ScSpecEventParamV0.json
@@ -7,7 +7,7 @@
     "doc",
     "location",
     "name",
-    "type_"
+    "type"
   ],
   "properties": {
     "$schema": {
@@ -22,7 +22,7 @@
     "name": {
       "$ref": "#/definitions/StringM<30>"
     },
-    "type_": {
+    "type": {
       "$ref": "#/definitions/ScSpecTypeDef"
     }
   },

--- a/xdr-json/ScSpecEventV0.json
+++ b/xdr-json/ScSpecEventV0.json
@@ -68,7 +68,7 @@
         "doc",
         "location",
         "name",
-        "type_"
+        "type"
       ],
       "properties": {
         "doc": {
@@ -80,7 +80,7 @@
         "name": {
           "$ref": "#/definitions/StringM<30>"
         },
-        "type_": {
+        "type": {
           "$ref": "#/definitions/ScSpecTypeDef"
         }
       }

--- a/xdr-json/ScSpecFunctionInputV0.json
+++ b/xdr-json/ScSpecFunctionInputV0.json
@@ -6,7 +6,7 @@
   "required": [
     "doc",
     "name",
-    "type_"
+    "type"
   ],
   "properties": {
     "$schema": {
@@ -18,7 +18,7 @@
     "name": {
       "$ref": "#/definitions/StringM<30>"
     },
-    "type_": {
+    "type": {
       "$ref": "#/definitions/ScSpecTypeDef"
     }
   },

--- a/xdr-json/ScSpecFunctionV0.json
+++ b/xdr-json/ScSpecFunctionV0.json
@@ -42,7 +42,7 @@
       "required": [
         "doc",
         "name",
-        "type_"
+        "type"
       ],
       "properties": {
         "doc": {
@@ -51,7 +51,7 @@
         "name": {
           "$ref": "#/definitions/StringM<30>"
         },
-        "type_": {
+        "type": {
           "$ref": "#/definitions/ScSpecTypeDef"
         }
       }

--- a/xdr-json/ScSpecUdtStructFieldV0.json
+++ b/xdr-json/ScSpecUdtStructFieldV0.json
@@ -6,7 +6,7 @@
   "required": [
     "doc",
     "name",
-    "type_"
+    "type"
   ],
   "properties": {
     "$schema": {
@@ -18,7 +18,7 @@
     "name": {
       "$ref": "#/definitions/StringM<30>"
     },
-    "type_": {
+    "type": {
       "$ref": "#/definitions/ScSpecTypeDef"
     }
   },

--- a/xdr-json/ScSpecUdtStructV0.json
+++ b/xdr-json/ScSpecUdtStructV0.json
@@ -242,7 +242,7 @@
       "required": [
         "doc",
         "name",
-        "type_"
+        "type"
       ],
       "properties": {
         "doc": {
@@ -251,7 +251,7 @@
         "name": {
           "$ref": "#/definitions/StringM<30>"
         },
-        "type_": {
+        "type": {
           "$ref": "#/definitions/ScSpecTypeDef"
         }
       }

--- a/xdr-json/ScSpecUdtUnionCaseTupleV0.json
+++ b/xdr-json/ScSpecUdtUnionCaseTupleV0.json
@@ -6,7 +6,7 @@
   "required": [
     "doc",
     "name",
-    "type_"
+    "type"
   ],
   "properties": {
     "$schema": {
@@ -18,7 +18,7 @@
     "name": {
       "$ref": "#/definitions/StringM<60>"
     },
-    "type_": {
+    "type": {
       "type": "array",
       "items": {
         "$ref": "#/definitions/ScSpecTypeDef"

--- a/xdr-json/ScSpecUdtUnionCaseV0.json
+++ b/xdr-json/ScSpecUdtUnionCaseV0.json
@@ -243,7 +243,7 @@
       "required": [
         "doc",
         "name",
-        "type_"
+        "type"
       ],
       "properties": {
         "doc": {
@@ -252,7 +252,7 @@
         "name": {
           "$ref": "#/definitions/StringM<60>"
         },
-        "type_": {
+        "type": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/ScSpecTypeDef"

--- a/xdr-json/ScSpecUdtUnionV0.json
+++ b/xdr-json/ScSpecUdtUnionV0.json
@@ -242,7 +242,7 @@
       "required": [
         "doc",
         "name",
-        "type_"
+        "type"
       ],
       "properties": {
         "doc": {
@@ -251,7 +251,7 @@
         "name": {
           "$ref": "#/definitions/StringM<60>"
         },
-        "type_": {
+        "type": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/ScSpecTypeDef"

--- a/xdr-json/SerializedBinaryFuseFilter.json
+++ b/xdr-json/SerializedBinaryFuseFilter.json
@@ -12,7 +12,7 @@
     "segment_count",
     "segment_count_length",
     "segment_length",
-    "type_"
+    "type"
   ],
   "properties": {
     "$schema": {
@@ -54,7 +54,7 @@
       "format": "uint32",
       "minimum": 0.0
     },
-    "type_": {
+    "type": {
       "$ref": "#/definitions/BinaryFuseFilterType"
     }
   },

--- a/xdr-json/SorobanTransactionMeta.json
+++ b/xdr-json/SorobanTransactionMeta.json
@@ -42,7 +42,7 @@
       "required": [
         "body",
         "ext",
-        "type_"
+        "type"
       ],
       "properties": {
         "body": {
@@ -61,7 +61,7 @@
         "ext": {
           "$ref": "#/definitions/ExtensionPoint"
         },
-        "type_": {
+        "type": {
           "$ref": "#/definitions/ContractEventType"
         }
       }

--- a/xdr-json/StellarMessage.json
+++ b/xdr-json/StellarMessage.json
@@ -903,7 +903,7 @@
       "type": "object",
       "required": [
         "req_hash",
-        "type_"
+        "type"
       ],
       "properties": {
         "req_hash": {
@@ -913,7 +913,7 @@
           "contentEncoding": "hex",
           "contentMediaType": "application/binary"
         },
-        "type_": {
+        "type": {
           "$ref": "#/definitions/MessageType"
         }
       }

--- a/xdr-json/TransactionEvent.json
+++ b/xdr-json/TransactionEvent.json
@@ -26,7 +26,7 @@
       "required": [
         "body",
         "ext",
-        "type_"
+        "type"
       ],
       "properties": {
         "body": {
@@ -45,7 +45,7 @@
         "ext": {
           "$ref": "#/definitions/ExtensionPoint"
         },
-        "type_": {
+        "type": {
           "$ref": "#/definitions/ContractEventType"
         }
       }

--- a/xdr-json/TransactionMeta.json
+++ b/xdr-json/TransactionMeta.json
@@ -1270,7 +1270,7 @@
       "required": [
         "body",
         "ext",
-        "type_"
+        "type"
       ],
       "properties": {
         "body": {
@@ -1289,7 +1289,7 @@
         "ext": {
           "$ref": "#/definitions/ExtensionPoint"
         },
-        "type_": {
+        "type": {
           "$ref": "#/definitions/ContractEventType"
         }
       }

--- a/xdr-json/TransactionMetaV3.json
+++ b/xdr-json/TransactionMetaV3.json
@@ -1242,7 +1242,7 @@
       "required": [
         "body",
         "ext",
-        "type_"
+        "type"
       ],
       "properties": {
         "body": {
@@ -1261,7 +1261,7 @@
         "ext": {
           "$ref": "#/definitions/ExtensionPoint"
         },
-        "type_": {
+        "type": {
           "$ref": "#/definitions/ContractEventType"
         }
       }

--- a/xdr-json/TransactionMetaV4.json
+++ b/xdr-json/TransactionMetaV4.json
@@ -1258,7 +1258,7 @@
       "required": [
         "body",
         "ext",
-        "type_"
+        "type"
       ],
       "properties": {
         "body": {
@@ -1277,7 +1277,7 @@
         "ext": {
           "$ref": "#/definitions/ExtensionPoint"
         },
-        "type_": {
+        "type": {
           "$ref": "#/definitions/ContractEventType"
         }
       }

--- a/xdr-json/TransactionResultMeta.json
+++ b/xdr-json/TransactionResultMeta.json
@@ -1466,7 +1466,7 @@
       "required": [
         "body",
         "ext",
-        "type_"
+        "type"
       ],
       "properties": {
         "body": {
@@ -1485,7 +1485,7 @@
         "ext": {
           "$ref": "#/definitions/ExtensionPoint"
         },
-        "type_": {
+        "type": {
           "$ref": "#/definitions/ContractEventType"
         }
       }

--- a/xdr-json/TransactionResultMetaV1.json
+++ b/xdr-json/TransactionResultMetaV1.json
@@ -1474,7 +1474,7 @@
       "required": [
         "body",
         "ext",
-        "type_"
+        "type"
       ],
       "properties": {
         "body": {
@@ -1493,7 +1493,7 @@
         "ext": {
           "$ref": "#/definitions/ExtensionPoint"
         },
-        "type_": {
+        "type": {
           "$ref": "#/definitions/ContractEventType"
         }
       }


### PR DESCRIPTION
### What

Fields named `type` now serialize to JSON as `type` instead of the keyword-escaped `type_`.

### Why

SEP-51 says a field's JSON key is its snake_case name with no keyword escaping, so `type` must serialize as `type`. Since `type` is a Rust keyword the generator escaped it to `type_`, which leaked into the JSON and schemas.

Close #558

### Known limitations

This is a breaking change to the generated JSON: output is now `type`, not `type_`. Decoding is preserved — `type_` still deserializes via an alias.