### PR TITLE
fix: SkipWhitespace must not report EOF on an all-whitespace read

### DIFF
--- a/src/generated.rs
+++ b/src/generated.rs
@@ -2419,17 +2419,28 @@ impl<R: Read> SkipWhitespace<R> {
 #[cfg(feature = "std")]
 impl<R: Read> Read for SkipWhitespace<R> {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        let n = self.inner.read(buf)?;
+        loop {
+            let n = self.inner.read(buf)?;
+            if n == 0 {
+                return Ok(0);
+            }
 
-        let mut written = 0;
-        for read in 0..n {
-            if !buf[read].is_ascii_whitespace() {
-                buf[written] = buf[read];
-                written += 1;
+            let mut written = 0;
+            for read in 0..n {
+                if !buf[read].is_ascii_whitespace() {
+                    buf[written] = buf[read];
+                    written += 1;
+                }
+            }
+
+            // Only report EOF (Ok(0)) when the inner reader is genuinely at end
+            // (n == 0 above). If an entire read was whitespace, keep reading
+            // instead of returning Ok(0), which the caller treats as EOF and
+            // would use to silently truncate the decoded stream.
+            if written > 0 {
+                return Ok(written);
             }
         }
-
-        Ok(written)
     }
 }
 

--- a/tests/tx_base64_skip_whitespace.rs
+++ b/tests/tx_base64_skip_whitespace.rs
@@ -7,6 +7,35 @@ use stellar_xdr::Error;
 use stellar_xdr::{Limited, Limits, ReadXdr, WriteXdr};
 
 #[test]
+fn test_skip_whitespace_long_run() -> Result<(), Error> {
+    // A whitespace run at least as long as the base64 decoder's internal read
+    // buffer (1024 bytes) must not be treated as end-of-input. Before the fix,
+    // SkipWhitespace::read returned Ok(0) when a whole delegate read was
+    // whitespace, which the decoder interprets as EOF -> silent truncation.
+    let v_bytes = [1u32.to_xdr(Limits::none())?, 2u32.to_xdr(Limits::none())?].concat();
+    let core = base64::engine::general_purpose::STANDARD.encode(&v_bytes);
+    assert_eq!(core, "AAAAAQAAAAI=");
+    let ws = " ".repeat(2048);
+
+    // Leading long whitespace run.
+    let leading = format!("{ws}{core}");
+    assert_eq!(
+        u64::from_xdr_base64(&leading, Limits::none()),
+        Ok((1u64 << 32) | 2u64)
+    );
+
+    // Interior long whitespace run (split the base64 mid-string).
+    let (a, b) = core.split_at(4);
+    let interior = format!("{a}{ws}{b}");
+    assert_eq!(
+        u64::from_xdr_base64(&interior, Limits::none()),
+        Ok((1u64 << 32) | 2u64)
+    );
+
+    Ok(())
+}
+
+#[test]
 fn test_skip_whitespace() -> Result<(), Error> {
     let v_bytes = [1u32.to_xdr(Limits::none())?, 2u32.to_xdr(Limits::none())?].concat();
 

--- a/tests/tx_base64_skip_whitespace.rs
+++ b/tests/tx_base64_skip_whitespace.rs
@@ -8,10 +8,11 @@ use stellar_xdr::{Limited, Limits, ReadXdr, WriteXdr};
 
 #[test]
 fn test_skip_whitespace_long_run() -> Result<(), Error> {
-    // A whitespace run at least as long as the base64 decoder's internal read
-    // buffer (1024 bytes) must not be treated as end-of-input. Before the fix,
-    // SkipWhitespace::read returned Ok(0) when a whole delegate read was
-    // whitespace, which the decoder interprets as EOF -> silent truncation.
+    // A long contiguous whitespace run (2048 bytes here, large enough to fill
+    // at least one of the base64 decoder's internal read buffers) must not be
+    // treated as end-of-input. Before the fix, SkipWhitespace::read returned
+    // Ok(0) when a whole delegate read was whitespace, which the decoder
+    // interprets as EOF -> silent truncation.
     let v_bytes = [1u32.to_xdr(Limits::none())?, 2u32.to_xdr(Limits::none())?].concat();
     let core = base64::engine::general_purpose::STANDARD.encode(&v_bytes);
     assert_eq!(core, "AAAAAQAAAAI=");

--- a/xdr-generator-rust/generator/header.rs
+++ b/xdr-generator-rust/generator/header.rs
@@ -2342,17 +2342,28 @@ impl<R: Read> SkipWhitespace<R> {
 #[cfg(feature = "std")]
 impl<R: Read> Read for SkipWhitespace<R> {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        let n = self.inner.read(buf)?;
+        loop {
+            let n = self.inner.read(buf)?;
+            if n == 0 {
+                return Ok(0);
+            }
 
-        let mut written = 0;
-        for read in 0..n {
-            if !buf[read].is_ascii_whitespace() {
-                buf[written] = buf[read];
-                written += 1;
+            let mut written = 0;
+            for read in 0..n {
+                if !buf[read].is_ascii_whitespace() {
+                    buf[written] = buf[read];
+                    written += 1;
+                }
+            }
+
+            // Only report EOF (Ok(0)) when the inner reader is genuinely at end
+            // (n == 0 above). If an entire read was whitespace, keep reading
+            // instead of returning Ok(0), which the caller treats as EOF and
+            // would use to silently truncate the decoded stream.
+            if written > 0 {
+                return Ok(written);
             }
         }
-
-        Ok(written)
     }
 }
 


### PR DESCRIPTION
### What
`SkipWhitespace::read` returned `Ok(0)` whenever a single delegate read yielded a chunk that was entirely ASCII whitespace (`n > 0` but `0` bytes written after filtering). Per the `Read` contract, `Ok(0)` on a non-empty buffer signals EOF, so `base64::read::DecoderReader` (1024-byte internal buffer) treats a whitespace run of **≥ 1024 bytes** as end-of-input and **silently truncates** the decoded XDR stream.

The fix loops until at least one non-whitespace byte is produced, or the inner reader genuinely reaches EOF (returns `0`).

### Background
`SkipWhitespace` was added to make the base64 read paths tolerate whitespace (the fix for #505). It handles the common case (whitespace every ~64 chars, PEM-style) correctly. This is a follow-up hardening for the edge case of a long contiguous whitespace run.

### Reproduction (fails before, passes after)
```rust
let core = "AAAAAQAAAAI="; // base64 of two u32s: (1u64 << 32) | 2
let leading = format!("{}{}", " ".repeat(2048), core);
assert_eq!(u64::from_xdr_base64(&leading, Limits::none()), Ok((1u64 << 32) | 2u64));
```
Before this change the assertion fails with `Err(Io(UnexpectedEof, "failed to fill whole buffer"))` — the 2048-space run is read as one all-whitespace chunk, `SkipWhitespace` returns `Ok(0)`, and the decoder stops before the real data. Interior whitespace runs of the same size truncate mid-stream.

### Impact
Correctness bug, low real-world frequency: normal PEM-wrapped or hand-pasted base64 breaks lines every ~64 chars, so ≥1024-byte contiguous whitespace runs are uncommon — but when they occur the failure is a silent/short decode, which is the dangerous kind.

### Scope
- The impl lives in the generator template `xdr-generator-rust/generator/header.rs` and is copied verbatim (via `include_str!`) into `src/generated.rs`; both are updated identically, so the generated output stays in sync with the template.
- Behavior is otherwise unchanged: the common small-whitespace case (existing `test_skip_whitespace`) still passes.

### Tests
Added `test_skip_whitespace_long_run` (leading and interior ≥1024-byte whitespace runs) to `tests/tx_base64_skip_whitespace.rs`. `cargo test --features base64 --test tx_base64_skip_whitespace` and `cargo clippy` are green.