### PR TITLE
Refactor: Use derive Default attribute instead of impl blocks

### DIFF
--- a/src/cli/compare.rs
+++ b/src/cli/compare.rs
@@ -46,16 +46,11 @@ pub struct Cmd {
     pub input: InputFormat,
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, ValueEnum)]
+#[derive(Default, Clone, Copy, Debug, Eq, Hash, PartialEq, ValueEnum)]
 pub enum InputFormat {
     Single,
+    #[default]
     SingleBase64,
-}
-
-impl Default for InputFormat {
-    fn default() -> Self {
-        Self::SingleBase64
-    }
 }
 
 // TODO: Remove run_x macro, it exists only to reduce the diff from when curr/next

--- a/src/cli/decode.rs
+++ b/src/cli/decode.rs
@@ -43,34 +43,24 @@ pub struct Cmd {
     pub output_format: OutputFormat,
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, ValueEnum)]
+#[derive(Default, Clone, Copy, Debug, Eq, Hash, PartialEq, ValueEnum)]
 pub enum InputFormat {
     Single,
     SingleBase64,
     Stream,
+    #[default]
     StreamBase64,
     StreamFramed,
 }
 
-impl Default for InputFormat {
-    fn default() -> Self {
-        Self::StreamBase64
-    }
-}
-
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, ValueEnum)]
+#[derive(Default, Clone, Copy, Debug, Eq, Hash, PartialEq, ValueEnum)]
 pub enum OutputFormat {
+    #[default]
     Json,
     JsonFormatted,
     Text,
     RustDebug,
     RustDebugFormatted,
-}
-
-impl Default for OutputFormat {
-    fn default() -> Self {
-        Self::Json
-    }
 }
 
 // TODO: Remove run_x macro, it exists only to reduce the diff from when curr/next

--- a/src/cli/encode.rs
+++ b/src/cli/encode.rs
@@ -63,30 +63,20 @@ pub struct Cmd {
     pub output_format: OutputFormat,
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, ValueEnum)]
+#[derive(Default, Clone, Copy, Debug, Eq, Hash, PartialEq, ValueEnum)]
 pub enum InputFormat {
+    #[default]
     Json,
 }
 
-impl Default for InputFormat {
-    fn default() -> Self {
-        Self::Json
-    }
-}
-
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, ValueEnum)]
+#[derive(Default, Clone, Copy, Debug, Eq, Hash, PartialEq, ValueEnum)]
 pub enum OutputFormat {
     Single,
+    #[default]
     SingleBase64,
     Stream,
     // TODO: StreamBase64,
     // TODO: StreamFramed,
-}
-
-impl Default for OutputFormat {
-    fn default() -> Self {
-        Self::SingleBase64
-    }
 }
 
 // TODO: Remove run_x macro, it exists only to reduce the diff from when curr/next

--- a/src/cli/generate/arbitrary.rs
+++ b/src/cli/generate/arbitrary.rs
@@ -50,9 +50,10 @@ pub struct Cmd {
     pub hint_attempts: u64,
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, ValueEnum)]
+#[derive(Default, Clone, Copy, Debug, Eq, Hash, PartialEq, ValueEnum)]
 pub enum OutputFormat {
     Single,
+    #[default]
     SingleBase64,
     // TODO: Stream,
     // TODO: StreamBase64,
@@ -60,12 +61,6 @@ pub enum OutputFormat {
     Json,
     JsonFormatted,
     Text,
-}
-
-impl Default for OutputFormat {
-    fn default() -> Self {
-        Self::SingleBase64
-    }
 }
 
 // TODO: Remove run_x macro, it exists only to reduce the diff from when curr/next

--- a/src/cli/generate/default.rs
+++ b/src/cli/generate/default.rs
@@ -33,9 +33,10 @@ pub struct Cmd {
     pub output_format: OutputFormat,
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, ValueEnum)]
+#[derive(Default, Clone, Copy, Debug, Eq, Hash, PartialEq, ValueEnum)]
 pub enum OutputFormat {
     Single,
+    #[default]
     SingleBase64,
     // TODO: Stream,
     // TODO: StreamBase64,
@@ -43,12 +44,6 @@ pub enum OutputFormat {
     Json,
     JsonFormatted,
     Text,
-}
-
-impl Default for OutputFormat {
-    fn default() -> Self {
-        Self::SingleBase64
-    }
 }
 
 // TODO: Remove run_x macro, it exists only to reduce the diff from when curr/next

--- a/src/cli/guess.rs
+++ b/src/cli/guess.rs
@@ -36,30 +36,20 @@ pub struct Cmd {
     pub certainty: usize,
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, ValueEnum)]
+#[derive(Default, Clone, Copy, Debug, Eq, Hash, PartialEq, ValueEnum)]
 pub enum InputFormat {
     Single,
+    #[default]
     SingleBase64,
     Stream,
     StreamBase64,
     StreamFramed,
 }
 
-impl Default for InputFormat {
-    fn default() -> Self {
-        Self::SingleBase64
-    }
-}
-
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, ValueEnum)]
+#[derive(Default, Clone, Copy, Debug, Eq, Hash, PartialEq, ValueEnum)]
 pub enum OutputFormat {
+    #[default]
     List,
-}
-
-impl Default for OutputFormat {
-    fn default() -> Self {
-        Self::List
-    }
 }
 
 // TODO: Remove run_x macro, it exists only to reduce the diff from when curr/next

--- a/src/cli/types/list.rs
+++ b/src/cli/types/list.rs
@@ -8,17 +8,12 @@ pub struct Cmd {
     pub output: OutputFormat,
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, ValueEnum)]
+#[derive(Default, Clone, Copy, Debug, Eq, Hash, PartialEq, ValueEnum)]
 pub enum OutputFormat {
+    #[default]
     Plain,
     Json,
     JsonFormatted,
-}
-
-impl Default for OutputFormat {
-    fn default() -> Self {
-        Self::Plain
-    }
 }
 
 impl Cmd {

--- a/src/cli/types/schema.rs
+++ b/src/cli/types/schema.rs
@@ -22,15 +22,10 @@ pub struct Cmd {
     pub output: OutputFormat,
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, ValueEnum)]
+#[derive(Default, Clone, Copy, Debug, Eq, Hash, PartialEq, ValueEnum)]
 pub enum OutputFormat {
+    #[default]
     JsonSchemaDraft201909,
-}
-
-impl Default for OutputFormat {
-    fn default() -> Self {
-        Self::JsonSchemaDraft201909
-    }
 }
 
 // TODO: Remove run_x macro, it exists only to reduce the diff from when curr/next

--- a/src/cli/types/schema_files.rs
+++ b/src/cli/types/schema_files.rs
@@ -24,15 +24,10 @@ pub struct Cmd {
     pub output: OutputFormat,
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, ValueEnum)]
+#[derive(Default, Clone, Copy, Debug, Eq, Hash, PartialEq, ValueEnum)]
 pub enum OutputFormat {
+    #[default]
     JsonSchemaDraft201909,
-}
-
-impl Default for OutputFormat {
-    fn default() -> Self {
-        Self::JsonSchemaDraft201909
-    }
 }
 
 // TODO: Remove run_x macro, it exists only to reduce the diff from when curr/next


### PR DESCRIPTION
### What

Replace the hand-written `impl Default` blocks on the CLI's `InputFormat` and `OutputFormat` enums with `#[derive(Default)]` and a `#[default]` variant attribute.

### Why

Nine copies of a six-line `impl Default` express nothing the derive can't, and the default variant is easier to spot on the variant itself than in a separate impl below the enum.

Broken out of #560, which requires the change to handle a newer version of clippy. We can make the change now though as its a good non-functional refactor.

### Known limitations

N/A
