### PR TITLE
Remove unused generate_to_file method

### DIFF
--- a/xdr-generator-rust/generator/src/generator.rs
+++ b/xdr-generator-rust/generator/src/generator.rs
@@ -31,20 +31,6 @@ impl RustGenerator {
         Self { options, type_info }
     }
 
-    /// Generate Rust code from the spec and write it to the output file.
-    #[allow(dead_code)]
-    pub fn generate_to_file(
-        &self,
-        spec: &XdrSpec,
-        output: &std::path::PathBuf,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        let header = include_str!("../header.rs");
-        let template = self.generate(spec, header);
-        let rendered = template.render()?;
-        std::fs::write(output, rendered)?;
-        Ok(())
-    }
-
     /// Generate Rust code from the spec and write each definition to its own
     /// file inside `output_dir`, plus a module file that ties them together.
     ///


### PR DESCRIPTION
### What
Remove the unused `generate_to_file` method from the Rust XDR generator.

### Why
It was marked `#[allow(dead_code)]` with zero callers anywhere in the workspace. `main.rs` writes generated output through `generate_to_dir` instead so this is probably a remnant to before I changed the code generation to write multiple files.