### PR TITLE
fix: reject AssetCode12 JSON shorter than 5 characters

### DIFF
--- a/src/str.rs
+++ b/src/str.rs
@@ -405,8 +405,8 @@ impl core::str::FromStr for AssetCode12 {
         // the XDR<>JSON conversion round-trippable.
         const MIN_LENGTH: usize = 5;
         let mut code = AssetCode12([0u8; 12]);
-        let n = escape_bytes::unescape_into(&mut code.0, s.as_bytes())
-            .map_err(|_| Error::Invalid)?;
+        let n =
+            escape_bytes::unescape_into(&mut code.0, s.as_bytes()).map_err(|_| Error::Invalid)?;
         if n < MIN_LENGTH {
             return Err(Error::Invalid);
         }

--- a/src/str.rs
+++ b/src/str.rs
@@ -394,6 +394,10 @@ impl core::fmt::Display for AssetCode4 {
 
 impl core::str::FromStr for AssetCode12 {
     type Err = Error;
+    /// Parses an `AssetCode12`. Requires at least 5 characters: any code shorter
+    /// than 5 is an `AssetCode4`, and accepting it here would not round-trip (the
+    /// `Display` impl always renders at least 5 characters). For length-agnostic
+    /// parsing that selects the right variant, use `AssetCode`'s `FromStr`.
     fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
         // AssetCode12's are always at least 5 characters, because any asset
         // code shorter than 5 characters is an AssetCode4. This mirrors the

--- a/src/str.rs
+++ b/src/str.rs
@@ -394,7 +394,7 @@ impl core::fmt::Display for AssetCode4 {
 
 impl core::str::FromStr for AssetCode12 {
     type Err = Error;
-    /// Parses an `AssetCode12`. Requires at least 5 characters: any code shorter
+    /// Parses an `AssetCode12`. Requires at least 5 bytes: any code shorter
     /// than 5 is an `AssetCode4`, and accepting it here would not round-trip (the
     /// `Display` impl always renders at least 5 characters). For length-agnostic
     /// parsing that selects the right variant, use `AssetCode`'s `FromStr`.

--- a/src/str.rs
+++ b/src/str.rs
@@ -399,7 +399,7 @@ impl core::str::FromStr for AssetCode12 {
     /// `Display` impl always renders at least 5 characters). For length-agnostic
     /// parsing that selects the right variant, use `AssetCode`'s `FromStr`.
     fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
-        // AssetCode12's are always at least 5 characters, because any asset
+        // An AssetCode12 is always at least 5 characters, because any asset
         // code shorter than 5 characters is an AssetCode4. This mirrors the
         // Display impl, which always renders at least 5 characters, and keeps
         // the XDR<>JSON conversion round-trippable.

--- a/src/str.rs
+++ b/src/str.rs
@@ -395,8 +395,17 @@ impl core::fmt::Display for AssetCode4 {
 impl core::str::FromStr for AssetCode12 {
     type Err = Error;
     fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
+        // AssetCode12's are always at least 5 characters, because any asset
+        // code shorter than 5 characters is an AssetCode4. This mirrors the
+        // Display impl, which always renders at least 5 characters, and keeps
+        // the XDR<>JSON conversion round-trippable.
+        const MIN_LENGTH: usize = 5;
         let mut code = AssetCode12([0u8; 12]);
-        escape_bytes::unescape_into(&mut code.0, s.as_bytes()).map_err(|_| Error::Invalid)?;
+        let n = escape_bytes::unescape_into(&mut code.0, s.as_bytes())
+            .map_err(|_| Error::Invalid)?;
+        if n < MIN_LENGTH {
+            return Err(Error::Invalid);
+        }
         Ok(code)
     }
 }

--- a/tests/str.rs
+++ b/tests/str.rs
@@ -589,10 +589,7 @@ fn asset_code_12_from_str() {
     assert_eq!(AssetCode12::from_str("abcd"), Err(Error::Invalid));
     // The canonical 5-byte escaped short form is accepted and round-trips with
     // Display (see asset_code_12_to_string).
-    assert_eq!(
-        AssetCode12::from_str(r"abc\0\0"),
-        Ok(AssetCode12(*b"abc\0\0\0\0\0\0\0\0\0"))
-    );
+    assert_eq!(AssetCode12::from_str(r"abc\0\0"), Ok(AssetCode12(*b"abc\0\0\0\0\0\0\0\0\0")));
     assert_eq!(AssetCode12::from_str("abcde"), Ok(AssetCode12(*b"abcde\0\0\0\0\0\0\0")));
     assert_eq!(AssetCode12::from_str("abcdef"), Ok(AssetCode12(*b"abcdef\0\0\0\0\0\0")));
     assert_eq!(AssetCode12::from_str("abcdefg"), Ok(AssetCode12(*b"abcdefg\0\0\0\0\0")));

--- a/tests/str.rs
+++ b/tests/str.rs
@@ -580,11 +580,19 @@ fn asset_code_4_to_string() {
 #[test]
 #[rustfmt::skip]
 fn asset_code_12_from_str() {
-    assert_eq!(AssetCode12::from_str(""), Ok(AssetCode12(*b"\0\0\0\0\0\0\0\0\0\0\0\0")));
-    assert_eq!(AssetCode12::from_str("a"), Ok(AssetCode12(*b"a\0\0\0\0\0\0\0\0\0\0\0")));
-    assert_eq!(AssetCode12::from_str("ab"), Ok(AssetCode12(*b"ab\0\0\0\0\0\0\0\0\0\0")));
-    assert_eq!(AssetCode12::from_str("abc"), Ok(AssetCode12(*b"abc\0\0\0\0\0\0\0\0\0")));
-    assert_eq!(AssetCode12::from_str("abcd"), Ok(AssetCode12(*b"abcd\0\0\0\0\0\0\0\0")));
+    // AssetCode12 must be at least 5 characters (shorter codes are AssetCode4),
+    // otherwise the value does not round-trip through Display. See #432.
+    assert_eq!(AssetCode12::from_str(""), Err(Error::Invalid));
+    assert_eq!(AssetCode12::from_str("a"), Err(Error::Invalid));
+    assert_eq!(AssetCode12::from_str("ab"), Err(Error::Invalid));
+    assert_eq!(AssetCode12::from_str("abc"), Err(Error::Invalid));
+    assert_eq!(AssetCode12::from_str("abcd"), Err(Error::Invalid));
+    // The canonical 5-byte escaped short form is accepted and round-trips with
+    // Display (see asset_code_12_to_string).
+    assert_eq!(
+        AssetCode12::from_str(r"abc\0\0"),
+        Ok(AssetCode12(*b"abc\0\0\0\0\0\0\0\0\0"))
+    );
     assert_eq!(AssetCode12::from_str("abcde"), Ok(AssetCode12(*b"abcde\0\0\0\0\0\0\0")));
     assert_eq!(AssetCode12::from_str("abcdef"), Ok(AssetCode12(*b"abcdef\0\0\0\0\0\0")));
     assert_eq!(AssetCode12::from_str("abcdefg"), Ok(AssetCode12(*b"abcdefg\0\0\0\0\0")));


### PR DESCRIPTION
### What
`AssetCode12::from_str` now rejects inputs that unescape to fewer than 5 bytes, returning `Error::Invalid`.

### Why
Closes #432. `AssetCode12::from_str` discarded the byte count and accepted any value, including sub-5-byte codes like `"abc"`. That value does not round-trip: the `Display` impl always renders at least 5 characters (any shorter code is an `AssetCode4`), so `"abc"` parsed to `[a,b,c,0,…]` and re-serialized as `"abc\0\0"`.

This is the read-side counterpart to #358 ("Fix render of AssetCode12 to JSON when shorter than 5 chars"), which added the 5-character minimum to `Display` but left `FromStr` unchanged. With both sides aligned, XDR<>JSON round-trips for `AssetCode12`.

### Scope
- One hand-written function in `src/str.rs` (`impl FromStr for AssetCode12`); no codegen / `generated.rs` regeneration.
- The `AssetCode` enum's `FromStr` has independent length routing (`n <= 4` → `AssetCode4`, else `AssetCode12`) and does not call `AssetCode12::from_str`, so it is unaffected.
- The serde `DeserializeFromStr` derive on `AssetCode12` goes through `FromStr`, so the CLI `encode` path (the issue's repro) is fixed transitively.

### Tests
`tests/str.rs::asset_code_12_from_str` updated: the five sub-5-byte cases (`""`/`"a"`/`"ab"`/`"abc"`/`"abcd"`) now assert `Err(Error::Invalid)` (they asserted the buggy `Ok(...)` before), plus a new round-trip assertion for the canonical 5-byte short form. `cargo test --test str` (50 tests) and `cargo clippy` are green.