### PR TITLE
Shrink the CI cargo-hack feature powerset

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CARGO_HACK_ARGS: --feature-powerset --exclude-features default --group-features base64,serde,serde_json,schemars,arbitrary,hex,rand
+  CARGO_HACK_ARGS: --feature-powerset --exclude-features default --group-features base64,serde,serde_json,schemars,arbitrary,hex,rand,type_enum,serde_ignored
 
 jobs:
 
@@ -153,7 +153,7 @@ jobs:
           cargo-hack-feature-options: --manifest-path Cargo.toml --exclude-features default,cli,rand,schemars,serde,alloc,arbitrary,base64,hex,serde_json,std --each-feature
         - os: ubuntu-latest
           target: x86_64-unknown-linux-gnu
-          cargo-hack-feature-options: --feature-powerset --exclude-features default --group-features base64,serde,serde_json,schemars,arbitrary,hex,rand
+          cargo-hack-feature-options: --feature-powerset --exclude-features default --group-features base64,serde,serde_json,schemars,arbitrary,hex,rand,type_enum,serde_ignored
     uses: stellar/actions/.github/workflows/rust-publish-dry-run.yml@main
     with:
       runs-on: ${{ matrix.sys.os }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CARGO_HACK_ARGS: --feature-powerset --exclude-features default --group-features base64,serde,serde_json,schemars,arbitrary,hex,rand,type_enum,serde_ignored
+  CARGO_HACK_ARGS: --feature-powerset --exclude-features default --group-features base64,serde,serde_json,schemars,arbitrary,hex,rand,type_enum,serde_ignored,test_feature
 
 jobs:
 
@@ -153,7 +153,7 @@ jobs:
           cargo-hack-feature-options: --manifest-path Cargo.toml --exclude-features default,cli,rand,schemars,serde,alloc,arbitrary,base64,hex,serde_json,std --each-feature
         - os: ubuntu-latest
           target: x86_64-unknown-linux-gnu
-          cargo-hack-feature-options: --feature-powerset --exclude-features default --group-features base64,serde,serde_json,schemars,arbitrary,hex,rand,type_enum,serde_ignored
+          cargo-hack-feature-options: --feature-powerset --exclude-features default --group-features base64,serde,serde_json,schemars,arbitrary,hex,rand,type_enum,serde_ignored,test_feature
     uses: stellar/actions/.github/workflows/rust-publish-dry-run.yml@main
     with:
       runs-on: ${{ matrix.sys.os }}


### PR DESCRIPTION
### What

Group the `type_enum`, `serde_ignored`, and `test_feature` features into the existing cargo-hack `--group-features` group used by the CI feature powerset runs.

### Why

Every ungrouped feature doubles the powerset, so these three account for most of it: the feature combinations drop from 112 to 24, taking the build and test matrices from about 450 jobs to 98 per CI run. Extracted out of https://github.com/stellar/rs-stellar-xdr/pull/562.

### Known limitations

Grouped features are only ever enabled together, so combinations enabling any of the three independently of the rest of the group are no longer covered. All three are still compiled and tested as part of the group.
